### PR TITLE
Add VeToken duration staking helpers

### DIFF
--- a/snapshots/Ve33Test.json
+++ b/snapshots/Ve33Test.json
@@ -12,8 +12,8 @@
   "Router#ve33SwapVe33Position": "104061",
   "Router#ve33SwapZeroFeeVote": "53371",
   "Ve33#emissionAccrualOnPoolTouch": "84112",
-  "Ve33#vote one pool": "139594",
+  "Ve33#vote one pool": "139616",
   "Ve33Periphery#scheduleEmissions": "125496",
-  "VeToken#claimPoolFees": "59455",
-  "VeToken#vote": "139594"
+  "VeToken#claimPoolFees": "59648",
+  "VeToken#vote": "139616"
 }

--- a/snapshots/VeTokenTest.json
+++ b/snapshots/VeTokenTest.json
@@ -1,13 +1,13 @@
 {
-  "VeToken#createStake": "154430",
+  "VeToken#createStake": "154620",
   "VeToken#extendStake": "43684",
-  "VeToken#increaseStakeAmount": "35158",
-  "VeToken#mergeStakes": "33463",
+  "VeToken#increaseStakeAmount": "35290",
+  "VeToken#mergeStakes": "33485",
   "VeToken#splitStake": "72331",
-  "VeToken#stakeId": "3027",
-  "VeToken#stakes": "6594",
-  "VeToken#tokenURI gas": "402975",
-  "VeToken#transferFrom": "31259",
-  "VeToken#votingPower": "6024",
-  "VeToken#withdrawStake": "36839"
+  "VeToken#stakeId": "3071",
+  "VeToken#stakes": "6726",
+  "VeToken#tokenURI gas": "403107",
+  "VeToken#transferFrom": "31281",
+  "VeToken#votingPower": "6068",
+  "VeToken#withdrawStake": "36861"
 }

--- a/src/VeToken.sol
+++ b/src/VeToken.sol
@@ -67,6 +67,9 @@ contract VeToken is ERC721, PayableMulticallable, BaseLocker, UsesCore {
     /// @notice Thrown when a constructor string cannot be packed into one bytes32 word.
     error PackedStringTooLong();
 
+    /// @notice Thrown when a duration-based stake end cannot fit in uint64.
+    error StakeEndOverflow();
+
     /// @notice Creates the ERC721 stake wrapper.
     /// @param core The Ekubo Core contract used for lock and token settlement.
     /// @param _ve33 The Ve33 extension containing canonical vote-escrow accounting.
@@ -166,7 +169,7 @@ contract VeToken is ERC721, PayableMulticallable, BaseLocker, UsesCore {
     /// @param amount The amount of stake token to stake.
     /// @param end The stake end timestamp.
     /// @return veId The minted ERC721 token id.
-    function createStake(uint128 amount, uint64 end) external payable returns (uint256 veId) {
+    function createStake(uint128 amount, uint64 end) public payable returns (uint256 veId) {
         if (amount == 0) revert InvalidStakeAmount();
 
         veId = nextVeId;
@@ -176,6 +179,23 @@ contract VeToken is ERC721, PayableMulticallable, BaseLocker, UsesCore {
         _mintAndSetExtraDataUnchecked(msg.sender, veId, end);
 
         lock(abi.encode(CALL_TYPE_STAKE, msg.sender, stakeId(veId), amount));
+    }
+
+    /// @notice Creates a Ve33 stake ending `duration` seconds from now and mints an ERC721 token that controls it.
+    /// @dev The minted token id is used as the Ve33 stake salt. Stake token settlement happens in the Core lock.
+    /// @param amount The amount of stake token to stake.
+    /// @param duration The stake duration in seconds.
+    /// @return veId The minted ERC721 token id.
+    function createStakeForDuration(uint128 amount, uint32 duration) external payable returns (uint256 veId) {
+        veId = createStake(amount, _stakeEndFromDuration(duration));
+    }
+
+    /// @notice Creates a Ve33 stake ending at the maximum duration from now.
+    /// @dev The minted token id is used as the Ve33 stake salt. Stake token settlement happens in the Core lock.
+    /// @param amount The amount of stake token to stake.
+    /// @return veId The minted ERC721 token id.
+    function createStakeMaxDuration(uint128 amount) external payable returns (uint256 veId) {
+        veId = createStake(amount, _maxStakeEnd());
     }
 
     /// @notice Adds stake token to an existing represented stake.
@@ -192,8 +212,23 @@ contract VeToken is ERC721, PayableMulticallable, BaseLocker, UsesCore {
     /// @dev The caller must own or be approved for `veId`. Extending clears votes in Ve33.
     /// @param veId The ERC721 token id and Ve33 stake salt.
     /// @param end The new stake end timestamp.
-    function extendStake(uint256 veId, uint64 end) external payable authorizedForStake(veId) {
+    function extendStake(uint256 veId, uint64 end) public payable authorizedForStake(veId) {
         _extendStake(veId, end);
+    }
+
+    /// @notice Moves an existing represented stake to end `duration` seconds from now.
+    /// @dev The caller must own or be approved for `veId`. Extending clears votes in Ve33.
+    /// @param veId The ERC721 token id and Ve33 stake salt.
+    /// @param duration The new stake duration in seconds.
+    function extendStakeForDuration(uint256 veId, uint32 duration) external payable {
+        extendStake(veId, _stakeEndFromDuration(duration));
+    }
+
+    /// @notice Moves an existing represented stake to the maximum duration from now.
+    /// @dev The caller must own or be approved for `veId`. Extending clears votes in Ve33.
+    /// @param veId The ERC721 token id and Ve33 stake salt.
+    function extendStakeMaxDuration(uint256 veId) external payable {
+        extendStake(veId, _maxStakeEnd());
     }
 
     /// @notice Claims pending voter fees, then moves a represented stake to a later end timestamp.
@@ -205,7 +240,7 @@ contract VeToken is ERC721, PayableMulticallable, BaseLocker, UsesCore {
     /// @return amount0 The amount of token0 withdrawn to `recipient`.
     /// @return amount1 The amount of token1 withdrawn to `recipient`.
     function claimPoolFeesAndExtendStake(uint256 veId, uint64 end, PoolKey calldata poolKey, address recipient)
-        external
+        public
         payable
         authorizedForStake(veId)
         returns (uint128 amount0, uint128 amount1)
@@ -214,15 +249,65 @@ contract VeToken is ERC721, PayableMulticallable, BaseLocker, UsesCore {
         _extendStake(veId, end);
     }
 
+    /// @notice Claims pending voter fees, then moves a represented stake to end `duration` seconds from now.
+    /// @dev Useful before a vote-clearing extension because pending fees are discarded when votes are cleared.
+    /// @param veId The ERC721 token id and Ve33 stake salt.
+    /// @param duration The new stake duration in seconds.
+    /// @param poolKey The currently voted pool whose fees should be claimed before extending.
+    /// @param recipient Account receiving the claimed fees.
+    /// @return amount0 The amount of token0 withdrawn to `recipient`.
+    /// @return amount1 The amount of token1 withdrawn to `recipient`.
+    function claimPoolFeesAndExtendStakeForDuration(
+        uint256 veId,
+        uint32 duration,
+        PoolKey calldata poolKey,
+        address recipient
+    ) external payable returns (uint128 amount0, uint128 amount1) {
+        (amount0, amount1) = claimPoolFeesAndExtendStake(veId, _stakeEndFromDuration(duration), poolKey, recipient);
+    }
+
+    /// @notice Claims pending voter fees, then moves a represented stake to the maximum duration from now.
+    /// @dev Useful before a vote-clearing extension because pending fees are discarded when votes are cleared.
+    /// @param veId The ERC721 token id and Ve33 stake salt.
+    /// @param poolKey The currently voted pool whose fees should be claimed before extending.
+    /// @param recipient Account receiving the claimed fees.
+    /// @return amount0 The amount of token0 withdrawn to `recipient`.
+    /// @return amount1 The amount of token1 withdrawn to `recipient`.
+    function claimPoolFeesAndExtendStakeMaxDuration(uint256 veId, PoolKey calldata poolKey, address recipient)
+        external
+        payable
+        returns (uint128 amount0, uint128 amount1)
+    {
+        (amount0, amount1) = claimPoolFeesAndExtendStake(veId, _maxStakeEnd(), poolKey, recipient);
+    }
+
     /// @notice Claims pending voter fees to the caller, then moves a represented stake to a later end timestamp.
     function claimPoolFeesAndExtendStakeToSelf(uint256 veId, uint64 end, PoolKey calldata poolKey)
-        external
+        public
         payable
         returns (uint128 amount0, uint128 amount1)
     {
         if (!isAuthorizedForNft(msg.sender, veId)) revert NotAuthorizedForToken(msg.sender, veId);
         (amount0, amount1) = _claimPoolFees(veId, poolKey, msg.sender);
         _extendStake(veId, end);
+    }
+
+    /// @notice Claims pending voter fees to the caller, then moves a represented stake to end `duration` seconds from now.
+    function claimPoolFeesAndExtendStakeToSelfForDuration(uint256 veId, uint32 duration, PoolKey calldata poolKey)
+        external
+        payable
+        returns (uint128 amount0, uint128 amount1)
+    {
+        (amount0, amount1) = claimPoolFeesAndExtendStakeToSelf(veId, _stakeEndFromDuration(duration), poolKey);
+    }
+
+    /// @notice Claims pending voter fees to the caller, then moves a represented stake to the maximum duration from now.
+    function claimPoolFeesAndExtendStakeToSelfMaxDuration(uint256 veId, PoolKey calldata poolKey)
+        external
+        payable
+        returns (uint128 amount0, uint128 amount1)
+    {
+        (amount0, amount1) = claimPoolFeesAndExtendStakeToSelf(veId, _maxStakeEnd(), poolKey);
     }
 
     /// @notice Splits part of a represented stake into a newly minted ERC721 with the same end timestamp.
@@ -458,6 +543,20 @@ contract VeToken is ERC721, PayableMulticallable, BaseLocker, UsesCore {
         (amount0, amount1) = abi.decode(
             lock(abi.encode(CALL_TYPE_CLAIM_POOL_FEES, veId, recipient, poolKey)), (uint128, uint128)
         );
+    }
+
+    /// @notice Converts a duration into an absolute stake end timestamp.
+    function _stakeEndFromDuration(uint32 duration) private view returns (uint64 end) {
+        if (duration > VE33_MAX_STAKE_DURATION) revert IVe33.StakeDurationTooLong();
+
+        uint256 endTime = block.timestamp + duration;
+        if (endTime > type(uint64).max) revert StakeEndOverflow();
+        end = uint64(endTime);
+    }
+
+    /// @notice Returns the maximum valid stake end timestamp from now.
+    function _maxStakeEnd() private view returns (uint64) {
+        return _stakeEndFromDuration(uint32(VE33_MAX_STAKE_DURATION));
     }
 
     /// @notice Shared implementation for stake extension.

--- a/test/VeToken.t.sol
+++ b/test/VeToken.t.sol
@@ -7,11 +7,17 @@ import {LibString} from "solady/utils/LibString.sol";
 
 import {FullTest} from "./FullTest.sol";
 import {TestToken} from "./TestToken.sol";
+import {Router} from "../src/Router.sol";
 import {VeToken} from "../src/VeToken.sol";
 import {Ve33, VE33_STAKE_TOKEN_SAVED_BALANCE_ID, ve33CallPoints} from "../src/extensions/Ve33.sol";
 import {IVe33} from "../src/interfaces/extensions/IVe33.sol";
 import {CoreLib} from "../src/libraries/CoreLib.sol";
 import {Ve33Lib} from "../src/libraries/Ve33Lib.sol";
+import {createConcentratedPoolConfig} from "../src/types/poolConfig.sol";
+import {PoolId} from "../src/types/poolId.sol";
+import {PoolKey} from "../src/types/poolKey.sol";
+import {SqrtRatio} from "../src/types/sqrtRatio.sol";
+import {createSwapParameters} from "../src/types/swapParameters.sol";
 
 contract ZeroStakeTokenVe33 {
     function stakeToken() external pure returns (address) {
@@ -34,6 +40,7 @@ contract VeTokenTest is FullTest {
         address deployAddress = address(uint160(ve33CallPoints().toUint8()) << 152);
         deployCodeTo("Ve33.sol:Ve33", abi.encode(core, address(stakeToken)), deployAddress);
         ve33 = Ve33(payable(deployAddress));
+        router = new Router(core, address(0), address(ve33));
         veToken = new VeToken(core, ve33, "Vote Escrow TestToken", "veTT", "TestToken", "TT", 18);
         stakeToken.approve(address(veToken), type(uint256).max);
     }
@@ -56,6 +63,23 @@ contract VeTokenTest is FullTest {
     function _stakeTokenSavedBalance() internal view returns (uint128 saved) {
         (saved,) = core.savedBalances(
             address(ve33), address(stakeToken), address(type(uint160).max), VE33_STAKE_TOKEN_SAVED_BALANCE_ID
+        );
+    }
+
+    function _createVotedPoolWithFees() internal returns (uint256 veId, PoolKey memory poolKey) {
+        poolKey = createPool(address(token0), address(token1), 0, createConcentratedPoolConfig(0, 64, address(ve33)));
+        createPosition(poolKey, -64, 64, 1e18, 1e18);
+
+        veId = veToken.createStakeForDuration(1e18, 1 weeks);
+        veToken.vote(veId, poolKey, uint64(1 << 62));
+
+        token0.approve(address(router), type(uint256).max);
+        router.swapAllowPartialFill(
+            poolKey,
+            createSwapParameters({
+                _sqrtRatioLimit: SqrtRatio.wrap(0), _amount: int128(100_000), _isToken1: false, _skipAhead: 0
+            }),
+            address(this)
         );
     }
 
@@ -313,6 +337,128 @@ contract VeTokenTest is FullTest {
         veToken.ownerOf(veId);
         vm.expectRevert(ERC721.TokenDoesNotExist.selector);
         veToken.tokenURI(veId);
+    }
+
+    function test_createStakeForDurationUsesRelativeEndTime() public {
+        uint32 duration = 2 weeks;
+        uint64 expectedEnd = uint64(vm.getBlockTimestamp() + duration);
+
+        uint256 veId = veToken.createStakeForDuration(1e18, duration);
+
+        assertEq(veToken.ownerOf(veId), address(this));
+        assertEq(_stakeAmount(veId), 1e18);
+        assertEq(_stakeEnd(veId), expectedEnd);
+        assertEq(_stakeTokenSavedBalance(), 1e18);
+    }
+
+    function test_createStakeForDurationValidatesDuration() public {
+        vm.expectRevert(IVe33.StakeEndNotInFuture.selector);
+        veToken.createStakeForDuration(1, 0);
+
+        uint32 tooLongDuration = uint32(veToken.MAX_STAKE_DURATION() + 1);
+        vm.expectRevert(IVe33.StakeDurationTooLong.selector);
+        veToken.createStakeForDuration(1, tooLongDuration);
+    }
+
+    function test_durationStakeActionsPreventUint64EndTimeOverflow() public {
+        vm.warp(uint256(type(uint64).max) - 1);
+
+        vm.expectRevert(VeToken.StakeEndOverflow.selector);
+        veToken.createStakeForDuration(1, 2);
+
+        vm.expectRevert(VeToken.StakeEndOverflow.selector);
+        veToken.createStakeMaxDuration(1);
+
+        uint256 veId = veToken.createStakeForDuration(1, 1);
+        assertEq(_stakeEnd(veId), type(uint64).max);
+
+        vm.expectRevert(VeToken.StakeEndOverflow.selector);
+        veToken.extendStakeForDuration(veId, 2);
+    }
+
+    function test_extendStakeForDurationUsesRelativeEndTime() public {
+        uint256 veId = veToken.createStakeForDuration(1e18, 1 weeks);
+
+        vm.warp(vm.getBlockTimestamp() + 1 days);
+        uint32 duration = 3 weeks;
+        uint64 expectedEnd = uint64(vm.getBlockTimestamp() + duration);
+
+        veToken.extendStakeForDuration(veId, duration);
+
+        assertEq(_stakeAmount(veId), 1e18);
+        assertEq(_stakeEnd(veId), expectedEnd);
+    }
+
+    function test_maxDurationStakeActionsUseCurrentTimestamp() public {
+        uint256 maxStakeDuration = veToken.MAX_STAKE_DURATION();
+        uint64 createEnd = uint64(vm.getBlockTimestamp() + maxStakeDuration);
+
+        uint256 veId = veToken.createStakeMaxDuration(1e18);
+        assertEq(_stakeEnd(veId), createEnd);
+
+        vm.warp(vm.getBlockTimestamp() + 1 weeks);
+        uint64 extendEnd = uint64(vm.getBlockTimestamp() + maxStakeDuration);
+
+        veToken.extendStakeMaxDuration(veId);
+
+        assertEq(_stakeAmount(veId), 1e18);
+        assertEq(_stakeEnd(veId), extendEnd);
+        assertGt(extendEnd, createEnd);
+    }
+
+    function test_claimPoolFeesAndExtendStakeForDurationClaimsAndUsesRelativeEndTime() public {
+        (uint256 veId, PoolKey memory poolKey) = _createVotedPoolWithFees();
+        address recipient = address(0xBEEF);
+
+        uint256 recipientBalanceBefore = token1.balanceOf(recipient);
+        vm.warp(vm.getBlockTimestamp() + 1 days);
+        uint32 duration = 3 weeks;
+        uint64 expectedEnd = uint64(vm.getBlockTimestamp() + duration);
+
+        (uint128 claimed0, uint128 claimed1) =
+            veToken.claimPoolFeesAndExtendStakeForDuration(veId, duration, poolKey, recipient);
+
+        assertEq(claimed0, 0);
+        assertGt(claimed1, 0);
+        assertEq(token1.balanceOf(recipient), recipientBalanceBefore + claimed1);
+        assertEq(_stakeEnd(veId), expectedEnd);
+        assertEq(PoolId.unwrap(ve33.votedPool(address(veToken), veToken.stakeId(veId))), 0);
+        assertEq(ve33.poolTotalWeight(poolKey.toPoolId()), 0);
+    }
+
+    function test_claimPoolFeesAndExtendStakeToSelfMaxDurationClaimsAndUsesCurrentTimestamp() public {
+        (uint256 veId, PoolKey memory poolKey) = _createVotedPoolWithFees();
+
+        vm.warp(vm.getBlockTimestamp() + 1 days);
+        uint64 expectedEnd = uint64(vm.getBlockTimestamp() + veToken.MAX_STAKE_DURATION());
+        uint256 balanceBefore = token1.balanceOf(address(this));
+
+        (uint128 claimed0, uint128 claimed1) = veToken.claimPoolFeesAndExtendStakeToSelfMaxDuration(veId, poolKey);
+
+        assertEq(claimed0, 0);
+        assertGt(claimed1, 0);
+        assertEq(token1.balanceOf(address(this)), balanceBefore + claimed1);
+        assertEq(_stakeEnd(veId), expectedEnd);
+        assertEq(PoolId.unwrap(ve33.votedPool(address(veToken), veToken.stakeId(veId))), 0);
+        assertEq(ve33.poolTotalWeight(poolKey.toPoolId()), 0);
+    }
+
+    function test_claimPoolFeesAndExtendStakeDurationWrappersRevertPaths() public {
+        uint256 veId = veToken.createStakeForDuration(1e18, 1 weeks);
+        PoolKey memory poolKey;
+        address unauthorized = address(0xBAD);
+
+        vm.expectRevert(abi.encodeWithSelector(VeToken.NotAuthorizedForToken.selector, unauthorized, veId));
+        vm.prank(unauthorized);
+        veToken.claimPoolFeesAndExtendStakeToSelfForDuration(veId, 1 weeks, poolKey);
+
+        uint32 tooLongDuration = uint32(veToken.MAX_STAKE_DURATION() + 1);
+        vm.expectRevert(IVe33.StakeDurationTooLong.selector);
+        veToken.claimPoolFeesAndExtendStakeForDuration(veId, tooLongDuration, poolKey, address(this));
+
+        vm.warp(uint256(type(uint64).max) - 1);
+        vm.expectRevert(VeToken.StakeEndOverflow.selector);
+        veToken.claimPoolFeesAndExtendStakeToSelfForDuration(veId, 2, poolKey);
     }
 
     function test_splitAndMergeStakeLifecycle() public {


### PR DESCRIPTION
## Summary
- add duration-based VeToken create and extend helpers using uint32 durations from block.timestamp
- add max-duration create/extend helpers for one-call max locking from now
- guard duration-derived end timestamps against uint64 overflow and keep duration bounds aligned with Ve33 max stake duration
- add VeToken tests and refresh gas snapshots

## Testing
- forge fmt
- forge build --offline
- forge test --offline --match-contract VeTokenTest
- forge test --offline
- forge snapshot --offline