### PR TITLE
Deposit positions within a price range

### DIFF
--- a/script/DeploySTONX.s.sol
+++ b/script/DeploySTONX.s.sol
@@ -101,6 +101,7 @@ contract DeploySTONX is DeployVe33 {
             POSITION_TICK_UPPER,
             address(stonx) < usdg ? LIQUIDITY_TOKEN_AMOUNT : LIQUIDITY_USDG_AMOUNT,
             address(stonx) < usdg ? LIQUIDITY_USDG_AMOUNT : LIQUIDITY_TOKEN_AMOUNT,
+            sqrtRatio,
             sqrtRatio
         );
 

--- a/snapshots/MEVCaptureTest.json
+++ b/snapshots/MEVCaptureTest.json
@@ -9,7 +9,7 @@
   "output_token0_no_movement": "119549",
   "output_token1_move_tick_spacings": "119150",
   "output_token1_no_movement": "119150",
-  "positions withdraw after fees accumulate": "159728",
+  "positions withdraw after fees accumulate": "159704",
   "second_swap_with_additional_fees_gas_price": "101704",
   "third_swap_accumulates_fees": "115631"
 }

--- a/snapshots/MEVCaptureTest.json
+++ b/snapshots/MEVCaptureTest.json
@@ -9,7 +9,7 @@
   "output_token0_no_movement": "119549",
   "output_token1_move_tick_spacings": "119150",
   "output_token1_no_movement": "119150",
-  "positions withdraw after fees accumulate": "159704",
+  "positions withdraw after fees accumulate": "159724",
   "second_swap_with_additional_fees_gas_price": "101704",
   "third_swap_accumulates_fees": "115631"
 }

--- a/snapshots/PositionsTest.json
+++ b/snapshots/PositionsTest.json
@@ -1,12 +1,12 @@
 {
-  "mintAndDeposit": "395499",
-  "mintAndDeposit eth": "368334",
-  "mintAndDeposit eth (free)": "368334",
-  "mintAndDeposit full range both tokens": "245216",
-  "mintAndDeposit full range max": "245772",
-  "mintAndDeposit full range min": "245396",
-  "withdraw": "133661",
-  "withdraw eth": "126980",
-  "withdraw eth (free)": "107018",
-  "withdraw full range both tokens": "116289"
+  "mintAndDeposit": "395958",
+  "mintAndDeposit eth": "368832",
+  "mintAndDeposit eth (free)": "368832",
+  "mintAndDeposit full range both tokens": "245675",
+  "mintAndDeposit full range max": "246351",
+  "mintAndDeposit full range min": "245915",
+  "withdraw": "133654",
+  "withdraw eth": "126969",
+  "withdraw eth (free)": "107000",
+  "withdraw full range both tokens": "116280"
 }

--- a/snapshots/PositionsTest.json
+++ b/snapshots/PositionsTest.json
@@ -1,12 +1,12 @@
 {
-  "mintAndDeposit": "394354",
-  "mintAndDeposit eth": "367099",
-  "mintAndDeposit eth (free)": "367077",
-  "mintAndDeposit full range both tokens": "244071",
-  "mintAndDeposit full range max": "244507",
-  "mintAndDeposit full range min": "244191",
-  "withdraw": "133657",
-  "withdraw eth": "126976",
-  "withdraw eth (free)": "107016",
-  "withdraw full range both tokens": "116272"
+  "mintAndDeposit": "395499",
+  "mintAndDeposit eth": "368334",
+  "mintAndDeposit eth (free)": "368334",
+  "mintAndDeposit full range both tokens": "245216",
+  "mintAndDeposit full range max": "245772",
+  "mintAndDeposit full range min": "245396",
+  "withdraw": "133661",
+  "withdraw eth": "126980",
+  "withdraw eth (free)": "107018",
+  "withdraw full range both tokens": "116289"
 }

--- a/snapshots/PositionsTest.json
+++ b/snapshots/PositionsTest.json
@@ -1,11 +1,11 @@
 {
-  "mintAndDeposit": "395958",
-  "mintAndDeposit eth": "368832",
-  "mintAndDeposit eth (free)": "368832",
-  "mintAndDeposit full range both tokens": "245675",
-  "mintAndDeposit full range max": "246351",
-  "mintAndDeposit full range min": "245915",
-  "withdraw": "133654",
+  "mintAndDeposit": "396036",
+  "mintAndDeposit eth": "368910",
+  "mintAndDeposit eth (free)": "368910",
+  "mintAndDeposit full range both tokens": "245753",
+  "mintAndDeposit full range max": "246429",
+  "mintAndDeposit full range min": "245993",
+  "withdraw": "133635",
   "withdraw eth": "126969",
   "withdraw eth (free)": "107000",
   "withdraw full range both tokens": "116280"

--- a/snapshots/Ve33Test.json
+++ b/snapshots/Ve33Test.json
@@ -14,9 +14,9 @@
   "Ve33Forwarder#moveStake": "39275",
   "Ve33Forwarder#stake": "101642",
   "Ve33Periphery#scheduleEmissions": "125470",
-  "Ve33Positions#claimAccruedEmissions": "118184",
-  "Ve33Positions#claimRewards": "46046",
-  "Ve33Positions#deposit": "404962",
+  "Ve33Positions#claimAccruedEmissions": "118268",
+  "Ve33Positions#claimRewards": "46130",
+  "Ve33Positions#deposit": "406801",
   "VeToken#claimPoolFees": "59715",
   "VeToken#vote": "139863"
 }

--- a/snapshots/Ve33Test.json
+++ b/snapshots/Ve33Test.json
@@ -16,7 +16,7 @@
   "Ve33Periphery#scheduleEmissions": "125470",
   "Ve33Positions#claimAccruedEmissions": "118314",
   "Ve33Positions#claimRewards": "46176",
-  "Ve33Positions#deposit": "407009",
+  "Ve33Positions#deposit": "407074",
   "VeToken#claimPoolFees": "59715",
   "VeToken#vote": "139863"
 }

--- a/snapshots/Ve33Test.json
+++ b/snapshots/Ve33Test.json
@@ -14,9 +14,9 @@
   "Ve33Forwarder#moveStake": "39275",
   "Ve33Forwarder#stake": "101642",
   "Ve33Periphery#scheduleEmissions": "125470",
-  "Ve33Positions#claimAccruedEmissions": "118281",
-  "Ve33Positions#claimRewards": "46143",
-  "Ve33Positions#deposit": "406801",
+  "Ve33Positions#claimAccruedEmissions": "118314",
+  "Ve33Positions#claimRewards": "46176",
+  "Ve33Positions#deposit": "407009",
   "VeToken#claimPoolFees": "59715",
   "VeToken#vote": "139863"
 }

--- a/src/Ve33Positions.sol
+++ b/src/Ve33Positions.sol
@@ -1,36 +1,32 @@
 // SPDX-License-Identifier: ekubo-license-v1.eth
 pragma solidity =0.8.33;
 
-import {BaseLocker} from "./base/BaseLocker.sol";
-import {BaseNonfungibleToken} from "./base/BaseNonfungibleToken.sol";
-import {PayableMulticallable} from "./base/PayableMulticallable.sol";
-import {UsesCore} from "./base/UsesCore.sol";
+import {BasePositionDepositor} from "./base/BasePositionDepositor.sol";
 import {Ve33} from "./extensions/Ve33.sol";
 import {ICore} from "./interfaces/ICore.sol";
 import {FlashAccountantLib} from "./libraries/FlashAccountantLib.sol";
 import {CoreLib} from "./libraries/CoreLib.sol";
 import {ExposedStorageLib} from "./libraries/ExposedStorageLib.sol";
 import {Ve33Lib} from "./libraries/Ve33Lib.sol";
-import {NATIVE_TOKEN_ADDRESS} from "./math/constants.sol";
-import {liquidityDeltaToAmountDelta, maxLiquidity} from "./math/liquidity.sol";
+import {liquidityDeltaToAmountDelta} from "./math/liquidity.sol";
 import {tickToSqrtRatio} from "./math/ticks.sol";
 import {PoolBalanceUpdate} from "./types/poolBalanceUpdate.sol";
 import {PoolId} from "./types/poolId.sol";
 import {PoolKey} from "./types/poolKey.sol";
+import {PoolState} from "./types/poolState.sol";
 import {PositionId, createPositionId} from "./types/positionId.sol";
 import {SqrtRatio} from "./types/sqrtRatio.sol";
+import {SwapParameters} from "./types/swapParameters.sol";
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
 import {SafeCastLib} from "solady/utils/SafeCastLib.sol";
-import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 
 /// @notice ERC721 position manager for Ve33 liquidity positions.
 /// @dev Ve33 LPs do not earn Core swap fees. This contract only manages liquidity principal and Ve33 reward claims.
-contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfungibleToken {
+contract Ve33Positions is BasePositionDepositor {
     using CoreLib for *;
     using ExposedStorageLib for *;
     using FlashAccountantLib for *;
 
-    uint256 private constant CALL_TYPE_DEPOSIT = 0;
     uint256 private constant CALL_TYPE_WITHDRAW = 1;
     uint256 private constant CALL_TYPE_CLAIM_REWARDS = 2;
     uint256 private constant CALL_TYPE_WITHDRAW_AND_CLAIM_REWARDS = 3;
@@ -41,12 +37,10 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
     /// @notice Token paid as LP rewards by Ve33.
     address public immutable stakeToken;
 
-    /// @notice Thrown when deposit fails due to insufficient liquidity for the given slippage tolerance.
-    /// @param liquidity The actual liquidity that would be provided.
-    /// @param minLiquidity The minimum liquidity required.
-    error DepositFailedDueToSlippage(uint128 liquidity, uint128 minLiquidity);
+    /// @notice Thrown when the available swap input cannot move the pool to the requested deposit price.
+    error DepositFailedToReachTargetPrice(SqrtRatio targetSqrtRatio, SqrtRatio actualSqrtRatio);
 
-    /// @notice Thrown when price movement causes the actual deposit amounts to exceed caller limits.
+    /// @notice Thrown when an extension moves the price while liquidity is being added.
     error DepositFailedDueToPriceMovement();
 
     /// @notice Thrown when deposit liquidity cannot fit in the Core position update type.
@@ -62,18 +56,12 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
     /// @param core Ekubo Core contract used for locks and position updates.
     /// @param _ve33 Ve33 extension whose pools are supported.
     /// @param owner Owner allowed to set collection metadata.
-    constructor(ICore core, Ve33 _ve33, address owner) BaseNonfungibleToken(owner) BaseLocker(core) UsesCore(core) {
+    constructor(ICore core, Ve33 _ve33, address owner) BasePositionDepositor(core, owner) {
         ve33 = _ve33;
         stakeToken = _ve33.stakeToken();
     }
 
     receive() external payable {}
-
-    /// @inheritdoc BaseNonfungibleToken
-    /// @dev Restricts generated token ids to 192 bits so the complete id is used as the Core position salt.
-    function saltToId(address minter, bytes32 salt) public view override returns (uint256 id) {
-        id = uint192(super.saltToId(minter, salt));
-    }
 
     /// @notice Computes the Core position id controlled by this NFT id and tick range.
     /// @param id ERC721 token id representing the position owner.
@@ -137,44 +125,6 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
         principal0 = uint128(-delta0);
         principal1 = uint128(-delta1);
         rewardAmount = _positionRewardAmount(poolKey, poolId, positionId_, tickLower, tickUpper, liquidity);
-    }
-
-    /// @notice Deposits tokens into a Ve33 liquidity position.
-    /// @param id ERC721 token id representing the position owner.
-    /// @param poolKey Pool receiving liquidity.
-    /// @param tickLower Lower position tick.
-    /// @param tickUpper Upper position tick.
-    /// @param maxAmount0 Maximum token0 to deposit.
-    /// @param maxAmount1 Maximum token1 to deposit.
-    /// @param minLiquidity Minimum liquidity to receive.
-    /// @return liquidity Amount of liquidity added.
-    /// @return amount0 Actual token0 deposited.
-    /// @return amount1 Actual token1 deposited.
-    function deposit(
-        uint256 id,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        uint128 minLiquidity
-    ) public payable authorizedForNft(id) returns (uint128 liquidity, uint128 amount0, uint128 amount1) {
-        (liquidity, amount0, amount1) = abi.decode(
-            lock(
-                abi.encode(
-                    CALL_TYPE_DEPOSIT,
-                    msg.sender,
-                    id,
-                    poolKey,
-                    tickLower,
-                    tickUpper,
-                    maxAmount0,
-                    maxAmount1,
-                    minLiquidity
-                )
-            ),
-            (uint128, uint128, uint128)
-        );
     }
 
     /// @notice Withdraws liquidity principal from a Ve33 position.
@@ -277,95 +227,12 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
         amount = claimRewards(id, poolKey, tickLower, tickUpper, msg.sender);
     }
 
-    /// @notice Initializes a Ve33 pool if it has not been initialized yet.
-    /// @param poolKey Pool to initialize.
-    /// @param tick Initial tick if initialization is needed.
-    /// @return initialized Whether this call initialized the pool.
-    /// @return sqrtRatio Existing or newly initialized sqrt ratio.
-    function maybeInitializePool(PoolKey memory poolKey, int32 tick)
-        external
-        payable
-        returns (bool initialized, SqrtRatio sqrtRatio)
-    {
-        _validateVe33Pool(poolKey);
-        sqrtRatio = CORE.poolState(poolKey.toPoolId()).sqrtRatio();
-        if (sqrtRatio.isZero()) {
-            initialized = true;
-            sqrtRatio = CORE.initializePool(poolKey, tick);
-        }
-    }
-
-    /// @notice Mints a new NFT and deposits liquidity.
-    function mintAndDeposit(
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        uint128 minLiquidity
-    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
-        id = mint();
-        (liquidity, amount0, amount1) = deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minLiquidity);
-    }
-
-    /// @notice Mints a new deterministic NFT and deposits liquidity.
-    function mintAndDepositWithSalt(
-        bytes32 salt,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        uint128 minLiquidity
-    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
-        id = mint(salt);
-        (liquidity, amount0, amount1) = deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minLiquidity);
-    }
-
-    /// @inheritdoc BaseLocker
+    /// @notice Handles position-manager operations while the Core lock is held.
     function handleLockData(uint256, bytes memory data) internal override returns (bytes memory result) {
         uint256 callType = abi.decode(data, (uint256));
 
         if (callType == CALL_TYPE_DEPOSIT) {
-            (
-                ,
-                address caller,
-                uint256 id,
-                PoolKey memory poolKey,
-                int32 tickLower,
-                int32 tickUpper,
-                uint128 maxAmount0,
-                uint128 maxAmount1,
-                uint128 minLiquidity
-            ) = abi.decode(data, (uint256, address, uint256, PoolKey, int32, int32, uint128, uint128, uint128));
-
-            _validateVe33Pool(poolKey);
-            SqrtRatio sqrtRatio = CORE.poolState(poolKey.toPoolId()).sqrtRatio();
-            uint128 liquidity =
-                maxLiquidity(sqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), maxAmount0, maxAmount1);
-
-            if (liquidity < minLiquidity) revert DepositFailedDueToSlippage(liquidity, minLiquidity);
-            if (liquidity > uint128(type(int128).max)) revert DepositOverflow();
-
-            PoolId poolId = poolKey.toPoolId();
-            PositionId positionId_ = positionId(id, tickLower, tickUpper);
-            uint128 existingLiquidity = Ve33Lib.positionLiquidity(CORE, poolId, address(this), positionId_);
-            if (existingLiquidity > uint128(type(int128).max) - liquidity) revert DepositOverflow();
-
-            PoolBalanceUpdate balanceUpdate = CORE.updatePosition(poolKey, positionId_, int128(liquidity));
-            uint128 amount0 = uint128(balanceUpdate.delta0());
-            uint128 amount1 = uint128(balanceUpdate.delta1());
-
-            if (amount0 > maxAmount0 || amount1 > maxAmount1) revert DepositFailedDueToPriceMovement();
-
-            if (poolKey.token0 != NATIVE_TOKEN_ADDRESS) {
-                ACCOUNTANT.payTwoFrom(caller, poolKey.token0, poolKey.token1, amount0, amount1);
-            } else {
-                if (amount0 != 0) SafeTransferLib.safeTransferETH(address(ACCOUNTANT), amount0);
-                if (amount1 != 0) ACCOUNTANT.payFrom(caller, poolKey.token1, amount1);
-            }
-
-            result = abi.encode(liquidity, amount0, amount1);
+            result = _handleDeposit(data);
         } else if (callType == CALL_TYPE_WITHDRAW) {
             (
                 ,
@@ -433,6 +300,27 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
 
     function _validateVe33Pool(PoolKey memory poolKey) private view {
         if (poolKey.config.extension() != address(ve33)) revert InvalidPoolExtension();
+    }
+
+    function _validatePool(PoolKey memory poolKey) internal view override {
+        _validateVe33Pool(poolKey);
+    }
+
+    function _validateDepositLiquidity(PoolKey memory poolKey, PositionId positionId_, uint128 liquidity)
+        internal
+        view
+        override
+    {
+        uint128 existingLiquidity = Ve33Lib.positionLiquidity(CORE, poolKey.toPoolId(), address(this), positionId_);
+        if (existingLiquidity > uint128(type(int128).max) - liquidity) revert DepositOverflow();
+    }
+
+    function _swap(PoolKey memory poolKey, SwapParameters params)
+        internal
+        override
+        returns (PoolBalanceUpdate balanceUpdate, PoolState stateAfter)
+    {
+        (balanceUpdate, stateAfter) = Ve33Lib.swap(CORE, ve33, poolKey, params);
     }
 
     function _positionRewardAmount(

--- a/src/Ve33Positions.sol
+++ b/src/Ve33Positions.sol
@@ -37,8 +37,8 @@ contract Ve33Positions is BasePositionDepositor {
     /// @notice Token paid as LP rewards by Ve33.
     address public immutable stakeToken;
 
-    /// @notice Thrown when the available swap input cannot move the pool to the requested deposit price.
-    error DepositFailedToReachTargetPrice(SqrtRatio targetSqrtRatio, SqrtRatio actualSqrtRatio);
+    /// @notice Thrown when the available swap input cannot move the pool into the requested deposit price range.
+    error DepositFailedToReachPriceRange(SqrtRatio minSqrtRatio, SqrtRatio maxSqrtRatio, SqrtRatio actualSqrtRatio);
 
     /// @notice Thrown when an extension moves the price while liquidity is being added.
     error DepositFailedDueToPriceMovement();

--- a/src/base/BasePositionDepositor.sol
+++ b/src/base/BasePositionDepositor.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: ekubo-license-v1.eth
+pragma solidity =0.8.33;
+
+import {BaseLocker} from "./BaseLocker.sol";
+import {BaseNonfungibleToken} from "./BaseNonfungibleToken.sol";
+import {PayableMulticallable} from "./PayableMulticallable.sol";
+import {UsesCore} from "./UsesCore.sol";
+import {ICore} from "../interfaces/ICore.sol";
+import {IPositions} from "../interfaces/IPositions.sol";
+import {CoreLib} from "../libraries/CoreLib.sol";
+import {FlashAccountantLib} from "../libraries/FlashAccountantLib.sol";
+import {maxLiquidity} from "../math/liquidity.sol";
+import {NATIVE_TOKEN_ADDRESS} from "../math/constants.sol";
+import {tickToSqrtRatio} from "../math/ticks.sol";
+import {PoolBalanceUpdate} from "../types/poolBalanceUpdate.sol";
+import {PoolKey} from "../types/poolKey.sol";
+import {PoolState} from "../types/poolState.sol";
+import {PositionId, createPositionId} from "../types/positionId.sol";
+import {SqrtRatio} from "../types/sqrtRatio.sol";
+import {SwapParameters, createSwapParameters} from "../types/swapParameters.sol";
+import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
+
+/// @notice Shared NFT deposit flow for regular and extension-specific position managers.
+abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseLocker, BaseNonfungibleToken {
+    using CoreLib for *;
+    using FlashAccountantLib for *;
+
+    uint256 internal constant CALL_TYPE_DEPOSIT = 0;
+
+    constructor(ICore core, address owner) BaseNonfungibleToken(owner) BaseLocker(core) UsesCore(core) {}
+
+    /// @inheritdoc BaseNonfungibleToken
+    /// @dev Restricts generated token ids to 192 bits so the complete id is used as the Core position salt.
+    function saltToId(address minter, bytes32 salt) public view virtual override returns (uint256 id) {
+        id = uint192(super.saltToId(minter, salt));
+    }
+
+    /// @notice Deposits tokens into a liquidity position at an exact pool price.
+    /// @param id The NFT token ID representing the position.
+    /// @param poolKey Pool receiving liquidity.
+    /// @param tickLower Lower tick of the position range.
+    /// @param tickUpper Upper tick of the position range.
+    /// @param maxAmount0 Maximum net amount of token0 to spend across the swap and deposit.
+    /// @param maxAmount1 Maximum net amount of token1 to spend across the swap and deposit.
+    /// @param sqrtRatio The pool price at which liquidity must be added.
+    /// @return liquidity Amount of liquidity added to the position.
+    /// @return amount0 Amount of token0 added to the position, excluding the preceding swap.
+    /// @return amount1 Amount of token1 added to the position, excluding the preceding swap.
+    function deposit(
+        uint256 id,
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio sqrtRatio
+    ) public payable virtual authorizedForNft(id) returns (uint128 liquidity, uint128 amount0, uint128 amount1) {
+        (liquidity, amount0, amount1) = abi.decode(
+            lock(
+                abi.encode(
+                    CALL_TYPE_DEPOSIT, msg.sender, id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, sqrtRatio
+                )
+            ),
+            (uint128, uint128, uint128)
+        );
+    }
+
+    /// @notice Initializes a supported pool if it has not been initialized yet.
+    function maybeInitializePool(PoolKey memory poolKey, int32 tick)
+        public
+        payable
+        virtual
+        returns (bool initialized, SqrtRatio sqrtRatio)
+    {
+        _validatePool(poolKey);
+        sqrtRatio = CORE.poolState(poolKey.toPoolId()).sqrtRatio();
+        if (sqrtRatio.isZero()) {
+            initialized = true;
+            sqrtRatio = CORE.initializePool(poolKey, tick);
+        }
+    }
+
+    /// @notice Mints a new NFT and deposits liquidity at an exact pool price.
+    function mintAndDeposit(
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio sqrtRatio
+    ) public payable virtual returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
+        id = mint();
+        (liquidity, amount0, amount1) = deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, sqrtRatio);
+    }
+
+    /// @notice Mints a new deterministic NFT and deposits liquidity at an exact pool price.
+    function mintAndDepositWithSalt(
+        bytes32 salt,
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio sqrtRatio
+    ) public payable virtual returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
+        id = mint(salt);
+        (liquidity, amount0, amount1) = deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, sqrtRatio);
+    }
+
+    function _handleDeposit(bytes memory data) internal returns (bytes memory result) {
+        (
+            ,
+            address caller,
+            uint256 id,
+            PoolKey memory poolKey,
+            int32 tickLower,
+            int32 tickUpper,
+            uint128 maxAmount0,
+            uint128 maxAmount1,
+            SqrtRatio targetSqrtRatio
+        ) = abi.decode(data, (uint256, address, uint256, PoolKey, int32, int32, uint128, uint128, SqrtRatio));
+
+        _validatePool(poolKey);
+
+        PoolState stateBefore = CORE.poolState(poolKey.toPoolId());
+        PoolBalanceUpdate swapBalanceUpdate;
+        PoolState stateAfter = stateBefore;
+
+        if (stateBefore.sqrtRatio() != targetSqrtRatio) {
+            bool increasing = targetSqrtRatio > stateBefore.sqrtRatio();
+            uint128 maxSwapAmount = increasing ? maxAmount1 : maxAmount0;
+            int128 swapAmount = maxSwapAmount > uint128(type(int128).max) ? type(int128).max : int128(maxSwapAmount);
+
+            (swapBalanceUpdate, stateAfter) = _swap(
+                poolKey,
+                createSwapParameters({
+                    _sqrtRatioLimit: targetSqrtRatio, _amount: swapAmount, _isToken1: increasing, _skipAhead: 0
+                })
+            );
+        }
+
+        if (stateAfter.sqrtRatio() != targetSqrtRatio) {
+            revert IPositions.DepositFailedToReachTargetPrice(targetSqrtRatio, stateAfter.sqrtRatio());
+        }
+
+        uint128 availableAmount0 = _availableAmount(maxAmount0, swapBalanceUpdate.delta0());
+        uint128 availableAmount1 = _availableAmount(maxAmount1, swapBalanceUpdate.delta1());
+        uint128 liquidity = maxLiquidity(
+            targetSqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), availableAmount0, availableAmount1
+        );
+
+        if (liquidity > uint128(type(int128).max)) revert IPositions.DepositOverflow();
+
+        PositionId positionId = createPositionId(bytes24(uint192(id)), tickLower, tickUpper);
+        _validateDepositLiquidity(poolKey, positionId, liquidity);
+        PoolBalanceUpdate depositBalanceUpdate = CORE.updatePosition(poolKey, positionId, int128(liquidity));
+
+        if (CORE.poolState(poolKey.toPoolId()).sqrtRatio() != targetSqrtRatio) {
+            revert IPositions.DepositFailedDueToPriceMovement();
+        }
+
+        int256 balanceDelta0 = int256(swapBalanceUpdate.delta0()) + int256(depositBalanceUpdate.delta0());
+        int256 balanceDelta1 = int256(swapBalanceUpdate.delta1()) + int256(depositBalanceUpdate.delta1());
+        if (balanceDelta0 > int256(uint256(maxAmount0)) || balanceDelta1 > int256(uint256(maxAmount1))) {
+            revert IPositions.DepositFailedDueToPriceMovement();
+        }
+
+        _settle(caller, poolKey, balanceDelta0, balanceDelta1);
+
+        result = abi.encode(liquidity, uint128(depositBalanceUpdate.delta0()), uint128(depositBalanceUpdate.delta1()));
+    }
+
+    function _availableAmount(uint128 maxAmount, int128 swapDelta) private pure returns (uint128 amount) {
+        uint256 available = uint256(maxAmount);
+        if (swapDelta >= 0) {
+            available -= uint128(swapDelta);
+        } else {
+            available += uint128(uint256(-int256(swapDelta)));
+        }
+        amount = available > type(uint128).max ? type(uint128).max : uint128(available);
+    }
+
+    function _settle(address caller, PoolKey memory poolKey, int256 delta0, int256 delta1) private {
+        if (delta0 >= 0 && delta1 >= 0 && poolKey.token0 != NATIVE_TOKEN_ADDRESS) {
+            ACCOUNTANT.payTwoFrom(caller, poolKey.token0, poolKey.token1, uint256(delta0), uint256(delta1));
+        } else {
+            _settleToken(caller, poolKey.token0, delta0);
+            _settleToken(caller, poolKey.token1, delta1);
+        }
+    }
+
+    function _settleToken(address caller, address token, int256 delta) private {
+        if (delta > 0) {
+            uint128 amount = uint128(uint256(delta));
+            if (token == NATIVE_TOKEN_ADDRESS) {
+                SafeTransferLib.safeTransferETH(address(ACCOUNTANT), amount);
+            } else {
+                ACCOUNTANT.payFrom(caller, token, amount);
+            }
+        } else if (delta < 0) {
+            ACCOUNTANT.withdraw(token, caller, uint128(uint256(-delta)));
+        }
+    }
+
+    function _validatePool(PoolKey memory poolKey) internal view virtual {}
+
+    function _validateDepositLiquidity(PoolKey memory poolKey, PositionId positionId, uint128 liquidity)
+        internal
+        view
+        virtual {}
+
+    function _swap(PoolKey memory poolKey, SwapParameters params)
+        internal
+        virtual
+        returns (PoolBalanceUpdate balanceUpdate, PoolState stateAfter);
+}

--- a/src/base/BasePositionDepositor.sol
+++ b/src/base/BasePositionDepositor.sol
@@ -6,7 +6,9 @@ import {BaseNonfungibleToken} from "./BaseNonfungibleToken.sol";
 import {PayableMulticallable} from "./PayableMulticallable.sol";
 import {UsesCore} from "./UsesCore.sol";
 import {ICore} from "../interfaces/ICore.sol";
+import {IPositionDepositor} from "../interfaces/IPositionDepositor.sol";
 import {IPositions} from "../interfaces/IPositions.sol";
+import {IBaseNonfungibleToken} from "../interfaces/IBaseNonfungibleToken.sol";
 import {CoreLib} from "../libraries/CoreLib.sol";
 import {FlashAccountantLib} from "../libraries/FlashAccountantLib.sol";
 import {maxLiquidity} from "../math/liquidity.sol";
@@ -21,7 +23,13 @@ import {SwapParameters, createSwapParameters} from "../types/swapParameters.sol"
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 
 /// @notice Shared NFT deposit flow for regular and extension-specific position managers.
-abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseLocker, BaseNonfungibleToken {
+abstract contract BasePositionDepositor is
+    IPositionDepositor,
+    UsesCore,
+    PayableMulticallable,
+    BaseLocker,
+    BaseNonfungibleToken
+{
     using CoreLib for *;
     using FlashAccountantLib for *;
 
@@ -31,7 +39,13 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
 
     /// @inheritdoc BaseNonfungibleToken
     /// @dev Restricts generated token ids to 192 bits so the complete id is used as the Core position salt.
-    function saltToId(address minter, bytes32 salt) public view virtual override returns (uint256 id) {
+    function saltToId(address minter, bytes32 salt)
+        public
+        view
+        virtual
+        override(BaseNonfungibleToken, IBaseNonfungibleToken)
+        returns (uint256 id)
+    {
         id = uint192(super.saltToId(minter, salt));
     }
 
@@ -56,10 +70,9 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
         uint128 maxAmount1,
         SqrtRatio minSqrtRatio,
         SqrtRatio maxSqrtRatio
-    ) public payable virtual returns (uint128 liquidity, uint128 amount0, uint128 amount1) {
-        return deposit(
-            id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, msg.sender
-        );
+    ) public payable virtual override returns (uint128 liquidity, uint128 amount0, uint128 amount1) {
+        return
+            deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, msg.sender);
     }
 
     /// @notice Deposits tokens into a liquidity position and sends unused swap output to `swapRecipient`.
@@ -73,7 +86,14 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
         SqrtRatio minSqrtRatio,
         SqrtRatio maxSqrtRatio,
         address swapRecipient
-    ) public payable virtual authorizedForNft(id) returns (uint128 liquidity, uint128 amount0, uint128 amount1) {
+    )
+        public
+        payable
+        virtual
+        override
+        authorizedForNft(id)
+        returns (uint128 liquidity, uint128 amount0, uint128 amount1)
+    {
         (liquidity, amount0, amount1) = abi.decode(
             lock(
                 abi.encode(
@@ -99,6 +119,7 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
         public
         payable
         virtual
+        override
         returns (bool initialized, SqrtRatio sqrtRatio)
     {
         _validatePool(poolKey);
@@ -118,7 +139,7 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
         uint128 maxAmount1,
         SqrtRatio minSqrtRatio,
         SqrtRatio maxSqrtRatio
-    ) public payable virtual returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
+    ) public payable virtual override returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
         return
             mintAndDeposit(
                 poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, msg.sender
@@ -135,7 +156,7 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
         SqrtRatio minSqrtRatio,
         SqrtRatio maxSqrtRatio,
         address swapRecipient
-    ) public payable virtual returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
+    ) public payable virtual override returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
         id = mint();
         (liquidity, amount0, amount1) = deposit(
             id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, swapRecipient
@@ -152,7 +173,7 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
         uint128 maxAmount1,
         SqrtRatio minSqrtRatio,
         SqrtRatio maxSqrtRatio
-    ) public payable virtual returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
+    ) public payable virtual override returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
         return mintAndDepositWithSalt(
             salt, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, msg.sender
         );
@@ -169,7 +190,7 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
         SqrtRatio minSqrtRatio,
         SqrtRatio maxSqrtRatio,
         address swapRecipient
-    ) public payable virtual returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
+    ) public payable virtual override returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
         id = mint(salt);
         (liquidity, amount0, amount1) = deposit(
             id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, swapRecipient
@@ -230,13 +251,12 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
         _validateDepositLiquidity(poolKey, positionId, liquidity);
         PoolBalanceUpdate depositBalanceUpdate = CORE.updatePosition(poolKey, positionId, int128(liquidity));
 
-        if (CORE.poolState(poolKey.toPoolId()).sqrtRatio() != depositSqrtRatio) {
-            revert IPositions.DepositFailedDueToPriceMovement();
-        }
-
         int256 balanceDelta0 = int256(swapBalanceUpdate.delta0()) + int256(depositBalanceUpdate.delta0());
         int256 balanceDelta1 = int256(swapBalanceUpdate.delta1()) + int256(depositBalanceUpdate.delta1());
-        if (balanceDelta0 > int256(uint256(maxAmount0)) || balanceDelta1 > int256(uint256(maxAmount1))) {
+        if (
+            CORE.poolState(poolKey.toPoolId()).sqrtRatio() != depositSqrtRatio
+                || balanceDelta0 > int256(uint256(maxAmount0)) || balanceDelta1 > int256(uint256(maxAmount1))
+        ) {
             revert IPositions.DepositFailedDueToPriceMovement();
         }
 

--- a/src/base/BasePositionDepositor.sol
+++ b/src/base/BasePositionDepositor.sol
@@ -35,14 +35,15 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
         id = uint192(super.saltToId(minter, salt));
     }
 
-    /// @notice Deposits tokens into a liquidity position at an exact pool price.
+    /// @notice Deposits tokens into a liquidity position within a pool price range.
     /// @param id The NFT token ID representing the position.
     /// @param poolKey Pool receiving liquidity.
     /// @param tickLower Lower tick of the position range.
     /// @param tickUpper Upper tick of the position range.
     /// @param maxAmount0 Maximum net amount of token0 to spend across the swap and deposit.
     /// @param maxAmount1 Maximum net amount of token1 to spend across the swap and deposit.
-    /// @param sqrtRatio The pool price at which liquidity must be added.
+    /// @param minSqrtRatio Lower bound of the acceptable pool price range.
+    /// @param maxSqrtRatio Upper bound of the acceptable pool price range.
     /// @return liquidity Amount of liquidity added to the position.
     /// @return amount0 Amount of token0 added to the position, excluding the preceding swap.
     /// @return amount1 Amount of token1 added to the position, excluding the preceding swap.
@@ -53,12 +54,40 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
         int32 tickUpper,
         uint128 maxAmount0,
         uint128 maxAmount1,
-        SqrtRatio sqrtRatio
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio
+    ) public payable virtual returns (uint128 liquidity, uint128 amount0, uint128 amount1) {
+        return deposit(
+            id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, msg.sender
+        );
+    }
+
+    /// @notice Deposits tokens into a liquidity position and sends unused swap output to `swapRecipient`.
+    function deposit(
+        uint256 id,
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio,
+        address swapRecipient
     ) public payable virtual authorizedForNft(id) returns (uint128 liquidity, uint128 amount0, uint128 amount1) {
         (liquidity, amount0, amount1) = abi.decode(
             lock(
                 abi.encode(
-                    CALL_TYPE_DEPOSIT, msg.sender, id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, sqrtRatio
+                    CALL_TYPE_DEPOSIT,
+                    msg.sender,
+                    swapRecipient,
+                    id,
+                    poolKey,
+                    tickLower,
+                    tickUpper,
+                    maxAmount0,
+                    maxAmount1,
+                    minSqrtRatio,
+                    maxSqrtRatio
                 )
             ),
             (uint128, uint128, uint128)
@@ -80,20 +109,40 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
         }
     }
 
-    /// @notice Mints a new NFT and deposits liquidity at an exact pool price.
+    /// @notice Mints a new NFT and deposits liquidity within a pool price range.
     function mintAndDeposit(
         PoolKey memory poolKey,
         int32 tickLower,
         int32 tickUpper,
         uint128 maxAmount0,
         uint128 maxAmount1,
-        SqrtRatio sqrtRatio
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio
     ) public payable virtual returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
-        id = mint();
-        (liquidity, amount0, amount1) = deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, sqrtRatio);
+        return
+            mintAndDeposit(
+                poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, msg.sender
+            );
     }
 
-    /// @notice Mints a new deterministic NFT and deposits liquidity at an exact pool price.
+    /// @notice Mints a new NFT, deposits liquidity, and sends unused swap output to `swapRecipient`.
+    function mintAndDeposit(
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio,
+        address swapRecipient
+    ) public payable virtual returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
+        id = mint();
+        (liquidity, amount0, amount1) = deposit(
+            id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, swapRecipient
+        );
+    }
+
+    /// @notice Mints a new deterministic NFT and deposits liquidity within a pool price range.
     function mintAndDepositWithSalt(
         bytes32 salt,
         PoolKey memory poolKey,
@@ -101,52 +150,78 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
         int32 tickUpper,
         uint128 maxAmount0,
         uint128 maxAmount1,
-        SqrtRatio sqrtRatio
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio
+    ) public payable virtual returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
+        return mintAndDepositWithSalt(
+            salt, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, msg.sender
+        );
+    }
+
+    /// @notice Mints a deterministic NFT, deposits liquidity, and sends unused swap output to `swapRecipient`.
+    function mintAndDepositWithSalt(
+        bytes32 salt,
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio,
+        address swapRecipient
     ) public payable virtual returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
         id = mint(salt);
-        (liquidity, amount0, amount1) = deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, sqrtRatio);
+        (liquidity, amount0, amount1) = deposit(
+            id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, swapRecipient
+        );
     }
 
     function _handleDeposit(bytes memory data) internal returns (bytes memory result) {
         (
             ,
             address caller,
+            address swapRecipient,
             uint256 id,
             PoolKey memory poolKey,
             int32 tickLower,
             int32 tickUpper,
             uint128 maxAmount0,
             uint128 maxAmount1,
-            SqrtRatio targetSqrtRatio
-        ) = abi.decode(data, (uint256, address, uint256, PoolKey, int32, int32, uint128, uint128, SqrtRatio));
+            SqrtRatio minSqrtRatio,
+            SqrtRatio maxSqrtRatio
+        ) = abi.decode(
+            data, (uint256, address, address, uint256, PoolKey, int32, int32, uint128, uint128, SqrtRatio, SqrtRatio)
+        );
 
         _validatePool(poolKey);
 
         PoolState stateBefore = CORE.poolState(poolKey.toPoolId());
         PoolBalanceUpdate swapBalanceUpdate;
         PoolState stateAfter = stateBefore;
+        SqrtRatio boundarySqrtRatio;
 
-        if (stateBefore.sqrtRatio() != targetSqrtRatio) {
-            bool increasing = targetSqrtRatio > stateBefore.sqrtRatio();
+        if (stateBefore.sqrtRatio() < minSqrtRatio || stateBefore.sqrtRatio() > maxSqrtRatio) {
+            bool increasing = stateBefore.sqrtRatio() < minSqrtRatio;
+            boundarySqrtRatio = increasing ? minSqrtRatio : maxSqrtRatio;
             uint128 maxSwapAmount = increasing ? maxAmount1 : maxAmount0;
             int128 swapAmount = maxSwapAmount > uint128(type(int128).max) ? type(int128).max : int128(maxSwapAmount);
 
             (swapBalanceUpdate, stateAfter) = _swap(
                 poolKey,
                 createSwapParameters({
-                    _sqrtRatioLimit: targetSqrtRatio, _amount: swapAmount, _isToken1: increasing, _skipAhead: 0
+                    _sqrtRatioLimit: boundarySqrtRatio, _amount: swapAmount, _isToken1: increasing, _skipAhead: 0
                 })
             );
+            if (stateAfter.sqrtRatio() != boundarySqrtRatio) {
+                revert IPositions.DepositFailedToReachPriceRange(minSqrtRatio, maxSqrtRatio, stateAfter.sqrtRatio());
+            }
         }
 
-        if (stateAfter.sqrtRatio() != targetSqrtRatio) {
-            revert IPositions.DepositFailedToReachTargetPrice(targetSqrtRatio, stateAfter.sqrtRatio());
-        }
-
+        SqrtRatio depositSqrtRatio = stateAfter.sqrtRatio();
         uint128 availableAmount0 = _availableAmount(maxAmount0, swapBalanceUpdate.delta0());
         uint128 availableAmount1 = _availableAmount(maxAmount1, swapBalanceUpdate.delta1());
         uint128 liquidity = maxLiquidity(
-            targetSqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), availableAmount0, availableAmount1
+            depositSqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), availableAmount0, availableAmount1
         );
 
         if (liquidity > uint128(type(int128).max)) revert IPositions.DepositOverflow();
@@ -155,7 +230,7 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
         _validateDepositLiquidity(poolKey, positionId, liquidity);
         PoolBalanceUpdate depositBalanceUpdate = CORE.updatePosition(poolKey, positionId, int128(liquidity));
 
-        if (CORE.poolState(poolKey.toPoolId()).sqrtRatio() != targetSqrtRatio) {
+        if (CORE.poolState(poolKey.toPoolId()).sqrtRatio() != depositSqrtRatio) {
             revert IPositions.DepositFailedDueToPriceMovement();
         }
 
@@ -165,7 +240,7 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
             revert IPositions.DepositFailedDueToPriceMovement();
         }
 
-        _settle(caller, poolKey, balanceDelta0, balanceDelta1);
+        _settle(caller, swapRecipient, poolKey, balanceDelta0, balanceDelta1);
 
         result = abi.encode(liquidity, uint128(depositBalanceUpdate.delta0()), uint128(depositBalanceUpdate.delta1()));
     }
@@ -180,16 +255,18 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
         amount = available > type(uint128).max ? type(uint128).max : uint128(available);
     }
 
-    function _settle(address caller, PoolKey memory poolKey, int256 delta0, int256 delta1) private {
+    function _settle(address caller, address swapRecipient, PoolKey memory poolKey, int256 delta0, int256 delta1)
+        private
+    {
         if (delta0 >= 0 && delta1 >= 0 && poolKey.token0 != NATIVE_TOKEN_ADDRESS) {
             ACCOUNTANT.payTwoFrom(caller, poolKey.token0, poolKey.token1, uint256(delta0), uint256(delta1));
         } else {
-            _settleToken(caller, poolKey.token0, delta0);
-            _settleToken(caller, poolKey.token1, delta1);
+            _settleToken(caller, swapRecipient, poolKey.token0, delta0);
+            _settleToken(caller, swapRecipient, poolKey.token1, delta1);
         }
     }
 
-    function _settleToken(address caller, address token, int256 delta) private {
+    function _settleToken(address caller, address swapRecipient, address token, int256 delta) private {
         if (delta > 0) {
             uint128 amount = uint128(uint256(delta));
             if (token == NATIVE_TOKEN_ADDRESS) {
@@ -198,7 +275,7 @@ abstract contract BasePositionDepositor is UsesCore, PayableMulticallable, BaseL
                 ACCOUNTANT.payFrom(caller, token, amount);
             }
         } else if (delta < 0) {
-            ACCOUNTANT.withdraw(token, caller, uint128(uint256(-delta)));
+            ACCOUNTANT.withdraw(token, swapRecipient, uint128(uint256(-delta)));
         }
     }
 

--- a/src/base/BasePositions.sol
+++ b/src/base/BasePositions.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: ekubo-license-v1.eth
 pragma solidity =0.8.33;
 
-import {BaseLocker} from "./BaseLocker.sol";
-import {UsesCore} from "./UsesCore.sol";
+import {BasePositionDepositor} from "./BasePositionDepositor.sol";
 import {ICore} from "../interfaces/ICore.sol";
-import {IBaseNonfungibleToken} from "../interfaces/IBaseNonfungibleToken.sol";
 import {IPositions} from "../interfaces/IPositions.sol";
 import {CoreLib} from "../libraries/CoreLib.sol";
 import {FlashAccountantLib} from "../libraries/FlashAccountantLib.sol";
@@ -13,43 +11,30 @@ import {PositionId, createPositionId} from "../types/positionId.sol";
 import {FeesPerLiquidity} from "../types/feesPerLiquidity.sol";
 import {Position} from "../types/position.sol";
 import {tickToSqrtRatio} from "../math/ticks.sol";
-import {maxLiquidity, liquidityDeltaToAmountDelta} from "../math/liquidity.sol";
-import {PayableMulticallable} from "./PayableMulticallable.sol";
+import {liquidityDeltaToAmountDelta} from "../math/liquidity.sol";
 import {SqrtRatio} from "../types/sqrtRatio.sol";
 import {SafeCastLib} from "solady/utils/SafeCastLib.sol";
-import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
-import {BaseNonfungibleToken} from "./BaseNonfungibleToken.sol";
-import {NATIVE_TOKEN_ADDRESS} from "../math/constants.sol";
 import {PoolId} from "../types/poolId.sol";
 import {PoolBalanceUpdate} from "../types/poolBalanceUpdate.sol";
+import {PoolState} from "../types/poolState.sol";
+import {SwapParameters} from "../types/swapParameters.sol";
 
 /// @title Base Positions Contract
 /// @author Moody Salem <moody@ekubo.org>
 /// @notice Abstract base contract for tracking liquidity positions in Ekubo Protocol as NFTs
 /// @dev Provides core position management functionality with abstract protocol fee collection methods
-abstract contract BasePositions is IPositions, UsesCore, PayableMulticallable, BaseLocker, BaseNonfungibleToken {
+abstract contract BasePositions is IPositions, BasePositionDepositor {
     using CoreLib for *;
     using FlashAccountantLib for *;
 
     /// @notice Constructs the BasePositions contract
     /// @param core The core contract instance
     /// @param owner The owner of the contract (for access control)
-    constructor(ICore core, address owner) BaseNonfungibleToken(owner) BaseLocker(core) UsesCore(core) {}
+    constructor(ICore core, address owner) BasePositionDepositor(core, owner) {}
 
-    uint256 private constant CALL_TYPE_DEPOSIT = 0;
     uint256 private constant CALL_TYPE_WITHDRAW = 1;
     uint256 private constant CALL_TYPE_WITHDRAW_PROTOCOL_FEES = 2;
-
-    /// @inheritdoc BaseNonfungibleToken
-    /// @dev Restricts generated token ids to 192 bits so the complete id is used as the Core position salt.
-    function saltToId(address minter, bytes32 salt)
-        public
-        view
-        override(BaseNonfungibleToken, IBaseNonfungibleToken)
-        returns (uint256 id)
-    {
-        id = uint192(super.saltToId(minter, salt));
-    }
+    uint8 private constant MEV_CAPTURE_CALL_POINTS = 0x55;
 
     /// @inheritdoc IPositions
     function getPositionFeesAndLiquidity(uint256 id, PoolKey memory poolKey, int32 tickLower, int32 tickUpper)
@@ -87,24 +72,59 @@ abstract contract BasePositions is IPositions, UsesCore, PayableMulticallable, B
         int32 tickUpper,
         uint128 maxAmount0,
         uint128 maxAmount1,
-        uint128 minLiquidity
-    ) public payable authorizedForNft(id) returns (uint128 liquidity, uint128 amount0, uint128 amount1) {
-        (liquidity, amount0, amount1) = abi.decode(
-            lock(
-                abi.encode(
-                    CALL_TYPE_DEPOSIT,
-                    msg.sender,
-                    id,
-                    poolKey,
-                    tickLower,
-                    tickUpper,
-                    maxAmount0,
-                    maxAmount1,
-                    minLiquidity
-                )
-            ),
-            (uint128, uint128, uint128)
-        );
+        SqrtRatio sqrtRatio
+    )
+        public
+        payable
+        override(IPositions, BasePositionDepositor)
+        returns (uint128 liquidity, uint128 amount0, uint128 amount1)
+    {
+        return super.deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, sqrtRatio);
+    }
+
+    /// @inheritdoc IPositions
+    function maybeInitializePool(PoolKey memory poolKey, int32 tick)
+        public
+        payable
+        override(IPositions, BasePositionDepositor)
+        returns (bool initialized, SqrtRatio sqrtRatio)
+    {
+        return super.maybeInitializePool(poolKey, tick);
+    }
+
+    /// @inheritdoc IPositions
+    function mintAndDeposit(
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio sqrtRatio
+    )
+        public
+        payable
+        override(IPositions, BasePositionDepositor)
+        returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1)
+    {
+        return super.mintAndDeposit(poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, sqrtRatio);
+    }
+
+    /// @inheritdoc IPositions
+    function mintAndDepositWithSalt(
+        bytes32 salt,
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio sqrtRatio
+    )
+        public
+        payable
+        override(IPositions, BasePositionDepositor)
+        returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1)
+    {
+        return super.mintAndDepositWithSalt(salt, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, sqrtRatio);
     }
 
     /// @inheritdoc IPositions
@@ -153,47 +173,6 @@ abstract contract BasePositions is IPositions, UsesCore, PayableMulticallable, B
     }
 
     /// @inheritdoc IPositions
-    function maybeInitializePool(PoolKey memory poolKey, int32 tick)
-        external
-        payable
-        returns (bool initialized, SqrtRatio sqrtRatio)
-    {
-        // the before update position hook shouldn't be taken into account here
-        sqrtRatio = CORE.poolState(poolKey.toPoolId()).sqrtRatio();
-        if (sqrtRatio.isZero()) {
-            initialized = true;
-            sqrtRatio = CORE.initializePool(poolKey, tick);
-        }
-    }
-
-    /// @inheritdoc IPositions
-    function mintAndDeposit(
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        uint128 minLiquidity
-    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
-        id = mint();
-        (liquidity, amount0, amount1) = deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minLiquidity);
-    }
-
-    /// @inheritdoc IPositions
-    function mintAndDepositWithSalt(
-        bytes32 salt,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        uint128 minLiquidity
-    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
-        id = mint(salt);
-        (liquidity, amount0, amount1) = deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minLiquidity);
-    }
-
-    /// @inheritdoc IPositions
     function withdrawProtocolFees(address token0, address token1, uint128 amount0, uint128 amount1, address recipient)
         external
         payable
@@ -233,6 +212,21 @@ abstract contract BasePositions is IPositions, UsesCore, PayableMulticallable, B
         virtual
         returns (uint128 protocolFee0, uint128 protocolFee1);
 
+    function _swap(PoolKey memory poolKey, SwapParameters params)
+        internal
+        override
+        returns (PoolBalanceUpdate balanceUpdate, PoolState stateAfter)
+    {
+        address extension = poolKey.config.extension();
+        // MEV Capture pools reject direct Core swaps and use the standard fixed-size forwarded swap payload.
+        if (uint8(uint160(extension) >> 152) == MEV_CAPTURE_CALL_POINTS) {
+            (balanceUpdate, stateAfter) =
+                abi.decode(CORE.forward(extension, abi.encode(poolKey, params)), (PoolBalanceUpdate, PoolState));
+        } else {
+            (balanceUpdate, stateAfter) = CORE.swap(0, poolKey, params);
+        }
+    }
+
     /// @notice Handles lock callback data for position operations
     /// @dev Internal function that processes different types of position operations
     /// @param data Encoded operation data
@@ -241,55 +235,7 @@ abstract contract BasePositions is IPositions, UsesCore, PayableMulticallable, B
         uint256 callType = abi.decode(data, (uint256));
 
         if (callType == CALL_TYPE_DEPOSIT) {
-            (
-                ,
-                address caller,
-                uint256 id,
-                PoolKey memory poolKey,
-                int32 tickLower,
-                int32 tickUpper,
-                uint128 maxAmount0,
-                uint128 maxAmount1,
-                uint128 minLiquidity
-            ) = abi.decode(data, (uint256, address, uint256, PoolKey, int32, int32, uint128, uint128, uint128));
-
-            SqrtRatio sqrtRatio = CORE.poolState(poolKey.toPoolId()).sqrtRatio();
-
-            uint128 liquidity =
-                maxLiquidity(sqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), maxAmount0, maxAmount1);
-
-            if (liquidity < minLiquidity) {
-                revert DepositFailedDueToSlippage(liquidity, minLiquidity);
-            }
-
-            if (liquidity > uint128(type(int128).max)) {
-                revert DepositOverflow();
-            }
-
-            PoolBalanceUpdate balanceUpdate = CORE.updatePosition(
-                poolKey,
-                createPositionId({_salt: bytes24(uint192(id)), _tickLower: tickLower, _tickUpper: tickUpper}),
-                int128(liquidity)
-            );
-
-            uint128 amount0 = uint128(balanceUpdate.delta0());
-            uint128 amount1 = uint128(balanceUpdate.delta1());
-
-            if (amount0 > maxAmount0 || amount1 > maxAmount1) revert DepositFailedDueToPriceMovement();
-
-            // Use multi-token payment for ERC20-only pools, fall back to individual payments for native token pools
-            if (poolKey.token0 != NATIVE_TOKEN_ADDRESS) {
-                ACCOUNTANT.payTwoFrom(caller, poolKey.token0, poolKey.token1, amount0, amount1);
-            } else {
-                if (amount0 != 0) {
-                    SafeTransferLib.safeTransferETH(address(ACCOUNTANT), amount0);
-                }
-                if (amount1 != 0) {
-                    ACCOUNTANT.payFrom(caller, poolKey.token1, amount1);
-                }
-            }
-
-            result = abi.encode(liquidity, amount0, amount1);
+            result = _handleDeposit(data);
         } else if (callType == CALL_TYPE_WITHDRAW) {
             (
                 ,

--- a/src/base/BasePositions.sol
+++ b/src/base/BasePositions.sol
@@ -23,7 +23,7 @@ import {SwapParameters} from "../types/swapParameters.sol";
 /// @author Moody Salem <moody@ekubo.org>
 /// @notice Abstract base contract for tracking liquidity positions in Ekubo Protocol as NFTs
 /// @dev Provides core position management functionality with abstract protocol fee collection methods
-abstract contract BasePositions is IPositions, BasePositionDepositor {
+abstract contract BasePositions is BasePositionDepositor, IPositions {
     using CoreLib for *;
     using FlashAccountantLib for *;
 
@@ -62,139 +62,6 @@ abstract contract BasePositions is IPositions, BasePositionDepositor {
             ? CORE.getPoolFeesPerLiquidity(poolId)
             : CORE.getPoolFeesPerLiquidityInside(poolId, tickLower, tickUpper);
         (fees0, fees1) = position.fees(feesPerLiquidityInside);
-    }
-
-    /// @inheritdoc IPositions
-    function deposit(
-        uint256 id,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        SqrtRatio minSqrtRatio,
-        SqrtRatio maxSqrtRatio
-    )
-        public
-        payable
-        override(IPositions, BasePositionDepositor)
-        returns (uint128 liquidity, uint128 amount0, uint128 amount1)
-    {
-        return super.deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio);
-    }
-
-    /// @inheritdoc IPositions
-    function deposit(
-        uint256 id,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        SqrtRatio minSqrtRatio,
-        SqrtRatio maxSqrtRatio,
-        address swapRecipient
-    )
-        public
-        payable
-        override(IPositions, BasePositionDepositor)
-        returns (uint128 liquidity, uint128 amount0, uint128 amount1)
-    {
-        return super.deposit(
-            id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, swapRecipient
-        );
-    }
-
-    /// @inheritdoc IPositions
-    function maybeInitializePool(PoolKey memory poolKey, int32 tick)
-        public
-        payable
-        override(IPositions, BasePositionDepositor)
-        returns (bool initialized, SqrtRatio sqrtRatio)
-    {
-        return super.maybeInitializePool(poolKey, tick);
-    }
-
-    /// @inheritdoc IPositions
-    function mintAndDeposit(
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        SqrtRatio minSqrtRatio,
-        SqrtRatio maxSqrtRatio
-    )
-        public
-        payable
-        override(IPositions, BasePositionDepositor)
-        returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1)
-    {
-        return super.mintAndDeposit(poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio);
-    }
-
-    /// @inheritdoc IPositions
-    function mintAndDeposit(
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        SqrtRatio minSqrtRatio,
-        SqrtRatio maxSqrtRatio,
-        address swapRecipient
-    )
-        public
-        payable
-        override(IPositions, BasePositionDepositor)
-        returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1)
-    {
-        return super.mintAndDeposit(
-            poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, swapRecipient
-        );
-    }
-
-    /// @inheritdoc IPositions
-    function mintAndDepositWithSalt(
-        bytes32 salt,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        SqrtRatio minSqrtRatio,
-        SqrtRatio maxSqrtRatio
-    )
-        public
-        payable
-        override(IPositions, BasePositionDepositor)
-        returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1)
-    {
-        return super.mintAndDepositWithSalt(
-            salt, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio
-        );
-    }
-
-    /// @inheritdoc IPositions
-    function mintAndDepositWithSalt(
-        bytes32 salt,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        SqrtRatio minSqrtRatio,
-        SqrtRatio maxSqrtRatio,
-        address swapRecipient
-    )
-        public
-        payable
-        override(IPositions, BasePositionDepositor)
-        returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1)
-    {
-        return super.mintAndDepositWithSalt(
-            salt, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, swapRecipient
-        );
     }
 
     /// @inheritdoc IPositions

--- a/src/base/BasePositions.sol
+++ b/src/base/BasePositions.sol
@@ -72,14 +72,37 @@ abstract contract BasePositions is IPositions, BasePositionDepositor {
         int32 tickUpper,
         uint128 maxAmount0,
         uint128 maxAmount1,
-        SqrtRatio sqrtRatio
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio
     )
         public
         payable
         override(IPositions, BasePositionDepositor)
         returns (uint128 liquidity, uint128 amount0, uint128 amount1)
     {
-        return super.deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, sqrtRatio);
+        return super.deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio);
+    }
+
+    /// @inheritdoc IPositions
+    function deposit(
+        uint256 id,
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio,
+        address swapRecipient
+    )
+        public
+        payable
+        override(IPositions, BasePositionDepositor)
+        returns (uint128 liquidity, uint128 amount0, uint128 amount1)
+    {
+        return super.deposit(
+            id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, swapRecipient
+        );
     }
 
     /// @inheritdoc IPositions
@@ -99,14 +122,36 @@ abstract contract BasePositions is IPositions, BasePositionDepositor {
         int32 tickUpper,
         uint128 maxAmount0,
         uint128 maxAmount1,
-        SqrtRatio sqrtRatio
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio
     )
         public
         payable
         override(IPositions, BasePositionDepositor)
         returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1)
     {
-        return super.mintAndDeposit(poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, sqrtRatio);
+        return super.mintAndDeposit(poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio);
+    }
+
+    /// @inheritdoc IPositions
+    function mintAndDeposit(
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio,
+        address swapRecipient
+    )
+        public
+        payable
+        override(IPositions, BasePositionDepositor)
+        returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1)
+    {
+        return super.mintAndDeposit(
+            poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, swapRecipient
+        );
     }
 
     /// @inheritdoc IPositions
@@ -117,14 +162,39 @@ abstract contract BasePositions is IPositions, BasePositionDepositor {
         int32 tickUpper,
         uint128 maxAmount0,
         uint128 maxAmount1,
-        SqrtRatio sqrtRatio
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio
     )
         public
         payable
         override(IPositions, BasePositionDepositor)
         returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1)
     {
-        return super.mintAndDepositWithSalt(salt, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, sqrtRatio);
+        return super.mintAndDepositWithSalt(
+            salt, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio
+        );
+    }
+
+    /// @inheritdoc IPositions
+    function mintAndDepositWithSalt(
+        bytes32 salt,
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio,
+        address swapRecipient
+    )
+        public
+        payable
+        override(IPositions, BasePositionDepositor)
+        returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1)
+    {
+        return super.mintAndDepositWithSalt(
+            salt, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minSqrtRatio, maxSqrtRatio, swapRecipient
+        );
     }
 
     /// @inheritdoc IPositions

--- a/src/interfaces/IPositionDepositor.sol
+++ b/src/interfaces/IPositionDepositor.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: ekubo-license-v1.eth
+pragma solidity ^0.8.0;
+
+import {PoolKey} from "../types/poolKey.sol";
+import {SqrtRatio} from "../types/sqrtRatio.sol";
+import {IBaseNonfungibleToken} from "./IBaseNonfungibleToken.sol";
+
+/// @notice Shared interface for adding liquidity through a position NFT manager.
+interface IPositionDepositor is IBaseNonfungibleToken {
+    /// @notice Swaps the pool into the requested price range when necessary, then deposits liquidity.
+    /// @param id The NFT token ID representing the position.
+    /// @param poolKey Pool key identifying the pool.
+    /// @param tickLower Lower tick of the position range.
+    /// @param tickUpper Upper tick of the position range.
+    /// @param maxAmount0 Maximum net amount of token0 to spend across the swap and deposit.
+    /// @param maxAmount1 Maximum net amount of token1 to spend across the swap and deposit.
+    /// @param minSqrtRatio Lower bound of the acceptable pool price range.
+    /// @param maxSqrtRatio Upper bound of the acceptable pool price range.
+    function deposit(
+        uint256 id,
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio
+    ) external payable returns (uint128 liquidity, uint128 amount0, uint128 amount1);
+
+    /// @notice Deposits within a price range and sends unused swap output to `swapRecipient`.
+    function deposit(
+        uint256 id,
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio,
+        address swapRecipient
+    ) external payable returns (uint128 liquidity, uint128 amount0, uint128 amount1);
+
+    /// @notice Initializes a pool if it has not been initialized yet.
+    function maybeInitializePool(PoolKey memory poolKey, int32 tick)
+        external
+        payable
+        returns (bool initialized, SqrtRatio sqrtRatio);
+
+    /// @notice Mints a new NFT, swaps into the requested price range when necessary, and deposits liquidity.
+    function mintAndDeposit(
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio
+    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1);
+
+    /// @notice Mints a new NFT, deposits within a price range, and sends unused swap output to `swapRecipient`.
+    function mintAndDeposit(
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio,
+        address swapRecipient
+    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1);
+
+    /// @notice Mints a deterministic NFT, swaps into the requested price range when necessary, and deposits liquidity.
+    function mintAndDepositWithSalt(
+        bytes32 salt,
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio
+    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1);
+
+    /// @notice Mints a deterministic NFT, deposits within a range, and sends unused swap output to `swapRecipient`.
+    function mintAndDepositWithSalt(
+        bytes32 salt,
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio,
+        address swapRecipient
+    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1);
+}

--- a/src/interfaces/IPositions.sol
+++ b/src/interfaces/IPositions.sol
@@ -9,15 +9,15 @@ import {IBaseNonfungibleToken} from "./IBaseNonfungibleToken.sol";
 /// @notice Interface for managing liquidity positions as NFTs in Ekubo Protocol
 /// @dev Defines the interface for depositing, withdrawing, and collecting fees from liquidity positions
 interface IPositions is IBaseNonfungibleToken {
-    /// @notice Thrown when deposit fails due to insufficient liquidity for the given slippage tolerance
-    /// @param liquidity The actual liquidity that would be provided
-    /// @param minLiquidity The minimum liquidity required
-    error DepositFailedDueToSlippage(uint128 liquidity, uint128 minLiquidity);
+    /// @notice Thrown when the available swap input cannot move the pool to the requested deposit price
+    /// @param targetSqrtRatio The requested deposit price
+    /// @param actualSqrtRatio The price reached by the swap
+    error DepositFailedToReachTargetPrice(SqrtRatio targetSqrtRatio, SqrtRatio actualSqrtRatio);
 
-    /// @notice Thrown when price moves during the beforeUpdatePosition extension call causing the desired deposit amounts to be exceeded
+    /// @notice Thrown when an extension moves the price while liquidity is being added
     error DepositFailedDueToPriceMovement();
 
-    /// @notice Thrown when deposit amount would cause overflow
+    /// @notice Thrown when deposit liquidity cannot fit in the Core position update type
     error DepositOverflow();
 
     /// @notice Thrown when the specified withdraw liquidity amount overflows type(int128).max
@@ -38,17 +38,17 @@ interface IPositions is IBaseNonfungibleToken {
         view
         returns (uint128 liquidity, uint128 principal0, uint128 principal1, uint128 fees0, uint128 fees1);
 
-    /// @notice Deposits tokens into a liquidity position
+    /// @notice Swaps the pool to `sqrtRatio`, then deposits as much liquidity as the token limits allow
     /// @param id The NFT token ID representing the position
     /// @param poolKey Pool key identifying the pool
     /// @param tickLower Lower tick of the price range of the position
     /// @param tickUpper Upper tick of the price range of the position
-    /// @param maxAmount0 Maximum amount of token0 to deposit
-    /// @param maxAmount1 Maximum amount of token1 to deposit
-    /// @param minLiquidity Minimum liquidity to receive (for slippage protection)
+    /// @param maxAmount0 Maximum net amount of token0 to spend across the swap and deposit
+    /// @param maxAmount1 Maximum net amount of token1 to spend across the swap and deposit
+    /// @param sqrtRatio The exact pool price at which liquidity must be added
     /// @return liquidity Amount of liquidity added to the position
-    /// @return amount0 Actual amount of token0 deposited
-    /// @return amount1 Actual amount of token1 deposited
+    /// @return amount0 Amount of token0 added to the position, excluding the preceding swap
+    /// @return amount1 Amount of token1 added to the position, excluding the preceding swap
     function deposit(
         uint256 id,
         PoolKey memory poolKey,
@@ -56,7 +56,7 @@ interface IPositions is IBaseNonfungibleToken {
         int32 tickUpper,
         uint128 maxAmount0,
         uint128 maxAmount1,
-        uint128 minLiquidity
+        SqrtRatio sqrtRatio
     ) external payable returns (uint128 liquidity, uint128 amount0, uint128 amount1);
 
     /// @notice Collects accumulated fees from a position to msg.sender
@@ -117,48 +117,29 @@ interface IPositions is IBaseNonfungibleToken {
         payable
         returns (uint128 amount0, uint128 amount1);
 
-    /// @notice Initializes a pool if it hasn't been initialized yet
-    /// @param poolKey Pool key identifying the pool
-    /// @param tick Initial tick for the pool if initialization is needed
-    /// @return initialized Whether the pool was initialized by this call
-    /// @return sqrtRatio The sqrt price ratio of the pool (existing or newly set)
+    /// @notice Initializes a pool if it has not been initialized yet
     function maybeInitializePool(PoolKey memory poolKey, int32 tick)
         external
         payable
         returns (bool initialized, SqrtRatio sqrtRatio);
 
-    /// @notice Mints a new NFT and deposits liquidity into it
-    /// @param poolKey Pool key identifying the pool
-    /// @param tickLower Lower tick of the price range of the position
-    /// @param tickUpper Upper tick of the price range of the position
-    /// @param maxAmount0 Maximum amount of token0 to deposit
-    /// @param maxAmount1 Maximum amount of token1 to deposit
-    /// @param minLiquidity Minimum liquidity to receive (for slippage protection)
-    /// @return id The newly minted NFT token ID
-    /// @return liquidity Amount of liquidity added to the position
-    /// @return amount0 Actual amount of token0 deposited
-    /// @return amount1 Actual amount of token1 deposited
+    /// @notice Mints a new NFT, swaps the pool to `sqrtRatio`, and deposits liquidity
+    /// @param maxAmount0 Maximum net amount of token0 to spend across the swap and deposit
+    /// @param maxAmount1 Maximum net amount of token1 to spend across the swap and deposit
+    /// @param sqrtRatio The exact pool price at which liquidity must be added
     function mintAndDeposit(
         PoolKey memory poolKey,
         int32 tickLower,
         int32 tickUpper,
         uint128 maxAmount0,
         uint128 maxAmount1,
-        uint128 minLiquidity
+        SqrtRatio sqrtRatio
     ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1);
 
-    /// @notice Mints a new NFT with a specific salt and deposits liquidity into it
-    /// @param salt Salt for deterministic NFT ID generation
-    /// @param poolKey Pool key identifying the pool
-    /// @param tickLower Lower tick of the price range of the position
-    /// @param tickUpper Upper tick of the price range of the position
-    /// @param maxAmount0 Maximum amount of token0 to deposit
-    /// @param maxAmount1 Maximum amount of token1 to deposit
-    /// @param minLiquidity Minimum liquidity to receive (for slippage protection)
-    /// @return id The newly minted NFT token ID
-    /// @return liquidity Amount of liquidity added to the position
-    /// @return amount0 Actual amount of token0 deposited
-    /// @return amount1 Actual amount of token1 deposited
+    /// @notice Mints a deterministic NFT, swaps the pool to `sqrtRatio`, and deposits liquidity
+    /// @param maxAmount0 Maximum net amount of token0 to spend across the swap and deposit
+    /// @param maxAmount1 Maximum net amount of token1 to spend across the swap and deposit
+    /// @param sqrtRatio The exact pool price at which liquidity must be added
     function mintAndDepositWithSalt(
         bytes32 salt,
         PoolKey memory poolKey,
@@ -166,7 +147,7 @@ interface IPositions is IBaseNonfungibleToken {
         int32 tickUpper,
         uint128 maxAmount0,
         uint128 maxAmount1,
-        uint128 minLiquidity
+        SqrtRatio sqrtRatio
     ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1);
 
     /// @notice Withdraws accumulated protocol fees (only callable by owner)

--- a/src/interfaces/IPositions.sol
+++ b/src/interfaces/IPositions.sol
@@ -9,10 +9,11 @@ import {IBaseNonfungibleToken} from "./IBaseNonfungibleToken.sol";
 /// @notice Interface for managing liquidity positions as NFTs in Ekubo Protocol
 /// @dev Defines the interface for depositing, withdrawing, and collecting fees from liquidity positions
 interface IPositions is IBaseNonfungibleToken {
-    /// @notice Thrown when the available swap input cannot move the pool to the requested deposit price
-    /// @param targetSqrtRatio The requested deposit price
+    /// @notice Thrown when the available swap input cannot move the pool into the requested deposit price range
+    /// @param minSqrtRatio Lower bound of the requested price range
+    /// @param maxSqrtRatio Upper bound of the requested price range
     /// @param actualSqrtRatio The price reached by the swap
-    error DepositFailedToReachTargetPrice(SqrtRatio targetSqrtRatio, SqrtRatio actualSqrtRatio);
+    error DepositFailedToReachPriceRange(SqrtRatio minSqrtRatio, SqrtRatio maxSqrtRatio, SqrtRatio actualSqrtRatio);
 
     /// @notice Thrown when an extension moves the price while liquidity is being added
     error DepositFailedDueToPriceMovement();
@@ -38,14 +39,15 @@ interface IPositions is IBaseNonfungibleToken {
         view
         returns (uint128 liquidity, uint128 principal0, uint128 principal1, uint128 fees0, uint128 fees1);
 
-    /// @notice Swaps the pool to `sqrtRatio`, then deposits as much liquidity as the token limits allow
+    /// @notice Swaps the pool into the requested price range when necessary, then deposits liquidity
     /// @param id The NFT token ID representing the position
     /// @param poolKey Pool key identifying the pool
     /// @param tickLower Lower tick of the price range of the position
     /// @param tickUpper Upper tick of the price range of the position
     /// @param maxAmount0 Maximum net amount of token0 to spend across the swap and deposit
     /// @param maxAmount1 Maximum net amount of token1 to spend across the swap and deposit
-    /// @param sqrtRatio The exact pool price at which liquidity must be added
+    /// @param minSqrtRatio Lower bound of the acceptable pool price range
+    /// @param maxSqrtRatio Upper bound of the acceptable pool price range
     /// @return liquidity Amount of liquidity added to the position
     /// @return amount0 Amount of token0 added to the position, excluding the preceding swap
     /// @return amount1 Amount of token1 added to the position, excluding the preceding swap
@@ -56,7 +58,21 @@ interface IPositions is IBaseNonfungibleToken {
         int32 tickUpper,
         uint128 maxAmount0,
         uint128 maxAmount1,
-        SqrtRatio sqrtRatio
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio
+    ) external payable returns (uint128 liquidity, uint128 amount0, uint128 amount1);
+
+    /// @notice Deposits within a price range and sends unused swap output to `swapRecipient`
+    function deposit(
+        uint256 id,
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio,
+        address swapRecipient
     ) external payable returns (uint128 liquidity, uint128 amount0, uint128 amount1);
 
     /// @notice Collects accumulated fees from a position to msg.sender
@@ -123,23 +139,38 @@ interface IPositions is IBaseNonfungibleToken {
         payable
         returns (bool initialized, SqrtRatio sqrtRatio);
 
-    /// @notice Mints a new NFT, swaps the pool to `sqrtRatio`, and deposits liquidity
+    /// @notice Mints a new NFT, swaps the pool into the requested price range when necessary, and deposits liquidity
     /// @param maxAmount0 Maximum net amount of token0 to spend across the swap and deposit
     /// @param maxAmount1 Maximum net amount of token1 to spend across the swap and deposit
-    /// @param sqrtRatio The exact pool price at which liquidity must be added
+    /// @param minSqrtRatio Lower bound of the acceptable pool price range
+    /// @param maxSqrtRatio Upper bound of the acceptable pool price range
     function mintAndDeposit(
         PoolKey memory poolKey,
         int32 tickLower,
         int32 tickUpper,
         uint128 maxAmount0,
         uint128 maxAmount1,
-        SqrtRatio sqrtRatio
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio
     ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1);
 
-    /// @notice Mints a deterministic NFT, swaps the pool to `sqrtRatio`, and deposits liquidity
+    /// @notice Mints a new NFT, deposits within a price range, and sends unused swap output to `swapRecipient`
+    function mintAndDeposit(
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio,
+        address swapRecipient
+    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1);
+
+    /// @notice Mints a deterministic NFT, swaps into the requested price range when necessary, and deposits liquidity
     /// @param maxAmount0 Maximum net amount of token0 to spend across the swap and deposit
     /// @param maxAmount1 Maximum net amount of token1 to spend across the swap and deposit
-    /// @param sqrtRatio The exact pool price at which liquidity must be added
+    /// @param minSqrtRatio Lower bound of the acceptable pool price range
+    /// @param maxSqrtRatio Upper bound of the acceptable pool price range
     function mintAndDepositWithSalt(
         bytes32 salt,
         PoolKey memory poolKey,
@@ -147,7 +178,21 @@ interface IPositions is IBaseNonfungibleToken {
         int32 tickUpper,
         uint128 maxAmount0,
         uint128 maxAmount1,
-        SqrtRatio sqrtRatio
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio
+    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1);
+
+    /// @notice Mints a deterministic NFT, deposits within a range, and sends unused swap output to `swapRecipient`
+    function mintAndDepositWithSalt(
+        bytes32 salt,
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1,
+        SqrtRatio minSqrtRatio,
+        SqrtRatio maxSqrtRatio,
+        address swapRecipient
     ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1);
 
     /// @notice Withdraws accumulated protocol fees (only callable by owner)

--- a/src/interfaces/IPositions.sol
+++ b/src/interfaces/IPositions.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.0;
 
 import {PoolKey} from "../types/poolKey.sol";
 import {SqrtRatio} from "../types/sqrtRatio.sol";
-import {IBaseNonfungibleToken} from "./IBaseNonfungibleToken.sol";
+import {IPositionDepositor} from "./IPositionDepositor.sol";
 
 /// @title Positions Interface
 /// @notice Interface for managing liquidity positions as NFTs in Ekubo Protocol
 /// @dev Defines the interface for depositing, withdrawing, and collecting fees from liquidity positions
-interface IPositions is IBaseNonfungibleToken {
+interface IPositions is IPositionDepositor {
     /// @notice Thrown when the available swap input cannot move the pool into the requested deposit price range
     /// @param minSqrtRatio Lower bound of the requested price range
     /// @param maxSqrtRatio Upper bound of the requested price range
@@ -38,42 +38,6 @@ interface IPositions is IBaseNonfungibleToken {
         external
         view
         returns (uint128 liquidity, uint128 principal0, uint128 principal1, uint128 fees0, uint128 fees1);
-
-    /// @notice Swaps the pool into the requested price range when necessary, then deposits liquidity
-    /// @param id The NFT token ID representing the position
-    /// @param poolKey Pool key identifying the pool
-    /// @param tickLower Lower tick of the price range of the position
-    /// @param tickUpper Upper tick of the price range of the position
-    /// @param maxAmount0 Maximum net amount of token0 to spend across the swap and deposit
-    /// @param maxAmount1 Maximum net amount of token1 to spend across the swap and deposit
-    /// @param minSqrtRatio Lower bound of the acceptable pool price range
-    /// @param maxSqrtRatio Upper bound of the acceptable pool price range
-    /// @return liquidity Amount of liquidity added to the position
-    /// @return amount0 Amount of token0 added to the position, excluding the preceding swap
-    /// @return amount1 Amount of token1 added to the position, excluding the preceding swap
-    function deposit(
-        uint256 id,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        SqrtRatio minSqrtRatio,
-        SqrtRatio maxSqrtRatio
-    ) external payable returns (uint128 liquidity, uint128 amount0, uint128 amount1);
-
-    /// @notice Deposits within a price range and sends unused swap output to `swapRecipient`
-    function deposit(
-        uint256 id,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        SqrtRatio minSqrtRatio,
-        SqrtRatio maxSqrtRatio,
-        address swapRecipient
-    ) external payable returns (uint128 liquidity, uint128 amount0, uint128 amount1);
 
     /// @notice Collects accumulated fees from a position to msg.sender
     /// @param id The NFT token ID representing the position
@@ -132,68 +96,6 @@ interface IPositions is IBaseNonfungibleToken {
         external
         payable
         returns (uint128 amount0, uint128 amount1);
-
-    /// @notice Initializes a pool if it has not been initialized yet
-    function maybeInitializePool(PoolKey memory poolKey, int32 tick)
-        external
-        payable
-        returns (bool initialized, SqrtRatio sqrtRatio);
-
-    /// @notice Mints a new NFT, swaps the pool into the requested price range when necessary, and deposits liquidity
-    /// @param maxAmount0 Maximum net amount of token0 to spend across the swap and deposit
-    /// @param maxAmount1 Maximum net amount of token1 to spend across the swap and deposit
-    /// @param minSqrtRatio Lower bound of the acceptable pool price range
-    /// @param maxSqrtRatio Upper bound of the acceptable pool price range
-    function mintAndDeposit(
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        SqrtRatio minSqrtRatio,
-        SqrtRatio maxSqrtRatio
-    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1);
-
-    /// @notice Mints a new NFT, deposits within a price range, and sends unused swap output to `swapRecipient`
-    function mintAndDeposit(
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        SqrtRatio minSqrtRatio,
-        SqrtRatio maxSqrtRatio,
-        address swapRecipient
-    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1);
-
-    /// @notice Mints a deterministic NFT, swaps into the requested price range when necessary, and deposits liquidity
-    /// @param maxAmount0 Maximum net amount of token0 to spend across the swap and deposit
-    /// @param maxAmount1 Maximum net amount of token1 to spend across the swap and deposit
-    /// @param minSqrtRatio Lower bound of the acceptable pool price range
-    /// @param maxSqrtRatio Upper bound of the acceptable pool price range
-    function mintAndDepositWithSalt(
-        bytes32 salt,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        SqrtRatio minSqrtRatio,
-        SqrtRatio maxSqrtRatio
-    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1);
-
-    /// @notice Mints a deterministic NFT, deposits within a range, and sends unused swap output to `swapRecipient`
-    function mintAndDepositWithSalt(
-        bytes32 salt,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        SqrtRatio minSqrtRatio,
-        SqrtRatio maxSqrtRatio,
-        address swapRecipient
-    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1);
 
     /// @notice Withdraws accumulated protocol fees (only callable by owner)
     /// @param token0 Address of token0

--- a/test/FullTest.sol
+++ b/test/FullTest.sol
@@ -253,8 +253,9 @@ abstract contract FullTest is Test {
         }
         TestToken(poolKey.token1).approve(address(positions), amount1);
 
+        SqrtRatio sqrtRatio = poolSqrtRatio(poolKey);
         (id, liquidity,,) = positions.mintAndDeposit{value: value}(
-            poolKey, tickLower, tickUpper, amount0, amount1, poolSqrtRatio(poolKey)
+            poolKey, tickLower, tickUpper, amount0, amount1, sqrtRatio, sqrtRatio
         );
     }
 

--- a/test/FullTest.sol
+++ b/test/FullTest.sol
@@ -18,6 +18,7 @@ import {SwapParameters} from "../src/types/swapParameters.sol";
 import {BaseLocker} from "../src/base/BaseLocker.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 import {FlashAccountantLib} from "../src/libraries/FlashAccountantLib.sol";
+import {CoreLib} from "../src/libraries/CoreLib.sol";
 import {Locker} from "../src/types/locker.sol";
 import {PoolBalanceUpdate} from "../src/types/poolBalanceUpdate.sol";
 
@@ -252,7 +253,13 @@ abstract contract FullTest is Test {
         }
         TestToken(poolKey.token1).approve(address(positions), amount1);
 
-        (id, liquidity,,) = positions.mintAndDeposit{value: value}(poolKey, tickLower, tickUpper, amount0, amount1, 0);
+        (id, liquidity,,) = positions.mintAndDeposit{value: value}(
+            poolKey, tickLower, tickUpper, amount0, amount1, poolSqrtRatio(poolKey)
+        );
+    }
+
+    function poolSqrtRatio(PoolKey memory poolKey) internal view returns (SqrtRatio) {
+        return CoreLib.poolState(core, poolKey.toPoolId()).sqrtRatio();
     }
 
     function advanceTime(uint256 by) internal returns (uint256 next) {

--- a/test/Orders.t.sol
+++ b/test/Orders.t.sol
@@ -494,6 +494,7 @@ contract OrdersTest is BaseOrdersTest {
             MAX_TICK,
             9065869775701580912051,
             16591196256327018126941976177968210,
+            poolSqrtRatio(poolKey),
             poolSqrtRatio(poolKey)
         );
 
@@ -501,7 +502,14 @@ contract OrdersTest is BaseOrdersTest {
 
         twamm.lockAndExecuteVirtualOrders(poolKey);
         (uint128 liquidity1,,) = positions.deposit(
-            pID, poolKey, MIN_TICK, MAX_TICK, 229636410600502050710229286961, 502804080817310396, poolSqrtRatio(poolKey)
+            pID,
+            poolKey,
+            MIN_TICK,
+            MAX_TICK,
+            229636410600502050710229286961,
+            502804080817310396,
+            poolSqrtRatio(poolKey),
+            poolSqrtRatio(poolKey)
         );
         (sqrtRatio, tick, liquidity) = core.poolState(poolId).parse();
 
@@ -548,6 +556,7 @@ contract OrdersTest is BaseOrdersTest {
             MAX_TICK,
             1412971749302168760052394,
             35831434466998775335139276644539,
+            poolSqrtRatio(poolKey),
             poolSqrtRatio(poolKey)
         );
 

--- a/test/Orders.t.sol
+++ b/test/Orders.t.sol
@@ -488,14 +488,21 @@ contract OrdersTest is BaseOrdersTest {
 
         twamm.lockAndExecuteVirtualOrders(poolKey);
         (uint128 liquidity0,,) = positions.deposit(
-            pID, poolKey, MIN_TICK, MAX_TICK, 9065869775701580912051, 16591196256327018126941976177968210, 0
+            pID,
+            poolKey,
+            MIN_TICK,
+            MAX_TICK,
+            9065869775701580912051,
+            16591196256327018126941976177968210,
+            poolSqrtRatio(poolKey)
         );
 
         advanceTime(102_399);
 
         twamm.lockAndExecuteVirtualOrders(poolKey);
-        (uint128 liquidity1,,) =
-            positions.deposit(pID, poolKey, MIN_TICK, MAX_TICK, 229636410600502050710229286961, 502804080817310396, 0);
+        (uint128 liquidity1,,) = positions.deposit(
+            pID, poolKey, MIN_TICK, MAX_TICK, 229636410600502050710229286961, 502804080817310396, poolSqrtRatio(poolKey)
+        );
         (sqrtRatio, tick, liquidity) = core.poolState(poolId).parse();
 
         assertEq(sqrtRatio.toFixed(), 13485562298671080879303606629460147559991345152);
@@ -535,7 +542,13 @@ contract OrdersTest is BaseOrdersTest {
 
         twamm.lockAndExecuteVirtualOrders(poolKey);
         (uint128 liquidity2,,) = positions.deposit(
-            pID, poolKey, MIN_TICK, MAX_TICK, 1412971749302168760052394, 35831434466998775335139276644539, 0
+            pID,
+            poolKey,
+            MIN_TICK,
+            MAX_TICK,
+            1412971749302168760052394,
+            35831434466998775335139276644539,
+            poolSqrtRatio(poolKey)
         );
 
         liquidity = core.poolState(poolId).liquidity();

--- a/test/Positions.t.sol
+++ b/test/Positions.t.sol
@@ -52,7 +52,7 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), 100);
 
         (uint256 id, uint128 liquidity,,) =
-            positions.mintAndDeposit(poolKey, -100, 100, 100, 100, poolSqrtRatio(poolKey));
+            positions.mintAndDeposit(poolKey, -100, 100, 100, 100, poolSqrtRatio(poolKey), poolSqrtRatio(poolKey));
         assertGt(id, 0);
         assertGt(liquidity, 0);
         PositionId positionId = createPositionId(bytes24(uint192(id)), -100, 100);
@@ -75,20 +75,21 @@ contract PositionsTest is FullTest {
         assertEq(amount1, 49);
     }
 
-    function test_deposit_swapsToTargetPriceBeforeAddingLiquidity() public {
+    function test_deposit_swapsToMinimumPriceBeforeAddingLiquidity() public {
         PoolKey memory poolKey = createPool(0, 0, 100, address(0));
         createPosition(poolKey, -1000, 1000, 1e18, 1e18);
 
         token0.approve(address(positions), 1e18);
         token1.approve(address(positions), 1e18);
-        SqrtRatio targetSqrtRatio = tickToSqrtRatio(100);
+        SqrtRatio minSqrtRatio = tickToSqrtRatio(100);
+        SqrtRatio maxSqrtRatio = tickToSqrtRatio(200);
 
         uint256 balance0Before = token0.balanceOf(address(this));
         uint256 balance1Before = token1.balanceOf(address(this));
         (, uint128 liquidity, uint128 amount0, uint128 amount1) =
-            positions.mintAndDeposit(poolKey, -1000, 1000, 1e18, 1e18, targetSqrtRatio);
+            positions.mintAndDeposit(poolKey, -1000, 1000, 1e18, 1e18, minSqrtRatio, maxSqrtRatio);
 
-        assertEq(poolSqrtRatio(poolKey).toFixed(), targetSqrtRatio.toFixed());
+        assertEq(poolSqrtRatio(poolKey).toFixed(), minSqrtRatio.toFixed());
         assertGt(liquidity, 0);
         assertGt(amount0, 0);
         assertGt(amount1, 0);
@@ -96,39 +97,79 @@ contract PositionsTest is FullTest {
         assertLe(balance1Before - token1.balanceOf(address(this)), 1e18);
     }
 
-    function test_deposit_returnsUnusedSwapOutputToCaller() public {
+    function test_deposit_sendsUnusedSwapOutputToRecipient() public {
         PoolKey memory poolKey = createPool(0, 0, 100, address(0));
         createPosition(poolKey, -1000, 1000, 1e18, 1e18);
 
         token0.approve(address(positions), 1e18);
-        SqrtRatio targetSqrtRatio = tickToSqrtRatio(-100);
+        SqrtRatio minSqrtRatio = tickToSqrtRatio(-200);
+        SqrtRatio maxSqrtRatio = tickToSqrtRatio(-100);
         uint256 balance0Before = token0.balanceOf(address(this));
         uint256 balance1Before = token1.balanceOf(address(this));
+        address swapRecipient = makeAddr("swapRecipient");
 
-        (, uint128 liquidity,, uint128 amount1) = positions.mintAndDeposit(poolKey, 0, 100, 1e18, 0, targetSqrtRatio);
+        (, uint128 liquidity,, uint128 amount1) =
+            positions.mintAndDeposit(poolKey, 0, 100, 1e18, 0, minSqrtRatio, maxSqrtRatio, swapRecipient);
 
-        assertEq(poolSqrtRatio(poolKey).toFixed(), targetSqrtRatio.toFixed());
+        assertEq(poolSqrtRatio(poolKey).toFixed(), maxSqrtRatio.toFixed());
         assertGt(liquidity, 0);
         assertEq(amount1, 0);
         assertLe(balance0Before - token0.balanceOf(address(this)), 1e18);
+        assertEq(token1.balanceOf(address(this)), balance1Before);
+        assertGt(token1.balanceOf(swapRecipient), 0);
+    }
+
+    function test_deposit_defaultsSwapRecipientToCaller() public {
+        PoolKey memory poolKey = createPool(0, 0, 100, address(0));
+        createPosition(poolKey, -1000, 1000, 1e18, 1e18);
+
+        token0.approve(address(positions), 1e18);
+        uint256 balance1Before = token1.balanceOf(address(this));
+        positions.mintAndDeposit(poolKey, 0, 100, 1e18, 0, tickToSqrtRatio(-200), tickToSqrtRatio(-100));
+
         assertGt(token1.balanceOf(address(this)), balance1Before);
     }
 
-    function test_deposit_revertsWhenMaxAmountCannotReachTargetPrice() public {
+    function test_deposit_doesNotSwapWhenPriceIsWithinRange() public {
+        PoolKey memory poolKey = createPool(0, 0, 100, address(0));
+        SqrtRatio sqrtRatioBefore = poolSqrtRatio(poolKey);
+
+        token0.approve(address(positions), 1e18);
+        token1.approve(address(positions), 1e18);
+        (, uint128 liquidity,,) =
+            positions.mintAndDeposit(poolKey, -1000, 1000, 1e18, 1e18, tickToSqrtRatio(-100), tickToSqrtRatio(100));
+
+        assertEq(poolSqrtRatio(poolKey).toFixed(), sqrtRatioBefore.toFixed());
+        assertGt(liquidity, 0);
+    }
+
+    function test_deposit_allowsZeroLiquidityNoop() public {
+        PoolKey memory poolKey = createPool(0, 0, 100, address(0));
+        uint256 id = positions.mint();
+
+        (uint128 liquidity, uint128 amount0, uint128 amount1) =
+            positions.deposit(id, poolKey, -1000, 1000, 0, 0, tickToSqrtRatio(-100), tickToSqrtRatio(100));
+
+        assertEq(liquidity, 0);
+        assertEq(amount0, 0);
+        assertEq(amount1, 0);
+    }
+
+    function test_deposit_revertsWhenMaxAmountCannotReachPriceRange() public {
         PoolKey memory poolKey = createPool(0, 0, 100, address(0));
         createPosition(poolKey, -1000, 1000, 1e18, 1e18);
 
         uint256 id = positions.mint();
         token1.approve(address(positions), 1);
-        SqrtRatio targetSqrtRatio = tickToSqrtRatio(100);
+        SqrtRatio minSqrtRatio = tickToSqrtRatio(100);
         SqrtRatio currentSqrtRatio = poolSqrtRatio(poolKey);
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                IPositions.DepositFailedToReachTargetPrice.selector, targetSqrtRatio, currentSqrtRatio
+                IPositions.DepositFailedToReachPriceRange.selector, minSqrtRatio, minSqrtRatio, currentSqrtRatio
             )
         );
-        positions.deposit(id, poolKey, -1000, 1000, 0, 1, targetSqrtRatio);
+        positions.deposit(id, poolKey, -1000, 1000, 0, 1, minSqrtRatio, minSqrtRatio);
     }
 
     function test_mintAndDeposit_shared_tick_boundary(CallPoints memory callPoints) public {
@@ -137,8 +178,9 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        (, uint128 liquidityA,,) = positions.mintAndDeposit(poolKey, -100, 100, 100, 100, poolSqrtRatio(poolKey));
-        (, uint128 liquidityB,,) = positions.mintAndDeposit(poolKey, -300, -100, 100, 100, poolSqrtRatio(poolKey));
+        SqrtRatio sqrtRatio = poolSqrtRatio(poolKey);
+        (, uint128 liquidityA,,) = positions.mintAndDeposit(poolKey, -100, 100, 100, 100, sqrtRatio, sqrtRatio);
+        (, uint128 liquidityB,,) = positions.mintAndDeposit(poolKey, -300, -100, 100, 100, sqrtRatio, sqrtRatio);
 
         (int128 liquidityDelta, uint128 liquidityNet) = core.poolTicks(poolKey.toPoolId(), -300);
         assertEq(liquidityDelta, int128(liquidityB));
@@ -360,8 +402,9 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), type(uint256).max);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) =
-            positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, poolSqrtRatio(poolKey));
+        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(
+            poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, poolSqrtRatio(poolKey), poolSqrtRatio(poolKey)
+        );
         vm.snapshotGasLastCall("mintAndDeposit full range max");
         assertGt(liquidity, 0);
 
@@ -390,8 +433,9 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), type(uint256).max);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) =
-            positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, poolSqrtRatio(poolKey));
+        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(
+            poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, poolSqrtRatio(poolKey), poolSqrtRatio(poolKey)
+        );
         vm.snapshotGasLastCall("mintAndDeposit full range min");
         assertGt(liquidity, 0);
 
@@ -420,7 +464,9 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        (uint256 id,,,) = positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, poolSqrtRatio(poolKey));
+        (uint256 id,,,) = positions.mintAndDeposit(
+            poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, poolSqrtRatio(poolKey), poolSqrtRatio(poolKey)
+        );
         (,,, uint128 f0, uint128 f1) = positions.getPositionFeesAndLiquidity(id, poolKey, MIN_TICK, MAX_TICK);
         assertEq(f0, 0);
         assertEq(f1, 0);
@@ -446,7 +492,9 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        (uint256 id,,,) = positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, poolSqrtRatio(poolKey));
+        (uint256 id,,,) = positions.mintAndDeposit(
+            poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, poolSqrtRatio(poolKey), poolSqrtRatio(poolKey)
+        );
         (,,, uint128 f0, uint128 f1) = positions.getPositionFeesAndLiquidity(id, poolKey, MIN_TICK, MAX_TICK);
         assertEq(f0, 0);
         assertEq(f1, 0);
@@ -514,7 +562,7 @@ contract PositionsTest is FullTest {
 
         coolAllContracts();
         (uint256 id, uint128 liquidity,,) =
-            positions.mintAndDeposit(poolKey, -100, 100, 100, 100, poolSqrtRatio(poolKey));
+            positions.mintAndDeposit(poolKey, -100, 100, 100, 100, poolSqrtRatio(poolKey), poolSqrtRatio(poolKey));
         vm.snapshotGasLastCall("mintAndDeposit");
 
         coolAllContracts();
@@ -528,8 +576,9 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), 100);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) =
-            positions.mintAndDeposit{value: 100}(poolKey, -100, 100, 100, 100, poolSqrtRatio(poolKey));
+        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit{value: 100}(
+            poolKey, -100, 100, 100, 100, poolSqrtRatio(poolKey), poolSqrtRatio(poolKey)
+        );
         vm.snapshotGasLastCall("mintAndDeposit eth");
 
         coolAllContracts();
@@ -544,8 +593,9 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), 100);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) =
-            positions.mintAndDeposit{value: 100}(poolKey, -100, 100, 100, 100, poolSqrtRatio(poolKey));
+        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit{value: 100}(
+            poolKey, -100, 100, 100, 100, poolSqrtRatio(poolKey), poolSqrtRatio(poolKey)
+        );
         vm.snapshotGasLastCall("mintAndDeposit eth (free)");
 
         coolAllContracts();
@@ -567,8 +617,9 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), type(uint256).max);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) =
-            positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey));
+        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(
+            poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey), poolSqrtRatio(poolKey)
+        );
         vm.snapshotGasLastCall("mintAndDeposit full range both tokens");
 
         coolAllContracts();
@@ -598,7 +649,7 @@ contract PositionsTest is FullTest {
 
         // Test 1: Mint and deposit should work regardless of protocol fee parameters
         (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) =
-            testPositions.mintAndDeposit(poolKey, -100, 100, 1000, 1000, poolSqrtRatio(poolKey));
+            testPositions.mintAndDeposit(poolKey, -100, 100, 1000, 1000, poolSqrtRatio(poolKey), poolSqrtRatio(poolKey));
 
         assertGt(id, 0, "Position ID should be greater than 0");
         assertGt(liquidity, 0, "Liquidity should be greater than 0");
@@ -673,7 +724,7 @@ contract PositionsTest is FullTest {
 
         // Test 1: Mint and deposit should work regardless of protocol fee parameters
         (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) =
-            testPositions.mintAndDeposit(poolKey, -100, 100, 1000, 1000, poolSqrtRatio(poolKey));
+            testPositions.mintAndDeposit(poolKey, -100, 100, 1000, 1000, poolSqrtRatio(poolKey), poolSqrtRatio(poolKey));
 
         assertGt(id, 0, "Position ID should be greater than 0");
         assertGt(liquidity, 0, "Liquidity should be greater than 0");

--- a/test/Positions.t.sol
+++ b/test/Positions.t.sol
@@ -12,6 +12,7 @@ import {MIN_TICK, MAX_TICK} from "../src/math/constants.sol";
 import {MIN_SQRT_RATIO, MAX_SQRT_RATIO} from "../src/types/sqrtRatio.sol";
 import {Positions} from "../src/Positions.sol";
 import {FreePositions} from "../src/FreePositions.sol";
+import {IPositions} from "../src/interfaces/IPositions.sol";
 import {tickToSqrtRatio} from "../src/math/ticks.sol";
 import {computeFee} from "../src/math/fee.sol";
 import {CoreLib} from "../src/libraries/CoreLib.sol";
@@ -50,7 +51,8 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), 100);
         token1.approve(address(positions), 100);
 
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(poolKey, -100, 100, 100, 100, 0);
+        (uint256 id, uint128 liquidity,,) =
+            positions.mintAndDeposit(poolKey, -100, 100, 100, 100, poolSqrtRatio(poolKey));
         assertGt(id, 0);
         assertGt(liquidity, 0);
         PositionId positionId = createPositionId(bytes24(uint192(id)), -100, 100);
@@ -73,14 +75,70 @@ contract PositionsTest is FullTest {
         assertEq(amount1, 49);
     }
 
+    function test_deposit_swapsToTargetPriceBeforeAddingLiquidity() public {
+        PoolKey memory poolKey = createPool(0, 0, 100, address(0));
+        createPosition(poolKey, -1000, 1000, 1e18, 1e18);
+
+        token0.approve(address(positions), 1e18);
+        token1.approve(address(positions), 1e18);
+        SqrtRatio targetSqrtRatio = tickToSqrtRatio(100);
+
+        uint256 balance0Before = token0.balanceOf(address(this));
+        uint256 balance1Before = token1.balanceOf(address(this));
+        (, uint128 liquidity, uint128 amount0, uint128 amount1) =
+            positions.mintAndDeposit(poolKey, -1000, 1000, 1e18, 1e18, targetSqrtRatio);
+
+        assertEq(poolSqrtRatio(poolKey).toFixed(), targetSqrtRatio.toFixed());
+        assertGt(liquidity, 0);
+        assertGt(amount0, 0);
+        assertGt(amount1, 0);
+        assertLe(balance0Before - token0.balanceOf(address(this)), 1e18);
+        assertLe(balance1Before - token1.balanceOf(address(this)), 1e18);
+    }
+
+    function test_deposit_returnsUnusedSwapOutputToCaller() public {
+        PoolKey memory poolKey = createPool(0, 0, 100, address(0));
+        createPosition(poolKey, -1000, 1000, 1e18, 1e18);
+
+        token0.approve(address(positions), 1e18);
+        SqrtRatio targetSqrtRatio = tickToSqrtRatio(-100);
+        uint256 balance0Before = token0.balanceOf(address(this));
+        uint256 balance1Before = token1.balanceOf(address(this));
+
+        (, uint128 liquidity,, uint128 amount1) = positions.mintAndDeposit(poolKey, 0, 100, 1e18, 0, targetSqrtRatio);
+
+        assertEq(poolSqrtRatio(poolKey).toFixed(), targetSqrtRatio.toFixed());
+        assertGt(liquidity, 0);
+        assertEq(amount1, 0);
+        assertLe(balance0Before - token0.balanceOf(address(this)), 1e18);
+        assertGt(token1.balanceOf(address(this)), balance1Before);
+    }
+
+    function test_deposit_revertsWhenMaxAmountCannotReachTargetPrice() public {
+        PoolKey memory poolKey = createPool(0, 0, 100, address(0));
+        createPosition(poolKey, -1000, 1000, 1e18, 1e18);
+
+        uint256 id = positions.mint();
+        token1.approve(address(positions), 1);
+        SqrtRatio targetSqrtRatio = tickToSqrtRatio(100);
+        SqrtRatio currentSqrtRatio = poolSqrtRatio(poolKey);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPositions.DepositFailedToReachTargetPrice.selector, targetSqrtRatio, currentSqrtRatio
+            )
+        );
+        positions.deposit(id, poolKey, -1000, 1000, 0, 1, targetSqrtRatio);
+    }
+
     function test_mintAndDeposit_shared_tick_boundary(CallPoints memory callPoints) public {
         PoolKey memory poolKey = createPool(0, 1 << 63, 100, callPoints);
 
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        (, uint128 liquidityA,,) = positions.mintAndDeposit(poolKey, -100, 100, 100, 100, 0);
-        (, uint128 liquidityB,,) = positions.mintAndDeposit(poolKey, -300, -100, 100, 100, 0);
+        (, uint128 liquidityA,,) = positions.mintAndDeposit(poolKey, -100, 100, 100, 100, poolSqrtRatio(poolKey));
+        (, uint128 liquidityB,,) = positions.mintAndDeposit(poolKey, -300, -100, 100, 100, poolSqrtRatio(poolKey));
 
         (int128 liquidityDelta, uint128 liquidityNet) = core.poolTicks(poolKey.toPoolId(), -300);
         assertEq(liquidityDelta, int128(liquidityB));
@@ -302,7 +360,8 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), type(uint256).max);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, 0);
+        (uint256 id, uint128 liquidity,,) =
+            positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, poolSqrtRatio(poolKey));
         vm.snapshotGasLastCall("mintAndDeposit full range max");
         assertGt(liquidity, 0);
 
@@ -331,7 +390,8 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), type(uint256).max);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, 0);
+        (uint256 id, uint128 liquidity,,) =
+            positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, poolSqrtRatio(poolKey));
         vm.snapshotGasLastCall("mintAndDeposit full range min");
         assertGt(liquidity, 0);
 
@@ -360,7 +420,7 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        (uint256 id,,,) = positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, 0);
+        (uint256 id,,,) = positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, poolSqrtRatio(poolKey));
         (,,, uint128 f0, uint128 f1) = positions.getPositionFeesAndLiquidity(id, poolKey, MIN_TICK, MAX_TICK);
         assertEq(f0, 0);
         assertEq(f1, 0);
@@ -386,7 +446,7 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        (uint256 id,,,) = positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, 0);
+        (uint256 id,,,) = positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, poolSqrtRatio(poolKey));
         (,,, uint128 f0, uint128 f1) = positions.getPositionFeesAndLiquidity(id, poolKey, MIN_TICK, MAX_TICK);
         assertEq(f0, 0);
         assertEq(f1, 0);
@@ -453,7 +513,8 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), 100);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(poolKey, -100, 100, 100, 100, 0);
+        (uint256 id, uint128 liquidity,,) =
+            positions.mintAndDeposit(poolKey, -100, 100, 100, 100, poolSqrtRatio(poolKey));
         vm.snapshotGasLastCall("mintAndDeposit");
 
         coolAllContracts();
@@ -467,7 +528,8 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), 100);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit{value: 100}(poolKey, -100, 100, 100, 100, 0);
+        (uint256 id, uint128 liquidity,,) =
+            positions.mintAndDeposit{value: 100}(poolKey, -100, 100, 100, 100, poolSqrtRatio(poolKey));
         vm.snapshotGasLastCall("mintAndDeposit eth");
 
         coolAllContracts();
@@ -482,7 +544,8 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), 100);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit{value: 100}(poolKey, -100, 100, 100, 100, 0);
+        (uint256 id, uint128 liquidity,,) =
+            positions.mintAndDeposit{value: 100}(poolKey, -100, 100, 100, 100, poolSqrtRatio(poolKey));
         vm.snapshotGasLastCall("mintAndDeposit eth (free)");
 
         coolAllContracts();
@@ -504,7 +567,8 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), type(uint256).max);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
+        (uint256 id, uint128 liquidity,,) =
+            positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey));
         vm.snapshotGasLastCall("mintAndDeposit full range both tokens");
 
         coolAllContracts();
@@ -534,7 +598,7 @@ contract PositionsTest is FullTest {
 
         // Test 1: Mint and deposit should work regardless of protocol fee parameters
         (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) =
-            testPositions.mintAndDeposit(poolKey, -100, 100, 1000, 1000, 0);
+            testPositions.mintAndDeposit(poolKey, -100, 100, 1000, 1000, poolSqrtRatio(poolKey));
 
         assertGt(id, 0, "Position ID should be greater than 0");
         assertGt(liquidity, 0, "Liquidity should be greater than 0");
@@ -609,7 +673,7 @@ contract PositionsTest is FullTest {
 
         // Test 1: Mint and deposit should work regardless of protocol fee parameters
         (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) =
-            testPositions.mintAndDeposit(poolKey, -100, 100, 1000, 1000, 0);
+            testPositions.mintAndDeposit(poolKey, -100, 100, 1000, 1000, poolSqrtRatio(poolKey));
 
         assertGt(id, 0, "Position ID should be greater than 0");
         assertGt(liquidity, 0, "Liquidity should be greater than 0");

--- a/test/PositionsRevenueBuybacks.t.sol
+++ b/test/PositionsRevenueBuybacks.t.sol
@@ -10,6 +10,7 @@ import {MIN_TICK, MAX_TICK} from "../src/math/constants.sol";
 import {Ownable} from "solady/auth/Ownable.sol";
 import {TestToken} from "./TestToken.sol";
 import {StorageSlot} from "../src/types/storageSlot.sol";
+import {SqrtRatio} from "../src/types/sqrtRatio.sol";
 
 contract PositionsRevenueBuybacksTest is BaseOrdersTest {
     PositionsRevenueBuybacks buybacks;
@@ -122,7 +123,8 @@ contract PositionsRevenueBuybacksTest is BaseOrdersTest {
         positions.maybeInitializePool(poolKey, 0);
         token0.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey));
+        SqrtRatio sqrtRatio = poolSqrtRatio(poolKey);
+        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, sqrtRatio, sqrtRatio);
 
         cheatDonateProtocolFees(address(token0), address(token1), 1e18, 1e17);
 
@@ -147,7 +149,8 @@ contract PositionsRevenueBuybacksTest is BaseOrdersTest {
         positions.maybeInitializePool(poolKey, 0);
         token1.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey));
+        SqrtRatio sqrtRatio = poolSqrtRatio(poolKey);
+        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, sqrtRatio, sqrtRatio);
 
         cheatDonateProtocolFees(address(token0), address(token1), 1e18, 1e17);
 
@@ -181,8 +184,10 @@ contract PositionsRevenueBuybacksTest is BaseOrdersTest {
         token1.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 2e18);
 
-        positions.mintAndDeposit(poolKey0, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey0));
-        positions.mintAndDeposit(poolKey1, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey1));
+        SqrtRatio sqrtRatio0 = poolSqrtRatio(poolKey0);
+        SqrtRatio sqrtRatio1 = poolSqrtRatio(poolKey1);
+        positions.mintAndDeposit(poolKey0, MIN_TICK, MAX_TICK, 1e18, 1e18, sqrtRatio0, sqrtRatio0);
+        positions.mintAndDeposit(poolKey1, MIN_TICK, MAX_TICK, 1e18, 1e18, sqrtRatio1, sqrtRatio1);
 
         (uint128 fees0, uint128 fees1) = positions.getProtocolFees(address(token0), address(token1));
         assertEq(fees0, 0);

--- a/test/PositionsRevenueBuybacks.t.sol
+++ b/test/PositionsRevenueBuybacks.t.sol
@@ -122,7 +122,7 @@ contract PositionsRevenueBuybacksTest is BaseOrdersTest {
         positions.maybeInitializePool(poolKey, 0);
         token0.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
+        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey));
 
         cheatDonateProtocolFees(address(token0), address(token1), 1e18, 1e17);
 
@@ -147,7 +147,7 @@ contract PositionsRevenueBuybacksTest is BaseOrdersTest {
         positions.maybeInitializePool(poolKey, 0);
         token1.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
+        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey));
 
         cheatDonateProtocolFees(address(token0), address(token1), 1e18, 1e17);
 
@@ -181,8 +181,8 @@ contract PositionsRevenueBuybacksTest is BaseOrdersTest {
         token1.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 2e18);
 
-        positions.mintAndDeposit(poolKey0, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
-        positions.mintAndDeposit(poolKey1, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
+        positions.mintAndDeposit(poolKey0, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey0));
+        positions.mintAndDeposit(poolKey1, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey1));
 
         (uint128 fees0, uint128 fees1) = positions.getProtocolFees(address(token0), address(token1));
         assertEq(fees0, 0);

--- a/test/SolvencyInvariantTest.t.sol
+++ b/test/SolvencyInvariantTest.t.sol
@@ -142,7 +142,9 @@ contract Handler is StdUtils, StdAssertions {
                 * int32(poolKey.config.concentratedTickSpacing());
         }
 
-        try positions.deposit(positionId, poolKey, tickLower, tickUpper, amount0, amount1, 0) returns (
+        try positions.deposit(
+            positionId, poolKey, tickLower, tickUpper, amount0, amount1, core.poolState(poolKey.toPoolId()).sqrtRatio()
+        ) returns (
             uint128 liquidity, uint128 result0, uint128 result1
         ) {
             if (liquidity > 0) {

--- a/test/SolvencyInvariantTest.t.sol
+++ b/test/SolvencyInvariantTest.t.sol
@@ -143,7 +143,14 @@ contract Handler is StdUtils, StdAssertions {
         }
 
         try positions.deposit(
-            positionId, poolKey, tickLower, tickUpper, amount0, amount1, core.poolState(poolKey.toPoolId()).sqrtRatio()
+            positionId,
+            poolKey,
+            tickLower,
+            tickUpper,
+            amount0,
+            amount1,
+            core.poolState(poolKey.toPoolId()).sqrtRatio(),
+            core.poolState(poolKey.toPoolId()).sqrtRatio()
         ) returns (
             uint128 liquidity, uint128 result0, uint128 result1
         ) {

--- a/test/SwapTest.t.sol
+++ b/test/SwapTest.t.sol
@@ -76,7 +76,7 @@ contract SwapTest is FullTest {
             tickUpper: MAX_TICK,
             maxAmount0: uint128(amount0),
             maxAmount1: uint128(amount1),
-            minLiquidity: liquidity
+            sqrtRatio: core.poolState(poolKey.toPoolId()).sqrtRatio()
         });
 
         assertEq(positionLiquidity, liquidity, "liquidity expected");

--- a/test/SwapTest.t.sol
+++ b/test/SwapTest.t.sol
@@ -76,7 +76,8 @@ contract SwapTest is FullTest {
             tickUpper: MAX_TICK,
             maxAmount0: uint128(amount0),
             maxAmount1: uint128(amount1),
-            sqrtRatio: core.poolState(poolKey.toPoolId()).sqrtRatio()
+            minSqrtRatio: core.poolState(poolKey.toPoolId()).sqrtRatio(),
+            maxSqrtRatio: core.poolState(poolKey.toPoolId()).sqrtRatio()
         });
 
         assertEq(positionLiquidity, liquidity, "liquidity expected");

--- a/test/TWAMMInvariantTest.t.sol
+++ b/test/TWAMMInvariantTest.t.sol
@@ -131,7 +131,14 @@ contract Handler is StdUtils, StdAssertions {
         PoolKey memory poolKey = allPoolKeys[bound(poolKeyIndex, 0, allPoolKeys.length - 1)];
 
         try positions.deposit(
-            positionId, poolKey, MIN_TICK, MAX_TICK, amount0, amount1, core.poolState(poolKey.toPoolId()).sqrtRatio()
+            positionId,
+            poolKey,
+            MIN_TICK,
+            MAX_TICK,
+            amount0,
+            amount1,
+            core.poolState(poolKey.toPoolId()).sqrtRatio(),
+            core.poolState(poolKey.toPoolId()).sqrtRatio()
         ) returns (
             uint128 liquidity, uint128, uint128
         ) {

--- a/test/TWAMMInvariantTest.t.sol
+++ b/test/TWAMMInvariantTest.t.sol
@@ -130,7 +130,9 @@ contract Handler is StdUtils, StdAssertions {
     function deposit(uint256 poolKeyIndex, uint128 amount0, uint128 amount1) public ifPoolExists {
         PoolKey memory poolKey = allPoolKeys[bound(poolKeyIndex, 0, allPoolKeys.length - 1)];
 
-        try positions.deposit(positionId, poolKey, MIN_TICK, MAX_TICK, amount0, amount1, 0) returns (
+        try positions.deposit(
+            positionId, poolKey, MIN_TICK, MAX_TICK, amount0, amount1, core.poolState(poolKey.toPoolId()).sqrtRatio()
+        ) returns (
             uint128 liquidity, uint128, uint128
         ) {
             if (liquidity > 0) {

--- a/test/base/RevenueBuybacks.t.sol
+++ b/test/base/RevenueBuybacks.t.sol
@@ -12,6 +12,7 @@ import {MIN_TICK, MAX_TICK} from "../../src/math/constants.sol";
 import {Ownable} from "solady/auth/Ownable.sol";
 import {TestToken} from "../TestToken.sol";
 import {RevenueBuybacksLib} from "../../src/libraries/RevenueBuybacksLib.sol";
+import {SqrtRatio} from "../../src/types/sqrtRatio.sol";
 
 contract RevenueBuybacksHarness is RevenueBuybacks {
     constructor(address owner, IOrders orders, address buyToken) RevenueBuybacks(owner, orders, buyToken) {}
@@ -154,7 +155,8 @@ contract RevenueBuybacksTest is BaseOrdersTest {
         positions.maybeInitializePool(poolKey, 0);
         token0.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey));
+        SqrtRatio sqrtRatio = poolSqrtRatio(poolKey);
+        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, sqrtRatio, sqrtRatio);
 
         (uint64 endTime, uint112 saleRate) = rb.roll(address(token0));
         assertEq(endTime, 3840);
@@ -190,7 +192,8 @@ contract RevenueBuybacksTest is BaseOrdersTest {
 
         positions.maybeInitializePool(poolKey, 0);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit{value: 1e18}(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey));
+        SqrtRatio sqrtRatio = poolSqrtRatio(poolKey);
+        positions.mintAndDeposit{value: 1e18}(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, sqrtRatio, sqrtRatio);
 
         (uint64 endTime, uint112 saleRate) = rb.roll(address(0));
         assertEq(endTime, 3840);
@@ -244,9 +247,8 @@ contract RevenueBuybacksTest is BaseOrdersTest {
         positions.maybeInitializePool(poolKey, 0);
         token0.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit{value: isEth ? 1e18 : 0}(
-            poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey)
-        );
+        SqrtRatio sqrtRatio = poolSqrtRatio(poolKey);
+        positions.mintAndDeposit{value: isEth ? 1e18 : 0}(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, sqrtRatio, sqrtRatio);
 
         (uint64 endTime,) = rb.roll(token);
         assertGt(endTime, startTime, "end time gt");

--- a/test/base/RevenueBuybacks.t.sol
+++ b/test/base/RevenueBuybacks.t.sol
@@ -154,7 +154,7 @@ contract RevenueBuybacksTest is BaseOrdersTest {
         positions.maybeInitializePool(poolKey, 0);
         token0.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
+        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey));
 
         (uint64 endTime, uint112 saleRate) = rb.roll(address(token0));
         assertEq(endTime, 3840);
@@ -190,7 +190,7 @@ contract RevenueBuybacksTest is BaseOrdersTest {
 
         positions.maybeInitializePool(poolKey, 0);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit{value: 1e18}(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
+        positions.mintAndDeposit{value: 1e18}(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey));
 
         (uint64 endTime, uint112 saleRate) = rb.roll(address(0));
         assertEq(endTime, 3840);
@@ -244,7 +244,9 @@ contract RevenueBuybacksTest is BaseOrdersTest {
         positions.maybeInitializePool(poolKey, 0);
         token0.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit{value: isEth ? 1e18 : 0}(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
+        positions.mintAndDeposit{value: isEth ? 1e18 : 0}(
+            poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, poolSqrtRatio(poolKey)
+        );
 
         (uint64 endTime,) = rb.roll(token);
         assertGt(endTime, startTime, "end time gt");

--- a/test/extensions/MEVCapture.t.sol
+++ b/test/extensions/MEVCapture.t.sol
@@ -16,6 +16,7 @@ import {ExposedStorageLib} from "../../src/libraries/ExposedStorageLib.sol";
 import {Router} from "../../src/Router.sol";
 import {MEVCapturePoolState} from "../../src/types/mevCapturePoolState.sol";
 import {PoolBalanceUpdate} from "../../src/types/poolBalanceUpdate.sol";
+import {tickToSqrtRatio} from "../../src/math/ticks.sol";
 
 abstract contract BaseMEVCaptureTest is FullTest {
     MEVCapture internal mevCapture;
@@ -49,6 +50,21 @@ contract MEVCaptureTest is BaseMEVCaptureTest {
 
     function test_isRegistered() public view {
         assertTrue(core.isExtensionRegistered(address(mevCapture)));
+    }
+
+    function test_positionsDepositSwapsThroughForwardToTargetPrice() public {
+        PoolKey memory poolKey = createMEVCapturePool({fee: 1 << 32, tickSpacing: 100, tick: 0});
+        token0.approve(address(positions), type(uint256).max);
+        token1.approve(address(positions), type(uint256).max);
+        createPosition(poolKey, -1000, 1000, 1e18, 1e18);
+        token0.approve(address(positions), type(uint256).max);
+        token1.approve(address(positions), type(uint256).max);
+
+        SqrtRatio targetSqrtRatio = tickToSqrtRatio(100);
+        (, uint128 liquidity,,) = positions.mintAndDeposit(poolKey, -1000, 1000, 1e18, 1e18, targetSqrtRatio);
+
+        assertEq(core.poolState(poolKey.toPoolId()).sqrtRatio().toFixed(), targetSqrtRatio.toFixed());
+        assertGt(liquidity, 0);
     }
 
     function getPoolState(PoolId poolId) private view returns (MEVCapturePoolState state) {

--- a/test/extensions/MEVCapture.t.sol
+++ b/test/extensions/MEVCapture.t.sol
@@ -52,7 +52,7 @@ contract MEVCaptureTest is BaseMEVCaptureTest {
         assertTrue(core.isExtensionRegistered(address(mevCapture)));
     }
 
-    function test_positionsDepositSwapsThroughForwardToTargetPrice() public {
+    function test_positionsDepositSwapsThroughForwardIntoPriceRange() public {
         PoolKey memory poolKey = createMEVCapturePool({fee: 1 << 32, tickSpacing: 100, tick: 0});
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
@@ -60,10 +60,10 @@ contract MEVCaptureTest is BaseMEVCaptureTest {
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        SqrtRatio targetSqrtRatio = tickToSqrtRatio(100);
-        (, uint128 liquidity,,) = positions.mintAndDeposit(poolKey, -1000, 1000, 1e18, 1e18, targetSqrtRatio);
+        SqrtRatio minSqrtRatio = tickToSqrtRatio(100);
+        (, uint128 liquidity,,) = positions.mintAndDeposit(poolKey, -1000, 1000, 1e18, 1e18, minSqrtRatio, minSqrtRatio);
 
-        assertEq(core.poolState(poolKey.toPoolId()).sqrtRatio().toFixed(), targetSqrtRatio.toFixed());
+        assertEq(core.poolState(poolKey.toPoolId()).sqrtRatio().toFixed(), minSqrtRatio.toFixed());
         assertGt(liquidity, 0);
     }
 

--- a/test/extensions/Oracle.t.sol
+++ b/test/extensions/Oracle.t.sol
@@ -86,7 +86,7 @@ abstract contract BaseOracleTest is FullTest {
             TestToken(token).approve(address(positions), type(uint256).max);
 
             vm.deal(address(positions), uint128(d0));
-            positions.deposit(positionId, pk, MIN_TICK, MAX_TICK, uint128(d0), uint128(d1), sqrtRatio);
+            positions.deposit(positionId, pk, MIN_TICK, MAX_TICK, uint128(d0), uint128(d1), sqrtRatio, sqrtRatio);
         } else if (liquidityBefore > liquidityNext) {
             uint128 diff = liquidityBefore - liquidityNext;
             if (diff > uint256(int256(type(int128).min))) {

--- a/test/extensions/Oracle.t.sol
+++ b/test/extensions/Oracle.t.sol
@@ -86,9 +86,7 @@ abstract contract BaseOracleTest is FullTest {
             TestToken(token).approve(address(positions), type(uint256).max);
 
             vm.deal(address(positions), uint128(d0));
-            positions.deposit(
-                positionId, pk, MIN_TICK, MAX_TICK, uint128(d0), uint128(d1), liquidityNext - liquidityBefore - 1
-            );
+            positions.deposit(positionId, pk, MIN_TICK, MAX_TICK, uint128(d0), uint128(d1), sqrtRatio);
         } else if (liquidityBefore > liquidityNext) {
             uint128 diff = liquidityBefore - liquidityNext;
             if (diff > uint256(int256(type(int128).min))) {

--- a/test/extensions/Ve33.t.sol
+++ b/test/extensions/Ve33.t.sol
@@ -248,7 +248,7 @@ contract Ve33Test is FullTest {
                 positionId.tickUpper(),
                 uint128(delta0),
                 uint128(delta1),
-                uint128(liquidityDelta)
+                core.poolState(poolKey.toPoolId()).sqrtRatio()
             );
             balanceUpdate = createPoolBalanceUpdate(int128(amount0), int128(amount1));
         } else {
@@ -1578,8 +1578,24 @@ contract Ve33Test is FullTest {
         (uint128 liquidity,,) = vePositions.getPositionLiquidity(id, poolKey, MIN_TICK, MAX_TICK);
         assertEq(liquidity, uint128(type(int128).max));
 
+        SqrtRatio sqrtRatio = core.poolState(poolKey.toPoolId()).sqrtRatio();
         vm.expectRevert(Ve33Positions.DepositOverflow.selector);
-        vePositions.deposit(id, poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, 1);
+        vePositions.deposit(id, poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, sqrtRatio);
+    }
+
+    function test_vePositionsSwapsToTargetPriceBeforeAddingLiquidity() public {
+        PoolKey memory poolKey = createFullRangePool(0, 0, address(ve));
+        PositionId positionId = _mintPosition(MIN_TICK, MAX_TICK);
+        _updatePosition(poolKey, positionId, 1e18);
+
+        SqrtRatio targetSqrtRatio = tickToSqrtRatio(100);
+        (uint128 liquidity, uint128 amount0, uint128 amount1) =
+            vePositions.deposit(_positionNftId(positionId), poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, targetSqrtRatio);
+
+        assertEq(core.poolState(poolKey.toPoolId()).sqrtRatio().toFixed(), targetSqrtRatio.toFixed());
+        assertGt(liquidity, 0);
+        assertGt(amount0, 0);
+        assertGt(amount1, 0);
     }
 
     function test_scheduleEmissionsAccruesMultipleEventsAtSameTime() public {

--- a/test/extensions/Ve33.t.sol
+++ b/test/extensions/Ve33.t.sol
@@ -248,6 +248,7 @@ contract Ve33Test is FullTest {
                 positionId.tickUpper(),
                 uint128(delta0),
                 uint128(delta1),
+                core.poolState(poolKey.toPoolId()).sqrtRatio(),
                 core.poolState(poolKey.toPoolId()).sqrtRatio()
             );
             balanceUpdate = createPoolBalanceUpdate(int128(amount0), int128(amount1));
@@ -1597,19 +1598,20 @@ contract Ve33Test is FullTest {
 
         SqrtRatio sqrtRatio = core.poolState(poolKey.toPoolId()).sqrtRatio();
         vm.expectRevert(Ve33Positions.DepositOverflow.selector);
-        vePositions.deposit(id, poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, sqrtRatio);
+        vePositions.deposit(id, poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, sqrtRatio, sqrtRatio);
     }
 
-    function test_vePositionsSwapsToTargetPriceBeforeAddingLiquidity() public {
+    function test_vePositionsSwapsIntoPriceRangeBeforeAddingLiquidity() public {
         PoolKey memory poolKey = createFullRangePool(0, 0, address(ve));
         PositionId positionId = _mintPosition(MIN_TICK, MAX_TICK);
         _updatePosition(poolKey, positionId, 1e18);
 
-        SqrtRatio targetSqrtRatio = tickToSqrtRatio(100);
-        (uint128 liquidity, uint128 amount0, uint128 amount1) =
-            vePositions.deposit(_positionNftId(positionId), poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, targetSqrtRatio);
+        SqrtRatio minSqrtRatio = tickToSqrtRatio(100);
+        (uint128 liquidity, uint128 amount0, uint128 amount1) = vePositions.deposit(
+            _positionNftId(positionId), poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, minSqrtRatio, minSqrtRatio
+        );
 
-        assertEq(core.poolState(poolKey.toPoolId()).sqrtRatio().toFixed(), targetSqrtRatio.toFixed());
+        assertEq(core.poolState(poolKey.toPoolId()).sqrtRatio().toFixed(), minSqrtRatio.toFixed());
         assertGt(liquidity, 0);
         assertGt(amount0, 0);
         assertGt(amount1, 0);

--- a/test/extensions/Ve33EmissionsInvariant.t.sol
+++ b/test/extensions/Ve33EmissionsInvariant.t.sol
@@ -308,7 +308,12 @@ contract Ve33EmissionsInvariantHandler is StdUtils, StdAssertions {
     function _mintPosition(uint256 poolIndex, int32 tickLower, int32 tickUpper) private {
         TrackedPool memory trackedPool = pools[poolIndex];
         (uint256 nftId, uint128 liquidity,,) = ve33Positions.mintAndDeposit(
-            trackedPool.poolKey, tickLower, tickUpper, uint128(POSITION_AMOUNT), uint128(POSITION_AMOUNT), 1
+            trackedPool.poolKey,
+            tickLower,
+            tickUpper,
+            uint128(POSITION_AMOUNT),
+            uint128(POSITION_AMOUNT),
+            core.poolState(trackedPool.poolKey.toPoolId()).sqrtRatio()
         );
         positions.push(
             TrackedPosition({

--- a/test/extensions/Ve33EmissionsInvariant.t.sol
+++ b/test/extensions/Ve33EmissionsInvariant.t.sol
@@ -313,6 +313,7 @@ contract Ve33EmissionsInvariantHandler is StdUtils, StdAssertions {
             tickUpper,
             uint128(POSITION_AMOUNT),
             uint128(POSITION_AMOUNT),
+            core.poolState(trackedPool.poolKey.toPoolId()).sqrtRatio(),
             core.poolState(trackedPool.poolKey.toPoolId()).sqrtRatio()
         );
         positions.push(


### PR DESCRIPTION
## Summary
- replace `minLiquidity` on position deposits with `minSqrtRatio` / `maxSqrtRatio` bounds
- swap to the nearest boundary only when the pool price is outside the accepted range
- bound net token spend across the swap and liquidity deposit
- add overloads that send excess swap output to an optional `swapRecipient`, defaulting to `msg.sender`
- keep zero-mintable-liquidity deposits as successful no-ops
- share deposit, settlement, mint, and initialization logic between BasePositions and Ve33Positions
- support direct Core swaps, MEV Capture forwarding, and Ve33 forwarding

The price range replaces minimum-liquidity protection: it constrains the deposit price and maximum spend, but intentionally does not guarantee a minimum minted-liquidity amount.

## Verification
- `forge fmt`
- `forge build --offline`
- `forge test --offline` (983 tests)
- `forge script --offline DeployAll`
- `forge snapshot --offline`
