### PR TITLE
Use uint192 IDs for position NFTs

### DIFF
--- a/snapshots/MEVCaptureTest.json
+++ b/snapshots/MEVCaptureTest.json
@@ -9,7 +9,7 @@
   "output_token0_no_movement": "119549",
   "output_token1_move_tick_spacings": "119150",
   "output_token1_no_movement": "119150",
-  "positions withdraw after fees accumulate": "159804",
+  "positions withdraw after fees accumulate": "159728",
   "second_swap_with_additional_fees_gas_price": "101704",
   "third_swap_accumulates_fees": "115631"
 }

--- a/snapshots/PositionsTest.json
+++ b/snapshots/PositionsTest.json
@@ -1,12 +1,12 @@
 {
-  "mintAndDeposit": "394348",
-  "mintAndDeposit eth": "367093",
-  "mintAndDeposit eth (free)": "367071",
-  "mintAndDeposit full range both tokens": "244065",
-  "mintAndDeposit full range max": "244501",
-  "mintAndDeposit full range min": "244185",
-  "withdraw": "133724",
-  "withdraw eth": "127053",
-  "withdraw eth (free)": "107092",
-  "withdraw full range both tokens": "116368"
+  "mintAndDeposit": "394354",
+  "mintAndDeposit eth": "367099",
+  "mintAndDeposit eth (free)": "367077",
+  "mintAndDeposit full range both tokens": "244071",
+  "mintAndDeposit full range max": "244507",
+  "mintAndDeposit full range min": "244191",
+  "withdraw": "133657",
+  "withdraw eth": "126976",
+  "withdraw eth (free)": "107016",
+  "withdraw full range both tokens": "116272"
 }

--- a/snapshots/Ve33Test.json
+++ b/snapshots/Ve33Test.json
@@ -14,9 +14,9 @@
   "Ve33Forwarder#moveStake": "39275",
   "Ve33Forwarder#stake": "101642",
   "Ve33Periphery#scheduleEmissions": "125470",
-  "Ve33Positions#claimAccruedEmissions": "118212",
-  "Ve33Positions#claimRewards": "46074",
-  "Ve33Positions#deposit": "404990",
+  "Ve33Positions#claimAccruedEmissions": "118184",
+  "Ve33Positions#claimRewards": "46046",
+  "Ve33Positions#deposit": "404962",
   "VeToken#claimPoolFees": "59715",
   "VeToken#vote": "139863"
 }

--- a/snapshots/Ve33Test.json
+++ b/snapshots/Ve33Test.json
@@ -14,9 +14,9 @@
   "Ve33Forwarder#moveStake": "39275",
   "Ve33Forwarder#stake": "101642",
   "Ve33Periphery#scheduleEmissions": "125470",
-  "Ve33Positions#claimAccruedEmissions": "118184",
-  "Ve33Positions#claimRewards": "46046",
-  "Ve33Positions#deposit": "404962",
+  "Ve33Positions#claimAccruedEmissions": "118212",
+  "Ve33Positions#claimRewards": "46074",
+  "Ve33Positions#deposit": "404990",
   "VeToken#claimPoolFees": "59715",
   "VeToken#vote": "139863"
 }

--- a/src/Ve33Positions.sol
+++ b/src/Ve33Positions.sol
@@ -58,6 +58,10 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
     /// @notice Thrown when a pool is not managed by this contract's Ve33 extension.
     error InvalidPoolExtension();
 
+    /// @notice Thrown when a token id cannot be represented exactly as a Core position salt.
+    /// @param id The ERC721 token id.
+    error PositionSaltOverflow(uint256 id);
+
     /// @notice Creates the Ve33 position NFT manager.
     /// @param core Ekubo Core contract used for locks and position updates.
     /// @param _ve33 Ve33 extension whose pools are supported.
@@ -69,12 +73,19 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
 
     receive() external payable {}
 
+    /// @inheritdoc BaseNonfungibleToken
+    /// @dev Restricts generated token ids to 192 bits so the complete id is used as the Core position salt.
+    function saltToId(address minter, bytes32 salt) public view override returns (uint256 id) {
+        id = uint192(super.saltToId(minter, salt));
+    }
+
     /// @notice Computes the Core position id controlled by this NFT id and tick range.
     /// @param id ERC721 token id representing the position owner.
     /// @param tickLower Lower position tick.
     /// @param tickUpper Upper position tick.
     /// @return The Core position id owned by this contract.
     function positionId(uint256 id, int32 tickLower, int32 tickUpper) public pure returns (PositionId) {
+        if (id > type(uint192).max) revert PositionSaltOverflow(id);
         return createPositionId(bytes24(uint192(id)), tickLower, tickUpper);
     }
 

--- a/src/Ve33Positions.sol
+++ b/src/Ve33Positions.sol
@@ -58,10 +58,6 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
     /// @notice Thrown when a pool is not managed by this contract's Ve33 extension.
     error InvalidPoolExtension();
 
-    /// @notice Thrown when a token id cannot be represented exactly as a Core position salt.
-    /// @param id The ERC721 token id.
-    error PositionSaltOverflow(uint256 id);
-
     /// @notice Creates the Ve33 position NFT manager.
     /// @param core Ekubo Core contract used for locks and position updates.
     /// @param _ve33 Ve33 extension whose pools are supported.
@@ -85,7 +81,6 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
     /// @param tickUpper Upper position tick.
     /// @return The Core position id owned by this contract.
     function positionId(uint256 id, int32 tickLower, int32 tickUpper) public pure returns (PositionId) {
-        if (id > type(uint192).max) revert PositionSaltOverflow(id);
         return createPositionId(bytes24(uint192(id)), tickLower, tickUpper);
     }
 

--- a/src/base/BaseNonfungibleToken.sol
+++ b/src/base/BaseNonfungibleToken.sol
@@ -89,7 +89,7 @@ abstract contract BaseNonfungibleToken is IBaseNonfungibleToken, Ownable, ERC721
     /// @dev Uses keccak256 hash of minter, salt, chain ID, and contract address to generate unique IDs.
     ///      IDs are deterministic per (minter, salt, chainId, contract) tuple; the same pair on a
     ///      different chain or contract yields a different ID.
-    function saltToId(address minter, bytes32 salt) public view returns (uint256 result) {
+    function saltToId(address minter, bytes32 salt) public view virtual returns (uint256 result) {
         assembly ("memory-safe") {
             let free := mload(0x40)
             mstore(free, minter)

--- a/src/base/BasePositions.sol
+++ b/src/base/BasePositions.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.33;
 import {BaseLocker} from "./BaseLocker.sol";
 import {UsesCore} from "./UsesCore.sol";
 import {ICore} from "../interfaces/ICore.sol";
+import {IBaseNonfungibleToken} from "../interfaces/IBaseNonfungibleToken.sol";
 import {IPositions} from "../interfaces/IPositions.sol";
 import {CoreLib} from "../libraries/CoreLib.sol";
 import {FlashAccountantLib} from "../libraries/FlashAccountantLib.sol";
@@ -38,6 +39,17 @@ abstract contract BasePositions is IPositions, UsesCore, PayableMulticallable, B
     uint256 private constant CALL_TYPE_DEPOSIT = 0;
     uint256 private constant CALL_TYPE_WITHDRAW = 1;
     uint256 private constant CALL_TYPE_WITHDRAW_PROTOCOL_FEES = 2;
+
+    /// @inheritdoc BaseNonfungibleToken
+    /// @dev Restricts generated token ids to 192 bits so the complete id is used as the Core position salt.
+    function saltToId(address minter, bytes32 salt)
+        public
+        view
+        override(BaseNonfungibleToken, IBaseNonfungibleToken)
+        returns (uint256 id)
+    {
+        id = uint192(super.saltToId(minter, salt));
+    }
 
     /// @inheritdoc IPositions
     function getPositionFeesAndLiquidity(uint256 id, PoolKey memory poolKey, int32 tickLower, int32 tickUpper)

--- a/test/Positions.t.sol
+++ b/test/Positions.t.sol
@@ -33,6 +33,7 @@ contract PositionsTest is FullTest {
 
     function test_saltToId(address minter, bytes32 salt) public {
         uint256 id = positions.saltToId(minter, salt);
+        assertLe(id, type(uint192).max);
         unchecked {
             assertNotEq(id, positions.saltToId(address(uint160(minter) + 1), salt));
             assertNotEq(id, positions.saltToId(minter, bytes32(uint256(salt) + 1)));

--- a/test/Positions.t.sol
+++ b/test/Positions.t.sol
@@ -19,6 +19,7 @@ import {CoreStorageLayout} from "../src/libraries/CoreStorageLayout.sol";
 import {StorageSlot} from "../src/types/storageSlot.sol";
 import {PoolState, createPoolState} from "../src/types/poolState.sol";
 import {PoolConfig, createStableswapPoolConfig} from "../src/types/poolConfig.sol";
+import {PositionId, createPositionId} from "../src/types/positionId.sol";
 
 contract PositionsTest is FullTest {
     using CoreLib for *;
@@ -52,6 +53,9 @@ contract PositionsTest is FullTest {
         (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(poolKey, -100, 100, 100, 100, 0);
         assertGt(id, 0);
         assertGt(liquidity, 0);
+        PositionId positionId = createPositionId(bytes24(uint192(id)), -100, 100);
+        assertEq(uint256(uint192(positionId.salt())), id);
+        assertEq(core.poolPositions(poolKey.toPoolId(), address(positions), positionId).liquidity, liquidity);
         assertEq(token0.balanceOf(address(core)), 100);
         assertEq(token1.balanceOf(address(core)), 100);
 

--- a/test/extensions/Ve33.t.sol
+++ b/test/extensions/Ve33.t.sol
@@ -604,13 +604,6 @@ contract Ve33Test is FullTest {
         assertEq(vePositions.positionId(id, -64, 64).salt(), bytes24(uint192(id)));
     }
 
-    function test_vePositionsRejectsTokenIdThatCannotFitPositionSalt() public {
-        uint256 id = uint256(type(uint192).max) + 1;
-
-        vm.expectRevert(abi.encodeWithSelector(Ve33Positions.PositionSaltOverflow.selector, id));
-        vePositions.positionId(id, -64, 64);
-    }
-
     function test_forwardCallTypesAreNamespacedOutsideAddressRange() public pure {
         assertEq(VE33_CLAIM_REWARDS, uint256(keccak256("IVe33#VE33_CLAIM_REWARDS")));
         assertEq(VE33_STAKE, uint256(keccak256("IVe33#VE33_STAKE")));

--- a/test/extensions/Ve33.t.sol
+++ b/test/extensions/Ve33.t.sol
@@ -597,6 +597,20 @@ contract Ve33Test is FullTest {
         assertEq(ve.stakeToken(), address(stakeToken));
     }
 
+    function test_vePositionsUsesCompleteUint192TokenIdAsPositionSalt(address minter, bytes32 salt) public view {
+        uint256 id = vePositions.saltToId(minter, salt);
+
+        assertLe(id, type(uint192).max);
+        assertEq(vePositions.positionId(id, -64, 64).salt(), bytes24(uint192(id)));
+    }
+
+    function test_vePositionsRejectsTokenIdThatCannotFitPositionSalt() public {
+        uint256 id = uint256(type(uint192).max) + 1;
+
+        vm.expectRevert(abi.encodeWithSelector(Ve33Positions.PositionSaltOverflow.selector, id));
+        vePositions.positionId(id, -64, 64);
+    }
+
     function test_forwardCallTypesAreNamespacedOutsideAddressRange() public pure {
         assertEq(VE33_CLAIM_REWARDS, uint256(keccak256("IVe33#VE33_CLAIM_REWARDS")));
         assertEq(VE33_STAKE, uint256(keccak256("IVe33#VE33_STAKE")));


### PR DESCRIPTION
## Summary

- constrain both standard and Ve33 position NFT IDs to 192 bits at generation time
- use the complete generated token ID as the Core position salt without additional overflow validation in position methods
- add fuzz coverage for both ID generators and update affected gas snapshots

## Testing

- `forge build --offline`
- `forge snapshot --offline` (973 tests passed)