### PR TITLE
Use unchecked `fullMulDiv` variant

### DIFF
--- a/snapshots/MEVCaptureRouterTest.json
+++ b/snapshots/MEVCaptureRouterTest.json
@@ -1,11 +1,11 @@
 {
-  "swap 100 token0 for eth": "61584",
+  "swap 100 token0 for eth": "61469",
   "swap 100 token0 for token1": "61463",
   "swap 100 wei of eth for token": "54988",
   "swap 100 wei of eth for token full range": "30801",
-  "swap 100 wei of token for eth full range": "37186",
-  "swap crossing one tick eth for token1": "66992",
-  "swap crossing one tick token1 for eth": "73227",
-  "swap crossing two ticks eth for token1": "85960",
-  "swap crossing two ticks token1 for eth": "82872"
+  "swap 100 wei of token for eth full range": "37071",
+  "swap crossing one tick eth for token1": "66975",
+  "swap crossing one tick token1 for eth": "72997",
+  "swap crossing two ticks eth for token1": "85923",
+  "swap crossing two ticks token1 for eth": "82642"
 }

--- a/snapshots/MEVCaptureTest.json
+++ b/snapshots/MEVCaptureTest.json
@@ -1,14 +1,14 @@
 {
   "initial_tick_far_from_zero_no_additional_fees": "137319",
-  "initial_tick_far_from_zero_no_additional_fees_output": "137741",
+  "initial_tick_far_from_zero_no_additional_fees_output": "137718",
   "input_token0_move_tick_spacings": "137184",
   "input_token0_no_movement": "137184",
-  "input_token1_move_tick_spacings": "137190",
-  "input_token1_no_movement": "137190",
-  "output_token0_move_tick_spacings": "137904",
-  "output_token0_no_movement": "137904",
-  "output_token1_move_tick_spacings": "137648",
-  "output_token1_no_movement": "137648",
+  "input_token1_move_tick_spacings": "137075",
+  "input_token1_no_movement": "137075",
+  "output_token0_move_tick_spacings": "137881",
+  "output_token0_no_movement": "137881",
+  "output_token1_move_tick_spacings": "137631",
+  "output_token1_no_movement": "137631",
   "second_swap_with_additional_fees_gas_price": "103119",
   "third_swap_accumulates_fees": "117077"
 }

--- a/snapshots/OracleTest.json
+++ b/snapshots/OracleTest.json
@@ -3,6 +3,6 @@
   "oracle.getExtrapolatedSnapshots(address(token1), 21, 3, 8)": "31163",
   "swap token0 in no write": "71095",
   "swap token0 in with write": "80900",
-  "swap token1 in no write": "77528",
-  "swap token1 in with write": "87313"
+  "swap token1 in no write": "77413",
+  "swap token1 in with write": "87198"
 }

--- a/snapshots/OrdersTest.json
+++ b/snapshots/OrdersTest.json
@@ -1,5 +1,5 @@
 {
-  "lockAndExecuteVirtualOrders max cost": "2884905",
+  "lockAndExecuteVirtualOrders max cost": "2881829",
   "lockAndExecuteVirtualOrders switch sell direction": "39377",
   "mintAndIncreaseSellAmount(first order)": "253715",
   "mintAndIncreaseSellAmount(second order)": "135962",

--- a/snapshots/PositionsTest.json
+++ b/snapshots/PositionsTest.json
@@ -1,10 +1,10 @@
 {
-  "mintAndDeposit": "394370",
-  "mintAndDeposit eth": "367147",
-  "mintAndDeposit full range both tokens": "204177",
-  "mintAndDeposit full range max": "204613",
-  "mintAndDeposit full range min": "204297",
-  "withdraw": "134010",
-  "withdraw eth": "127307",
-  "withdraw full range both tokens": "120597"
+  "mintAndDeposit": "394350",
+  "mintAndDeposit eth": "367127",
+  "mintAndDeposit full range both tokens": "204157",
+  "mintAndDeposit full range max": "204593",
+  "mintAndDeposit full range min": "204277",
+  "withdraw": "133918",
+  "withdraw eth": "127215",
+  "withdraw full range both tokens": "120482"
 }

--- a/snapshots/RouterTest.json
+++ b/snapshots/RouterTest.json
@@ -1,11 +1,11 @@
 {
-  "swap 100 token0 for eth": "95475",
+  "swap 100 token0 for eth": "95360",
   "swap 100 token0 for token1": "103702",
   "swap 100 wei of eth for token": "90628",
   "swap 100 wei of eth for token full range": "68845",
-  "swap 100 wei of token for eth full range": "75253",
-  "swap crossing one tick eth for token1": "108244",
-  "swap crossing one tick token1 for eth": "114730",
-  "swap crossing two ticks eth for token1": "132955",
-  "swap crossing two ticks token1 for eth": "130083"
+  "swap 100 wei of token for eth full range": "75138",
+  "swap crossing one tick eth for token1": "108227",
+  "swap crossing one tick token1 for eth": "114500",
+  "swap crossing two ticks eth for token1": "132918",
+  "swap crossing two ticks token1 for eth": "129853"
 }

--- a/src/math/delta.sol
+++ b/src/math/delta.sol
@@ -37,7 +37,7 @@ function amount0Delta(SqrtRatio sqrtRatioA, SqrtRatio sqrtRatioB, uint128 liquid
             if (result > type(uint128).max) revert Amount0DeltaOverflow();
             amount0 = uint128(result);
         } else {
-            uint256 result0 = FixedPointMathLib.fullMulDiv(
+            uint256 result0 = FixedPointMathLib.fullMulDivUnchecked(
                 (uint256(liquidity) << 128), (sqrtRatioUpper - sqrtRatioLower), sqrtRatioUpper
             );
             uint256 result = FixedPointMathLib.rawDiv(result0, sqrtRatioLower);


### PR DESCRIPTION
There are likely more places where this can be applied.
I also tried [here](https://github.com/EkuboProtocol/evm-contracts/blob/585492cdf85f64f00e9d3dde556c8cc435fc4ad6/src/math/twamm.sol#L57) but it increased costs (?) and there's also [this](https://github.com/EkuboProtocol/evm-contracts/blob/585492cdf85f64f00e9d3dde556c8cc435fc4ad6/src/math/twamm.sol#L127).

Other `FixedPointMathLib` functions don't have unchecked variants and perform checks that, depending on the context, may not be necessary.
There might be some significant savings here.