### PR TITLE
Remove unused Ve33 claim rewards recipient

### DIFF
--- a/snapshots/Ve33Test.json
+++ b/snapshots/Ve33Test.json
@@ -1,6 +1,6 @@
 {
-  "FreeVe33Positions#claimAccruedEmissions": "139054",
-  "FreeVe33Positions#claimRewards": "66916",
+  "FreeVe33Positions#claimAccruedEmissions": "138972",
+  "FreeVe33Positions#claimRewards": "66834",
   "FreeVe33Positions#deposit": "346133",
   "Router#coreSwapMatchingVe33SteadyState": "37353",
   "Router#ve33Stableswap": "96092",

--- a/src/base/BaseVe33Positions.sol
+++ b/src/base/BaseVe33Positions.sol
@@ -448,7 +448,7 @@ abstract contract BaseVe33Positions is UsesCore, PayableMulticallable, BaseLocke
         private
         returns (uint128 amount)
     {
-        amount = uint128(Ve33Lib.claimRewards(CORE, ve33, poolKey, positionId_, recipient));
+        amount = uint128(Ve33Lib.claimRewards(CORE, ve33, poolKey, positionId_));
         if (amount != 0) {
             uint128 protocolFee = _computeClaimRewardsProtocolFee(poolKey, amount);
             if (protocolFee != 0) {

--- a/src/extensions/Ve33.sol
+++ b/src/extensions/Ve33.sol
@@ -484,8 +484,7 @@ contract Ve33 is IVe33, BaseExtension, BaseForwardee, ExposedStorage, Ve33Storag
                 mstore(0x40, add(result, 0x60))
             }
         } else if (callType == VE33_CLAIM_REWARDS) {
-            (, PoolKey memory poolKey, PositionId positionId, address recipient) =
-                abi.decode(data, (uint256, PoolKey, PositionId, address));
+            (, PoolKey memory poolKey, PositionId positionId) = abi.decode(data, (uint256, PoolKey, PositionId));
             result = abi.encode(_claimRewards(poolKey, original.addr(), positionId));
         } else if (callType == VE33_STAKE) {
             (, StakeId stakeId, uint128 amount) = abi.decode(data, (uint256, StakeId, uint128));

--- a/src/interfaces/extensions/IVe33.sol
+++ b/src/interfaces/extensions/IVe33.sol
@@ -13,7 +13,7 @@ import {StakeId} from "../../types/stakeId.sol";
 // Payload after call type: abi.encode(PoolKey poolKey, SwapParameters params).
 uint256 constant VE33_SWAP = 0;
 // Forward call type for claiming LP reward-token emissions.
-// Payload after call type: abi.encode(PoolKey poolKey, PositionId positionId, address recipient).
+// Payload after call type: abi.encode(PoolKey poolKey, PositionId positionId).
 uint256 constant VE33_CLAIM_REWARDS = 1;
 // Forward call type for increasing a ve stake.
 // Payload after call type: abi.encode(StakeId stakeId, uint128 amount).

--- a/src/libraries/Ve33Lib.sol
+++ b/src/libraries/Ve33Lib.sol
@@ -59,13 +59,11 @@ library Ve33Lib {
     }
 
     /// @notice Claims LP rewards for a Ve33 position through Core.
-    function claimRewards(ICore core, IVe33 ve33, PoolKey memory poolKey, PositionId positionId, address recipient)
+    function claimRewards(ICore core, IVe33 ve33, PoolKey memory poolKey, PositionId positionId)
         internal
         returns (uint256 amount)
     {
-        amount = abi.decode(
-            core.forward(address(ve33), abi.encode(VE33_CLAIM_REWARDS, poolKey, positionId, recipient)), (uint256)
-        );
+        amount = abi.decode(core.forward(address(ve33), abi.encode(VE33_CLAIM_REWARDS, poolKey, positionId)), (uint256));
     }
 
     /// @notice Stakes tokens into Ve33 through Core.


### PR DESCRIPTION
## Summary
- remove the unused recipient from the VE33_CLAIM_REWARDS forward payload
- update Ve33Lib and BaseVe33Positions to keep recipient settlement in the wrapper layer
- refresh Ve33 gas snapshots for the smaller claim payload

## Tests
- forge test --offline --match-contract Ve33Test --match-test 'test_peripherySchedulesEmissionsAndClaimsRewards|test_vePositionsWithdrawAndClaimRewards|test_vePositionsTakesProtocolFeeFromClaimedRewards|test_concentratedRewardsPauseWhilePositionIsOutOfRangeAcrossCrossings'
- forge build --offline
- forge snapshot --offline