### PR TITLE
Add STONX Ve33 deployment script

### DIFF
--- a/script/DeploySTONX.s.sol
+++ b/script/DeploySTONX.s.sol
@@ -3,13 +3,15 @@ pragma solidity =0.8.33;
 
 import {console2} from "forge-std/console2.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
-import {DeployVe33} from "./DeployVe33.s.sol";
+import {DeployVe33, Ve33Deployment} from "./DeployVe33.s.sol";
 import {deployIfNeeded} from "./DeployAll.s.sol";
 import {MintableERC20} from "../src/MintableERC20.sol";
 import {Ve33} from "../src/extensions/Ve33.sol";
 import {ICore} from "../src/interfaces/ICore.sol";
 import {Ve33EmissionRateScheduler} from "../src/Ve33EmissionRateScheduler.sol";
 import {Ve33Positions} from "../src/Ve33Positions.sol";
+import {VeToken} from "../src/VeToken.sol";
+import {CoreLib} from "../src/libraries/CoreLib.sol";
 import {sqrtRatioToTick} from "../src/math/ticks.sol";
 import {PoolKey} from "../src/types/poolKey.sol";
 import {createConcentratedPoolConfig} from "../src/types/poolConfig.sol";
@@ -18,6 +20,8 @@ import {toSqrtRatio} from "../src/types/sqrtRatio.sol";
 /// @title DeploySTONX
 /// @notice Deploys and configures the STONX Ve33 system on RHC or RHC testnet.
 contract DeploySTONX is DeployVe33 {
+    using CoreLib for *;
+
     uint256 internal constant RHC_CHAIN_ID = 4663;
     uint256 internal constant RHC_TESTNET_CHAIN_ID = 46630;
 
@@ -31,10 +35,13 @@ contract DeploySTONX is DeployVe33 {
     // Outermost usable ticks within Core's global bounds for this tick spacing.
     int32 internal constant POSITION_TICK_LOWER = -88_722_432;
     int32 internal constant POSITION_TICK_UPPER = 88_722_432;
+    uint64 internal constant SWAP_FEE = uint64((uint256(type(uint64).max) * 30) / 10_000);
     uint32 internal constant EMISSION_SCHEDULE_DURATION = 3 days;
     uint160 internal constant EMISSION_RATE = uint160(uint256(333_333e15) * (1 << 32) / 1 days);
 
     error InvalidChainId(uint256 chainId);
+    error PoolHasNoLiquidity();
+    error NoEmissionsScheduled();
     error USDGNotFullySpent(uint128 spent);
 
     function run() public override {
@@ -50,30 +57,36 @@ contract DeploySTONX is DeployVe33 {
 
         vm.startBroadcast();
 
-        (MintableERC20 stonx, Ve33 ve33, Ve33Positions positions) = _deployVe33(core, deployer, salt);
+        Ve33Deployment memory deployment = _deployVe33(core, deployer, salt);
+        MintableERC20 stonx = MintableERC20(deployment.stakeToken);
 
         stonx.mint(deployer, DEPLOYER_TOKEN_AMOUNT);
         stonx.mint(deployer, LIQUIDITY_TOKEN_AMOUNT);
 
-        uint256 positionId = _seedLiquidity(stonx, ve33, positions, usdg, deployer, governance);
-        address schedulerAddress = _deployScheduler(stonx, ve33, core, salt, deployer, governance);
+        PoolKey memory poolKey = _stonxPoolKey(address(stonx), usdg, address(deployment.ve33));
+        uint256 positionId = _seedLiquidity(stonx, deployment.positions, poolKey, usdg, deployer, governance);
+        uint256 veId = _stakeAndVote(stonx, deployment.veToken, core, poolKey);
+        deployment.positions.transferOwnership(governance);
+        (address schedulerAddress, uint128 scheduledAmount) =
+            _deployScheduler(stonx, deployment.ve33, core, salt, deployer, governance);
 
         console2.log("STONX", address(stonx));
         console2.log("STONX/USDG Ve33 position", positionId);
+        console2.log("STONX VeToken stake", veId);
         console2.log("Ve33EmissionRateScheduler", schedulerAddress);
+        console2.log("Initial scheduled emissions", scheduledAmount);
 
         vm.stopBroadcast();
     }
 
     function _seedLiquidity(
         MintableERC20 stonx,
-        Ve33 ve33,
         Ve33Positions positions,
+        PoolKey memory poolKey,
         address usdg,
         address deployer,
         address governance
     ) internal returns (uint256 positionId) {
-        PoolKey memory poolKey = _stonxPoolKey(address(stonx), usdg, address(ve33));
         int32 poolInitialTick = this.initialTick(address(stonx), usdg);
         positions.maybeInitializePool(poolKey, poolInitialTick);
 
@@ -96,6 +109,17 @@ contract DeploySTONX is DeployVe33 {
         positions.transferFrom(deployer, governance, positionId);
     }
 
+    function _stakeAndVote(MintableERC20 stonx, VeToken veToken, ICore core, PoolKey memory poolKey)
+        internal
+        returns (uint256 veId)
+    {
+        if (core.poolState(poolKey.toPoolId()).liquidity() == 0) revert PoolHasNoLiquidity();
+
+        stonx.approve(address(veToken), DEPLOYER_TOKEN_AMOUNT);
+        veId = veToken.stakeMaxDuration(DEPLOYER_TOKEN_AMOUNT);
+        veToken.vote(veId, poolKey, SWAP_FEE);
+    }
+
     function _deployScheduler(
         MintableERC20 stonx,
         Ve33 ve33,
@@ -103,7 +127,7 @@ contract DeploySTONX is DeployVe33 {
         bytes32 salt,
         address deployer,
         address governance
-    ) internal returns (address schedulerAddress) {
+    ) internal returns (address schedulerAddress, uint128 scheduledAmount) {
         (schedulerAddress,) = deployIfNeeded(
             abi.encodePacked(type(Ve33EmissionRateScheduler).creationCode, abi.encode(deployer, core, ve33)),
             salt,
@@ -111,9 +135,18 @@ contract DeploySTONX is DeployVe33 {
             "Ve33EmissionRateScheduler"
         );
         Ve33EmissionRateScheduler scheduler = Ve33EmissionRateScheduler(payable(schedulerAddress));
+        scheduledAmount = _configureAndStartScheduler(stonx, scheduler, governance);
+    }
+
+    function _configureAndStartScheduler(MintableERC20 stonx, Ve33EmissionRateScheduler scheduler, address governance)
+        internal
+        returns (uint128 scheduledAmount)
+    {
         scheduler.setConfig(EMISSION_RATE, EMISSION_SCHEDULE_DURATION);
         scheduler.transferOwnership(governance);
-        stonx.transferOwnership(schedulerAddress);
+        stonx.transferOwnership(address(scheduler));
+        scheduledAmount = scheduler.mintAndSchedule();
+        if (scheduledAmount == 0) revert NoEmissionsScheduled();
     }
 
     function _stakeToken(address owner, bytes32 salt)
@@ -138,6 +171,10 @@ contract DeploySTONX is DeployVe33 {
 
     function _defaultPositionsSymbol() internal pure override returns (string memory) {
         return "stonxPO";
+    }
+
+    function _defaultVeTokenName(string memory) internal pure override returns (string memory) {
+        return "Vote-Escrow STONX";
     }
 
     function _stonxPoolKey(address stonx, address usdg, address ve33) internal pure returns (PoolKey memory poolKey) {

--- a/script/DeploySTONX.s.sol
+++ b/script/DeploySTONX.s.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: ekubo-license-v1.eth
+pragma solidity =0.8.33;
+
+import {console2} from "forge-std/console2.sol";
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+import {DeployVe33} from "./DeployVe33.s.sol";
+import {deployIfNeeded} from "./DeployAll.s.sol";
+import {MintableERC20} from "../src/MintableERC20.sol";
+import {Ve33} from "../src/extensions/Ve33.sol";
+import {ICore} from "../src/interfaces/ICore.sol";
+import {Ve33EmissionRateScheduler} from "../src/Ve33EmissionRateScheduler.sol";
+import {Ve33Positions} from "../src/Ve33Positions.sol";
+import {sqrtRatioToTick} from "../src/math/ticks.sol";
+import {PoolKey} from "../src/types/poolKey.sol";
+import {createConcentratedPoolConfig} from "../src/types/poolConfig.sol";
+import {toSqrtRatio} from "../src/types/sqrtRatio.sol";
+
+/// @title DeploySTONX
+/// @notice Deploys and configures the STONX Ve33 system on RHC or RHC testnet.
+contract DeploySTONX is DeployVe33 {
+    uint256 internal constant RHC_CHAIN_ID = 4663;
+    uint256 internal constant RHC_TESTNET_CHAIN_ID = 46630;
+
+    address internal constant DEFAULT_USDG_ADDRESS = 0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168;
+    address internal constant DEFAULT_GOVERNANCE_ADDRESS = 0xcd87828F4f279D3C5fD7af531370298964B5EAAb;
+
+    uint128 internal constant LIQUIDITY_TOKEN_AMOUNT = 333_333e18;
+    uint128 internal constant LIQUIDITY_USDG_AMOUNT = 333_333e6;
+    uint128 internal constant DEPLOYER_TOKEN_AMOUNT = 333_333e18;
+    uint32 internal constant TICK_SPACING = 1024;
+    // Outermost usable ticks within Core's global bounds for this tick spacing.
+    int32 internal constant POSITION_TICK_LOWER = -88_722_432;
+    int32 internal constant POSITION_TICK_UPPER = 88_722_432;
+    uint32 internal constant EMISSION_SCHEDULE_DURATION = 3 days;
+    uint160 internal constant EMISSION_RATE = uint160(uint256(333_333e15) * (1 << 32) / 1 days);
+
+    error InvalidChainId(uint256 chainId);
+    error USDGNotFullySpent(uint128 spent);
+
+    function run() public override {
+        if (block.chainid != RHC_CHAIN_ID && block.chainid != RHC_TESTNET_CHAIN_ID) {
+            revert InvalidChainId(block.chainid);
+        }
+
+        bytes32 salt = vm.envOr("SALT", DEFAULT_DEPLOYMENT_SALT);
+        ICore core = ICore(payable(vm.envOr("CORE_ADDRESS", payable(DEFAULT_CORE_ADDRESS))));
+        address deployer = vm.getWallets()[0];
+        address usdg = vm.envOr("USDG_ADDRESS", DEFAULT_USDG_ADDRESS);
+        address governance = vm.envOr("GOVERNANCE_ADDRESS", DEFAULT_GOVERNANCE_ADDRESS);
+
+        vm.startBroadcast();
+
+        (MintableERC20 stonx, Ve33 ve33, Ve33Positions positions) = _deployVe33(core, deployer, salt);
+
+        stonx.mint(deployer, DEPLOYER_TOKEN_AMOUNT);
+        stonx.mint(deployer, LIQUIDITY_TOKEN_AMOUNT);
+
+        uint256 positionId = _seedLiquidity(stonx, ve33, positions, usdg, deployer, governance);
+        address schedulerAddress = _deployScheduler(stonx, ve33, core, salt, deployer, governance);
+
+        console2.log("STONX", address(stonx));
+        console2.log("STONX/USDG Ve33 position", positionId);
+        console2.log("Ve33EmissionRateScheduler", schedulerAddress);
+
+        vm.stopBroadcast();
+    }
+
+    function _seedLiquidity(
+        MintableERC20 stonx,
+        Ve33 ve33,
+        Ve33Positions positions,
+        address usdg,
+        address deployer,
+        address governance
+    ) internal returns (uint256 positionId) {
+        PoolKey memory poolKey = _stonxPoolKey(address(stonx), usdg, address(ve33));
+        int32 poolInitialTick = this.initialTick(address(stonx), usdg);
+        positions.maybeInitializePool(poolKey, poolInitialTick);
+
+        stonx.approve(address(positions), LIQUIDITY_TOKEN_AMOUNT);
+        IERC20(usdg).approve(address(positions), LIQUIDITY_USDG_AMOUNT);
+
+        uint128 amount0;
+        uint128 amount1;
+        (positionId,, amount0, amount1) = positions.mintAndDeposit(
+            poolKey,
+            POSITION_TICK_LOWER,
+            POSITION_TICK_UPPER,
+            address(stonx) < usdg ? LIQUIDITY_TOKEN_AMOUNT : LIQUIDITY_USDG_AMOUNT,
+            address(stonx) < usdg ? LIQUIDITY_USDG_AMOUNT : LIQUIDITY_TOKEN_AMOUNT,
+            0
+        );
+
+        uint128 usdgSpent = address(stonx) < usdg ? amount1 : amount0;
+        if (usdgSpent != LIQUIDITY_USDG_AMOUNT) revert USDGNotFullySpent(usdgSpent);
+        positions.transferFrom(deployer, governance, positionId);
+    }
+
+    function _deployScheduler(
+        MintableERC20 stonx,
+        Ve33 ve33,
+        ICore core,
+        bytes32 salt,
+        address deployer,
+        address governance
+    ) internal returns (address schedulerAddress) {
+        (schedulerAddress,) = deployIfNeeded(
+            abi.encodePacked(type(Ve33EmissionRateScheduler).creationCode, abi.encode(deployer, core, ve33)),
+            salt,
+            address(0),
+            "Ve33EmissionRateScheduler"
+        );
+        Ve33EmissionRateScheduler scheduler = Ve33EmissionRateScheduler(payable(schedulerAddress));
+        scheduler.setConfig(EMISSION_RATE, EMISSION_SCHEDULE_DURATION);
+        scheduler.transferOwnership(governance);
+        stonx.transferOwnership(schedulerAddress);
+    }
+
+    function _stakeToken(address owner, bytes32 salt)
+        internal
+        override
+        returns (address stakeToken, string memory name, string memory symbol, uint8 decimals)
+    {
+        name = "Ekubo Stock Liquidity Token";
+        symbol = "STONX";
+        decimals = 18;
+        (stakeToken,) = deployIfNeeded(
+            abi.encodePacked(type(MintableERC20).creationCode, abi.encode(owner, name, symbol)),
+            salt,
+            address(0),
+            "STONX"
+        );
+    }
+
+    function _defaultPositionsName() internal pure override returns (string memory) {
+        return "Ekubo STONX Positions";
+    }
+
+    function _defaultPositionsSymbol() internal pure override returns (string memory) {
+        return "stonxPO";
+    }
+
+    function _stonxPoolKey(address stonx, address usdg, address ve33) internal pure returns (PoolKey memory poolKey) {
+        (poolKey.token0, poolKey.token1) = stonx < usdg ? (stonx, usdg) : (usdg, stonx);
+        poolKey.config = createConcentratedPoolConfig({_fee: 0, _tickSpacing: TICK_SPACING, _extension: ve33});
+    }
+
+    function initialTick(address stonx, address usdg) external pure returns (int32 tick) {
+        uint256 sqrtRatioX128 = stonx < usdg ? (uint256(1) << 128) / 1e6 : (uint256(1) << 128) * 1e6;
+        tick = sqrtRatioToTick(toSqrtRatio(sqrtRatioX128, true));
+
+        // Round toward the USDG-limiting side so the position spends the full configured USDG amount.
+        if (stonx < usdg) ++tick;
+    }
+}

--- a/script/DeployVe33.s.sol
+++ b/script/DeployVe33.s.sol
@@ -15,6 +15,13 @@ import {NATIVE_TOKEN_ADDRESS} from "../src/math/constants.sol";
 import {deployExtension, deployIfNeeded} from "./DeployAll.s.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 
+struct Ve33Deployment {
+    address stakeToken;
+    Ve33 ve33;
+    VeToken veToken;
+    Ve33Positions positions;
+}
+
 /// @title DeployVe33
 /// @notice Deploys the Ve33 extension, VeToken ERC721 wrapper, Ve33Positions, Ve33Periphery, and Ve33DataFetcher.
 contract DeployVe33 is Script {
@@ -36,7 +43,7 @@ contract DeployVe33 is Script {
 
     function _deployVe33(ICore core, address deployer, bytes32 salt)
         internal
-        returns (MintableERC20 stakeToken, Ve33 ve33, Ve33Positions positions)
+        returns (Ve33Deployment memory deployment)
     {
         address stakeTokenAddress;
         string memory stakeTokenName;
@@ -44,7 +51,7 @@ contract DeployVe33 is Script {
         uint8 stakeTokenDecimals;
 
         (stakeTokenAddress, stakeTokenName, stakeTokenSymbol, stakeTokenDecimals) = _stakeToken(deployer, salt);
-        stakeToken = MintableERC20(stakeTokenAddress);
+        deployment.stakeToken = stakeTokenAddress;
 
         (address ve33Address,) = deployExtension(
             abi.encodePacked(type(Ve33).creationCode, abi.encode(core, stakeTokenAddress)),
@@ -54,11 +61,13 @@ contract DeployVe33 is Script {
             "Ve33"
         );
 
-        ve33 = Ve33(payable(ve33Address));
+        deployment.ve33 = Ve33(payable(ve33Address));
 
-        _deployVeToken(core, ve33, stakeTokenAddress, stakeTokenName, stakeTokenSymbol, stakeTokenDecimals, salt);
-        positions = _deployPositions(core, ve33, deployer, salt);
-        _deployVe33Support(core, ve33, salt);
+        deployment.veToken = _deployVeToken(
+            core, deployment.ve33, stakeTokenAddress, stakeTokenName, stakeTokenSymbol, stakeTokenDecimals, salt
+        );
+        deployment.positions = _deployPositions(core, deployment.ve33, deployer, salt);
+        _deployVe33Support(core, deployment.ve33, salt);
     }
 
     function _deployVeToken(
@@ -69,7 +78,7 @@ contract DeployVe33 is Script {
         string memory stakeTokenSymbol,
         uint8 stakeTokenDecimals,
         bytes32 salt
-    ) internal {
+    ) internal returns (VeToken veToken) {
         (address veTokenMetadata,) = deployIfNeeded(
             abi.encodePacked(
                 type(VeTokenMetadata).creationCode,
@@ -80,10 +89,10 @@ contract DeployVe33 is Script {
             "VeTokenMetadata"
         );
 
-        string memory veTokenName = _envStringOr("VE_TOKEN_NAME", string.concat("Vote-Escrow ", stakeTokenName));
-        string memory veTokenSymbol = _envStringOr("VE_TOKEN_SYMBOL", string.concat("ve", stakeTokenSymbol));
+        string memory veTokenName = _envStringOr("VE_TOKEN_NAME", _defaultVeTokenName(stakeTokenName));
+        string memory veTokenSymbol = _envStringOr("VE_TOKEN_SYMBOL", _defaultVeTokenSymbol(stakeTokenSymbol));
 
-        deployIfNeeded(
+        (address veTokenAddress,) = deployIfNeeded(
             abi.encodePacked(
                 type(VeToken).creationCode,
                 abi.encode(core, ve33, VeTokenMetadata(veTokenMetadata), veTokenName, veTokenSymbol)
@@ -92,6 +101,7 @@ contract DeployVe33 is Script {
             address(0),
             "VeToken"
         );
+        veToken = VeToken(payable(veTokenAddress));
     }
 
     function _deployPositions(ICore core, Ve33 ve33, address deployer, bytes32 salt)
@@ -166,6 +176,14 @@ contract DeployVe33 is Script {
 
     function _defaultPositionsSymbol() internal pure virtual returns (string memory) {
         return "ekuVe33Po";
+    }
+
+    function _defaultVeTokenName(string memory stakeTokenName) internal pure virtual returns (string memory) {
+        return string.concat("Vote-Escrow ", stakeTokenName);
+    }
+
+    function _defaultVeTokenSymbol(string memory stakeTokenSymbol) internal pure virtual returns (string memory) {
+        return string.concat("ve", stakeTokenSymbol);
     }
 
     function _stakeTokenName(address stakeToken) internal returns (string memory) {

--- a/script/DeployVe33.s.sol
+++ b/script/DeployVe33.s.sol
@@ -22,33 +22,54 @@ contract DeployVe33 is Script {
     bytes32 internal constant DEFAULT_DEPLOYMENT_SALT =
         0x28f4114b40904ad1cfbb42175a55ad64187c1b299773bd6318baa292375cf0dd;
 
-    function run() public {
+    function run() public virtual {
         bytes32 salt = vm.envOr("SALT", DEFAULT_DEPLOYMENT_SALT);
         ICore core = ICore(payable(vm.envOr("CORE_ADDRESS", payable(DEFAULT_CORE_ADDRESS))));
         address deployer = vm.envOr("OWNER_ADDRESS", vm.getWallets()[0]);
 
         vm.startBroadcast();
 
-        (address stakeToken, string memory stakeTokenName, string memory stakeTokenSymbol, uint8 stakeTokenDecimals) =
-            _stakeToken(deployer, salt);
+        _deployVe33(core, deployer, salt);
+
+        vm.stopBroadcast();
+    }
+
+    function _deployVe33(ICore core, address deployer, bytes32 salt)
+        internal
+        returns (MintableERC20 stakeToken, Ve33 ve33, Ve33Positions positions)
+    {
+        address stakeTokenAddress;
+        string memory stakeTokenName;
+        string memory stakeTokenSymbol;
+        uint8 stakeTokenDecimals;
+
+        (stakeTokenAddress, stakeTokenName, stakeTokenSymbol, stakeTokenDecimals) = _stakeToken(deployer, salt);
+        stakeToken = MintableERC20(stakeTokenAddress);
 
         (address ve33Address,) = deployExtension(
-            abi.encodePacked(type(Ve33).creationCode, abi.encode(core, stakeToken)),
+            abi.encodePacked(type(Ve33).creationCode, abi.encode(core, stakeTokenAddress)),
             salt,
             ve33CallPoints(),
             address(0),
             "Ve33"
         );
 
-        Ve33 ve33 = Ve33(payable(ve33Address));
+        ve33 = Ve33(payable(ve33Address));
 
-        string memory veTokenName = _envStringOr("VE_TOKEN_NAME", string.concat("Vote-Escrow ", stakeTokenName));
-        string memory veTokenSymbol = _envStringOr("VE_TOKEN_SYMBOL", string.concat("ve", stakeTokenSymbol));
-        string memory positionsName = _envStringOr("VE33_POSITIONS_NAME", "Ekubo Ve33 Positions");
-        string memory positionsSymbol = _envStringOr("VE33_POSITIONS_SYMBOL", "ekuVe33Po");
-        string memory positionsBaseUrl =
-            _envStringOr("VE33_POSITIONS_BASE_URL", "https://prod-api.ekubo.org/positions/");
+        _deployVeToken(core, ve33, stakeTokenAddress, stakeTokenName, stakeTokenSymbol, stakeTokenDecimals, salt);
+        positions = _deployPositions(core, ve33, deployer, salt);
+        _deployVe33Support(core, ve33, salt);
+    }
 
+    function _deployVeToken(
+        ICore core,
+        Ve33 ve33,
+        address stakeToken,
+        string memory stakeTokenName,
+        string memory stakeTokenSymbol,
+        uint8 stakeTokenDecimals,
+        bytes32 salt
+    ) internal {
         (address veTokenMetadata,) = deployIfNeeded(
             abi.encodePacked(
                 type(VeTokenMetadata).creationCode,
@@ -59,6 +80,9 @@ contract DeployVe33 is Script {
             "VeTokenMetadata"
         );
 
+        string memory veTokenName = _envStringOr("VE_TOKEN_NAME", string.concat("Vote-Escrow ", stakeTokenName));
+        string memory veTokenSymbol = _envStringOr("VE_TOKEN_SYMBOL", string.concat("ve", stakeTokenSymbol));
+
         deployIfNeeded(
             abi.encodePacked(
                 type(VeToken).creationCode,
@@ -68,10 +92,18 @@ contract DeployVe33 is Script {
             address(0),
             "VeToken"
         );
+    }
 
-        address positionsAddress;
-        bool deployedPositions;
-        (positionsAddress, deployedPositions) = deployIfNeeded(
+    function _deployPositions(ICore core, Ve33 ve33, address deployer, bytes32 salt)
+        internal
+        returns (Ve33Positions positions)
+    {
+        string memory positionsName = _envStringOr("VE33_POSITIONS_NAME", _defaultPositionsName());
+        string memory positionsSymbol = _envStringOr("VE33_POSITIONS_SYMBOL", _defaultPositionsSymbol());
+        string memory positionsBaseUrl =
+            _envStringOr("VE33_POSITIONS_BASE_URL", "https://prod-api.ekubo.org/positions/");
+
+        (address positionsAddress, bool deployedPositions) = deployIfNeeded(
             abi.encodePacked(type(Ve33Positions).creationCode, abi.encode(core, ve33, deployer)),
             salt,
             address(0),
@@ -79,11 +111,15 @@ contract DeployVe33 is Script {
         );
 
         if (deployedPositions) {
-            Ve33Positions(payable(positionsAddress))
-                .setMetadata({newName: positionsName, newSymbol: positionsSymbol, newBaseUrl: positionsBaseUrl});
+            positions = Ve33Positions(payable(positionsAddress));
+            positions.setMetadata({newName: positionsName, newSymbol: positionsSymbol, newBaseUrl: positionsBaseUrl});
             console2.log("Set Ve33 positions metadata");
+        } else {
+            positions = Ve33Positions(payable(positionsAddress));
         }
+    }
 
+    function _deployVe33Support(ICore core, Ve33 ve33, bytes32 salt) internal {
         deployIfNeeded(
             abi.encodePacked(type(Ve33Periphery).creationCode, abi.encode(core, ve33)),
             salt,
@@ -94,11 +130,11 @@ contract DeployVe33 is Script {
         deployIfNeeded(
             abi.encodePacked(type(Ve33DataFetcher).creationCode, abi.encode(ve33)), salt, address(0), "Ve33DataFetcher"
         );
-        vm.stopBroadcast();
     }
 
     function _stakeToken(address owner, bytes32 salt)
         internal
+        virtual
         returns (
             address stakeToken,
             string memory stakeTokenName,
@@ -122,6 +158,14 @@ contract DeployVe33 is Script {
                 "MintableERC20"
             );
         }
+    }
+
+    function _defaultPositionsName() internal pure virtual returns (string memory) {
+        return "Ekubo Ve33 Positions";
+    }
+
+    function _defaultPositionsSymbol() internal pure virtual returns (string memory) {
+        return "ekuVe33Po";
     }
 
     function _stakeTokenName(address stakeToken) internal returns (string memory) {

--- a/test/DeploySTONX.t.sol
+++ b/test/DeploySTONX.t.sol
@@ -4,31 +4,65 @@ pragma solidity =0.8.33;
 import {FullTest} from "./FullTest.sol";
 import {DeploySTONX} from "../script/DeploySTONX.s.sol";
 import {MintableERC20} from "../src/MintableERC20.sol";
+import {BaseNonfungibleToken} from "../src/base/BaseNonfungibleToken.sol";
 import {Ve33, ve33CallPoints} from "../src/extensions/Ve33.sol";
+import {ICore} from "../src/interfaces/ICore.sol";
+import {CoreLib} from "../src/libraries/CoreLib.sol";
+import {Ve33Lib} from "../src/libraries/Ve33Lib.sol";
+import {Ve33DataFetcher} from "../src/lens/Ve33DataFetcher.sol";
+import {Ve33EmissionRateScheduler} from "../src/Ve33EmissionRateScheduler.sol";
+import {Ve33Periphery} from "../src/Ve33Periphery.sol";
 import {Ve33Positions} from "../src/Ve33Positions.sol";
+import {VeToken} from "../src/VeToken.sol";
+import {VeTokenMetadata} from "../src/VeTokenMetadata.sol";
+import {PoolId} from "../src/types/poolId.sol";
 import {PoolKey} from "../src/types/poolKey.sol";
+import {Ve33EmissionRateConfig} from "../src/types/ve33EmissionRateConfig.sol";
+import {VePoolSwapFeeState} from "../src/types/vePoolSwapFeeState.sol";
 
 contract DeploySTONXHarness is DeploySTONX {
-    function seedLiquidity(MintableERC20 stonx, Ve33 ve33, Ve33Positions positions, address usdg, address governance)
-        external
-        returns (uint256 positionId)
-    {
-        positionId = _seedLiquidity(stonx, ve33, positions, usdg, address(this), governance);
+    function setPositionsMetadata(Ve33Positions positions) external {
+        positions.setMetadata("Ekubo STONX Positions", "stonxPO", "https://prod-api.ekubo.org/positions/");
     }
 
-    function stonxPoolKey(address stonx, address usdg, address ve33) external pure returns (PoolKey memory) {
-        return _stonxPoolKey(stonx, usdg, ve33);
+    function initialize(
+        MintableERC20 stonx,
+        Ve33 ve33,
+        VeToken veToken,
+        Ve33Positions positions,
+        Ve33EmissionRateScheduler scheduler,
+        ICore core,
+        address usdg,
+        address governance
+    ) external returns (PoolKey memory poolKey, uint256 positionId, uint256 veId, uint128 scheduledAmount) {
+        poolKey = _stonxPoolKey(address(stonx), usdg, address(ve33));
+        positionId = _seedLiquidity(stonx, positions, poolKey, usdg, address(this), governance);
+        veId = _stakeAndVote(stonx, veToken, core, poolKey);
+        positions.transferOwnership(governance);
+        scheduledAmount = _configureAndStartScheduler(stonx, scheduler, governance);
     }
 }
 
 contract DeploySTONXTest is FullTest {
+    using CoreLib for *;
+    using Ve33Lib for Ve33;
+
     uint128 private constant STONX_AMOUNT = 333_333e18;
     uint128 private constant USDG_AMOUNT = 333_333e6;
+    int32 private constant POSITION_TICK_LOWER = -88_722_432;
+    int32 private constant POSITION_TICK_UPPER = 88_722_432;
+    uint64 private constant SWAP_FEE = uint64((uint256(type(uint64).max) * 30) / 10_000);
+    uint160 private constant EMISSION_RATE = uint160(uint256(333_333e15) * (1 << 32) / 1 days);
 
     DeploySTONXHarness private deployer;
     MintableERC20 private stonx;
     Ve33 private ve33;
+    VeTokenMetadata private metadata;
+    VeToken private veToken;
     Ve33Positions private ve33Positions;
+    Ve33Periphery private periphery;
+    Ve33DataFetcher private dataFetcher;
+    Ve33EmissionRateScheduler private scheduler;
 
     function setUp() public override {
         super.setUp();
@@ -38,31 +72,133 @@ contract DeploySTONXTest is FullTest {
         address ve33Address = address(uint160(ve33CallPoints().toUint8()) << 152);
         deployCodeTo("Ve33.sol:Ve33", abi.encode(core, stonx), ve33Address);
         ve33 = Ve33(payable(ve33Address));
-        ve33Positions = new Ve33Positions(core, ve33, address(this));
+
+        metadata = new VeTokenMetadata("Ekubo Stock Liquidity Token", "STONX", 18, address(stonx));
+        veToken = new VeToken(core, ve33, metadata, "Vote-Escrow STONX", "veSTONX");
+        ve33Positions = new Ve33Positions(core, ve33, address(deployer));
+        deployer.setPositionsMetadata(ve33Positions);
+        periphery = new Ve33Periphery(core, ve33);
+        dataFetcher = new Ve33DataFetcher(ve33);
+        scheduler = new Ve33EmissionRateScheduler(address(deployer), core, ve33);
 
         stonx.mint(address(deployer), STONX_AMOUNT);
+        stonx.mint(address(deployer), STONX_AMOUNT);
+        stonx.transferOwnership(address(deployer));
     }
 
-    function test_seedLiquidityWhenSTONXIsToken0() public {
-        _testSeedLiquidity(address(type(uint160).max - 1));
+    function test_initializeWhenSTONXIsToken0() public {
+        _testInitialize(address(type(uint160).max - 1));
     }
 
-    function test_seedLiquidityWhenSTONXIsToken1() public {
-        _testSeedLiquidity(address(0x10000));
+    function test_initializeWhenSTONXIsToken1() public {
+        _testInitialize(address(0x10000));
     }
 
-    function _testSeedLiquidity(address usdgAddress) private {
+    function _testInitialize(address usdgAddress) private {
         deployCodeTo("MintableERC20.sol:MintableERC20", abi.encode(address(this), "USDG", "USDG"), usdgAddress);
         MintableERC20 usdg = MintableERC20(usdgAddress);
         usdg.mint(address(deployer), USDG_AMOUNT);
 
-        uint256 positionId = deployer.seedLiquidity(stonx, ve33, ve33Positions, usdgAddress, owner);
-        PoolKey memory poolKey = deployer.stonxPoolKey(address(stonx), usdgAddress, address(ve33));
-        (uint128 liquidity,,) = ve33Positions.getPositionLiquidity(positionId, poolKey, -88_722_432, 88_722_432);
+        uint256 positionId;
+        uint256 veId;
+        uint128 scheduledAmount;
+        PoolKey memory poolKey;
+        (poolKey, positionId, veId, scheduledAmount) =
+            deployer.initialize(stonx, ve33, veToken, ve33Positions, scheduler, core, usdgAddress, owner);
+        PoolId poolId = poolKey.toPoolId();
 
+        _assertDeploymentOwnership(positionId, veId);
+        _assertPositionAndPoolState(poolKey, poolId, positionId, usdg);
+        _assertStakeAndVoteState(poolId, veId);
+        _assertEmissionState(scheduledAmount);
+        _assertEmissionsReachPosition(poolKey, positionId);
+    }
+
+    function _assertDeploymentOwnership(uint256 positionId, uint256 veId) private view {
+        assertEq(stonx.owner(), address(scheduler));
+        assertEq(scheduler.owner(), owner);
+        assertEq(ve33Positions.owner(), owner);
         assertEq(ve33Positions.ownerOf(positionId), owner);
+        assertEq(veToken.ownerOf(veId), address(deployer));
+
+        assertEq(address(veToken.ve33()), address(ve33));
+        assertEq(address(veToken.metadata()), address(metadata));
+        assertEq(address(ve33Positions.ve33()), address(ve33));
+        assertEq(address(periphery.ve33()), address(ve33));
+        assertEq(address(dataFetcher.VE33_EXTENSION()), address(ve33));
+        assertEq(address(scheduler.ve33()), address(ve33));
+        assertEq(address(scheduler.core()), address(core));
+        assertEq(address(scheduler.token()), address(stonx));
+        assertEq(veToken.stakeToken(), address(stonx));
+        assertEq(ve33Positions.stakeToken(), address(stonx));
+        assertEq(periphery.stakeToken(), address(stonx));
+
+        assertEq(stonx.name(), "Ekubo Stock Liquidity Token");
+        assertEq(stonx.symbol(), "STONX");
+        assertEq(stonx.decimals(), 18);
+        assertEq(veToken.name(), "Vote-Escrow STONX");
+        assertEq(veToken.symbol(), "veSTONX");
+        assertEq(ve33Positions.name(), "Ekubo STONX Positions");
+        assertEq(ve33Positions.symbol(), "stonxPO");
+        assertEq(ve33Positions.baseUrl(), "https://prod-api.ekubo.org/positions/");
+    }
+
+    function _assertPositionAndPoolState(PoolKey memory poolKey, PoolId poolId, uint256 positionId, MintableERC20 usdg)
+        private
+        view
+    {
+        (uint128 positionLiquidity,,) =
+            ve33Positions.getPositionLiquidity(positionId, poolKey, POSITION_TICK_LOWER, POSITION_TICK_UPPER);
+
+        assertGt(positionLiquidity, 0);
+        assertGt(core.poolState(poolId).liquidity(), 0);
         assertEq(usdg.balanceOf(address(deployer)), 0);
         assertLe(stonx.balanceOf(address(deployer)), STONX_AMOUNT);
-        assertGt(liquidity, 0);
+    }
+
+    function _assertStakeAndVoteState(PoolId poolId, uint256 veId) private view {
+        (uint128 stakeAmount, uint64 stakeEndTime) = veToken.stakes(veId);
+        (PoolId votedPoolId, uint128 voteWeight, uint64 votedSwapFee, uint128 claimable0, uint128 claimable1) =
+            veToken.voteState(veId);
+        VePoolSwapFeeState poolVoteState = ve33.poolSwapFeeState(poolId);
+
+        assertEq(stakeAmount, STONX_AMOUNT);
+        assertEq(stakeEndTime, block.timestamp + veToken.MAX_STAKE_DURATION());
+        assertEq(PoolId.unwrap(votedPoolId), PoolId.unwrap(poolId));
+        assertEq(voteWeight, STONX_AMOUNT);
+        assertEq(votedSwapFee, SWAP_FEE);
+        assertEq(claimable0, 0);
+        assertEq(claimable1, 0);
+        assertEq(poolVoteState.totalWeight(), STONX_AMOUNT);
+        assertEq(poolVoteState.swapFee(), SWAP_FEE);
+        assertEq(ve33.poolFeeWeightSum(poolId), uint192(uint256(STONX_AMOUNT) * SWAP_FEE));
+        assertEq(ve33.totalVoteWeight(), STONX_AMOUNT);
+    }
+
+    function _assertEmissionState(uint128 scheduledAmount) private view {
+        Ve33EmissionRateConfig config = scheduler.config();
+
+        assertGt(scheduledAmount, 0);
+        assertEq(config.targetRate(), EMISSION_RATE);
+        assertEq(config.scheduleDuration(), 3 days);
+        assertEq(ve33.emissionRate(), EMISSION_RATE);
+        assertEq(stonx.totalSupply(), uint256(STONX_AMOUNT) * 2 + scheduledAmount);
+    }
+
+    function _assertEmissionsReachPosition(PoolKey memory poolKey, uint256 positionId) private {
+        vm.warp(block.timestamp + 1 days);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(BaseNonfungibleToken.NotUnauthorizedForToken.selector, address(this), positionId)
+        );
+        ve33Positions.claimRewards(positionId, poolKey, POSITION_TICK_LOWER, POSITION_TICK_UPPER, address(this));
+
+        // Governance owns the position NFT and is the only initially authorized reward claimant.
+        vm.prank(owner);
+        uint256 claimed =
+            ve33Positions.claimRewards(positionId, poolKey, POSITION_TICK_LOWER, POSITION_TICK_UPPER, owner);
+
+        assertGt(claimed, 0);
+        assertEq(stonx.balanceOf(owner), claimed);
     }
 }

--- a/test/DeploySTONX.t.sol
+++ b/test/DeploySTONX.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: ekubo-license-v1.eth
+pragma solidity =0.8.33;
+
+import {FullTest} from "./FullTest.sol";
+import {DeploySTONX} from "../script/DeploySTONX.s.sol";
+import {MintableERC20} from "../src/MintableERC20.sol";
+import {Ve33, ve33CallPoints} from "../src/extensions/Ve33.sol";
+import {Ve33Positions} from "../src/Ve33Positions.sol";
+import {PoolKey} from "../src/types/poolKey.sol";
+
+contract DeploySTONXHarness is DeploySTONX {
+    function seedLiquidity(MintableERC20 stonx, Ve33 ve33, Ve33Positions positions, address usdg, address governance)
+        external
+        returns (uint256 positionId)
+    {
+        positionId = _seedLiquidity(stonx, ve33, positions, usdg, address(this), governance);
+    }
+
+    function stonxPoolKey(address stonx, address usdg, address ve33) external pure returns (PoolKey memory) {
+        return _stonxPoolKey(stonx, usdg, ve33);
+    }
+}
+
+contract DeploySTONXTest is FullTest {
+    uint128 private constant STONX_AMOUNT = 333_333e18;
+    uint128 private constant USDG_AMOUNT = 333_333e6;
+
+    DeploySTONXHarness private deployer;
+    MintableERC20 private stonx;
+    Ve33 private ve33;
+    Ve33Positions private ve33Positions;
+
+    function setUp() public override {
+        super.setUp();
+
+        deployer = new DeploySTONXHarness();
+        stonx = new MintableERC20(address(this), "Ekubo Stock Liquidity Token", "STONX");
+        address ve33Address = address(uint160(ve33CallPoints().toUint8()) << 152);
+        deployCodeTo("Ve33.sol:Ve33", abi.encode(core, stonx), ve33Address);
+        ve33 = Ve33(payable(ve33Address));
+        ve33Positions = new Ve33Positions(core, ve33, address(this));
+
+        stonx.mint(address(deployer), STONX_AMOUNT);
+    }
+
+    function test_seedLiquidityWhenSTONXIsToken0() public {
+        _testSeedLiquidity(address(type(uint160).max - 1));
+    }
+
+    function test_seedLiquidityWhenSTONXIsToken1() public {
+        _testSeedLiquidity(address(0x10000));
+    }
+
+    function _testSeedLiquidity(address usdgAddress) private {
+        deployCodeTo("MintableERC20.sol:MintableERC20", abi.encode(address(this), "USDG", "USDG"), usdgAddress);
+        MintableERC20 usdg = MintableERC20(usdgAddress);
+        usdg.mint(address(deployer), USDG_AMOUNT);
+
+        uint256 positionId = deployer.seedLiquidity(stonx, ve33, ve33Positions, usdgAddress, owner);
+        PoolKey memory poolKey = deployer.stonxPoolKey(address(stonx), usdgAddress, address(ve33));
+        (uint128 liquidity,,) = ve33Positions.getPositionLiquidity(positionId, poolKey, -88_722_432, 88_722_432);
+
+        assertEq(ve33Positions.ownerOf(positionId), owner);
+        assertEq(usdg.balanceOf(address(deployer)), 0);
+        assertLe(stonx.balanceOf(address(deployer)), STONX_AMOUNT);
+        assertGt(liquidity, 0);
+    }
+}


### PR DESCRIPTION
## Summary

- add an RHC-only STONX deployment script built on DeployVe33
- deploy the STONX Ve33, VeToken, positions, periphery, and data fetcher contracts
- seed a full-range STONX/USDG position at the decimal-adjusted one-dollar price and transfer it to governance
- max-duration stake the deployer allocation and vote its full weight to the seeded pool at a 0.3% swap fee
- transfer contract ownership, then configure and start the 333.333 STONX/day three-day emission schedule only after liquidity and voting are live
- validate both token address orderings, ownership and metadata, pool liquidity, stake/vote state, emission state, governance-only reward authorization, and a successful reward claim

## Testing

- forge build --offline
- forge test --offline (975 tests passed)
- forge snapshot --offline (975 tests passed)