### PR TITLE
use the same strategy to avoid loading fees per liquidity

### DIFF
--- a/snapshots/MEVCaptureRouterTest.json
+++ b/snapshots/MEVCaptureRouterTest.json
@@ -1,11 +1,11 @@
 {
-  "swap 100 token0 for eth": "61453",
-  "swap 100 token0 for token1": "61438",
-  "swap 100 wei of eth for token": "54963",
-  "swap 100 wei of eth for token full range": "30776",
-  "swap 100 wei of token for eth full range": "37055",
-  "swap crossing one tick eth for token1": "66913",
-  "swap crossing one tick token1 for eth": "72953",
-  "swap crossing two ticks eth for token1": "85849",
-  "swap crossing two ticks token1 for eth": "82586"
+  "swap 100 token0 for eth": "61506",
+  "swap 100 token0 for token1": "61491",
+  "swap 100 wei of eth for token": "55016",
+  "swap 100 wei of eth for token full range": "30829",
+  "swap 100 wei of token for eth full range": "37108",
+  "swap crossing one tick eth for token1": "67098",
+  "swap crossing one tick token1 for eth": "73138",
+  "swap crossing two ticks eth for token1": "86077",
+  "swap crossing two ticks token1 for eth": "82814"
 }

--- a/snapshots/MEVCaptureTest.json
+++ b/snapshots/MEVCaptureTest.json
@@ -1,14 +1,14 @@
 {
-  "initial_tick_far_from_zero_no_additional_fees": "137291",
-  "initial_tick_far_from_zero_no_additional_fees_output": "137690",
-  "input_token0_move_tick_spacings": "137156",
-  "input_token0_no_movement": "137156",
-  "input_token1_move_tick_spacings": "137056",
-  "input_token1_no_movement": "137056",
-  "output_token0_move_tick_spacings": "137853",
-  "output_token0_no_movement": "137853",
-  "output_token1_move_tick_spacings": "137612",
-  "output_token1_no_movement": "137612",
-  "second_swap_with_additional_fees_gas_price": "103091",
-  "third_swap_accumulates_fees": "117062"
+  "initial_tick_far_from_zero_no_additional_fees": "137344",
+  "initial_tick_far_from_zero_no_additional_fees_output": "137752",
+  "input_token0_move_tick_spacings": "137209",
+  "input_token0_no_movement": "137209",
+  "input_token1_move_tick_spacings": "137109",
+  "input_token1_no_movement": "137109",
+  "output_token0_move_tick_spacings": "137915",
+  "output_token0_no_movement": "137915",
+  "output_token1_move_tick_spacings": "137674",
+  "output_token1_no_movement": "137674",
+  "second_swap_with_additional_fees_gas_price": "103144",
+  "third_swap_accumulates_fees": "117115"
 }

--- a/snapshots/OracleTest.json
+++ b/snapshots/OracleTest.json
@@ -1,8 +1,8 @@
 {
   "oracle#getExtrapolatedSnapshots": "17908",
   "oracle.getExtrapolatedSnapshots(address(token1), 21, 3, 8)": "31163",
-  "swap token0 in no write": "71070",
-  "swap token0 in with write": "80875",
-  "swap token1 in no write": "77397",
-  "swap token1 in with write": "87182"
+  "swap token0 in no write": "71046",
+  "swap token0 in with write": "80851",
+  "swap token1 in no write": "77373",
+  "swap token1 in with write": "87158"
 }

--- a/snapshots/OrdersTest.json
+++ b/snapshots/OrdersTest.json
@@ -1,10 +1,10 @@
 {
-  "lockAndExecuteVirtualOrders max cost": "2877626",
-  "lockAndExecuteVirtualOrders switch sell direction": "39119",
+  "lockAndExecuteVirtualOrders max cost": "2881745",
+  "lockAndExecuteVirtualOrders switch sell direction": "39037",
   "mintAndIncreaseSellAmount(first order)": "253709",
   "mintAndIncreaseSellAmount(second order)": "135956",
-  "swap and executeVirtualOrders double sided": "162796",
-  "swap and executeVirtualOrders double sided crossed": "171523",
-  "swap and executeVirtualOrders no orders": "116615",
-  "swap and executeVirtualOrders single sided": "153582"
+  "swap and executeVirtualOrders double sided": "162849",
+  "swap and executeVirtualOrders double sided crossed": "171576",
+  "swap and executeVirtualOrders no orders": "116668",
+  "swap and executeVirtualOrders single sided": "153688"
 }

--- a/snapshots/RouterTest.json
+++ b/snapshots/RouterTest.json
@@ -1,11 +1,11 @@
 {
-  "swap 100 token0 for eth": "95344",
-  "swap 100 token0 for token1": "103677",
-  "swap 100 wei of eth for token": "90603",
-  "swap 100 wei of eth for token full range": "68820",
-  "swap 100 wei of token for eth full range": "75122",
-  "swap crossing one tick eth for token1": "108165",
-  "swap crossing one tick token1 for eth": "114456",
-  "swap crossing two ticks eth for token1": "132844",
-  "swap crossing two ticks token1 for eth": "129797"
+  "swap 100 token0 for eth": "95397",
+  "swap 100 token0 for token1": "103730",
+  "swap 100 wei of eth for token": "90656",
+  "swap 100 wei of eth for token full range": "68873",
+  "swap 100 wei of token for eth full range": "75175",
+  "swap crossing one tick eth for token1": "108350",
+  "swap crossing one tick token1 for eth": "114641",
+  "swap crossing two ticks eth for token1": "133072",
+  "swap crossing two ticks token1 for eth": "130025"
 }

--- a/src/types/poolConfig.sol
+++ b/src/types/poolConfig.sol
@@ -14,7 +14,6 @@ using {
     extension,
     isFullRange,
     validate,
-    mustLoadFees,
     maxLiquidityPerTickConcentratedLiquidity
 } for PoolConfig global;
 
@@ -96,18 +95,6 @@ function maxLiquidityPerTickConcentratedLiquidity(PoolConfig config) pure return
     unchecked {
         // maxLiquidity = type(uint128).max / numTicks
         maxLiquidity = uint128(FixedPointMathLib.rawDiv(type(uint128).max, numTicks));
-    }
-}
-
-/// @notice Determines if fees must be loaded for swaps in this pool
-/// @dev Returns true if either tick spacing or fee are nonzero
-/// @param config The pool config
-/// @return r True if fees must be loaded on swap
-function mustLoadFees(PoolConfig config) pure returns (bool r) {
-    assembly ("memory-safe") {
-        // only if either of tick spacing and fee are nonzero
-        // if _both_ are zero, then we know we do not need to load fees for swaps
-        r := iszero(iszero(and(config, 0xffffffffffffffffffffffff)))
     }
 }
 


### PR DESCRIPTION
this is more generic than the must load fees hack since it can also save gas in cases where fees per liquidity does not need to be loaded incidentally