### PR TITLE
Withdraw Ve33 pool tokens before rewards

### DIFF
--- a/snapshots/Ve33Test.json
+++ b/snapshots/Ve33Test.json
@@ -14,8 +14,8 @@
   "Ve33Forwarder#moveStake": "39275",
   "Ve33Forwarder#stake": "101642",
   "Ve33Periphery#scheduleEmissions": "125470",
-  "Ve33Positions#claimAccruedEmissions": "118184",
-  "Ve33Positions#claimRewards": "46046",
+  "Ve33Positions#claimAccruedEmissions": "118257",
+  "Ve33Positions#claimRewards": "46119",
   "Ve33Positions#deposit": "404962",
   "VeToken#claimPoolFees": "59715",
   "VeToken#vote": "139863"

--- a/src/Ve33Positions.sol
+++ b/src/Ve33Positions.sol
@@ -402,13 +402,16 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
             if (liquidity > uint128(type(int128).max)) revert WithdrawOverflow();
 
             PositionId positionId_ = positionId(id, tickLower, tickUpper);
-            uint128 rewardAmount = _claimRewards(poolKey, positionId_, recipient);
+            uint128 rewardAmount = uint128(Ve33Lib.claimRewards(CORE, ve33, poolKey, positionId_));
 
             PoolBalanceUpdate balanceUpdate = CORE.updatePosition(poolKey, positionId_, -int128(liquidity));
             uint128 amount0 = uint128(-balanceUpdate.delta0());
             uint128 amount1 = uint128(-balanceUpdate.delta1());
 
             ACCOUNTANT.withdrawTwo(poolKey.token0, poolKey.token1, recipient, amount0, amount1);
+            if (rewardAmount != 0) {
+                ACCOUNTANT.withdraw(stakeToken, recipient, rewardAmount);
+            }
             result = abi.encode(amount0, amount1, rewardAmount);
         } else if (callType == CALL_TYPE_CLAIM_REWARDS) {
             (, PoolKey memory poolKey, PositionId positionId_, address recipient) =

--- a/src/Ve33Positions.sol
+++ b/src/Ve33Positions.sol
@@ -418,19 +418,13 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
                 abi.decode(data, (uint256, PoolKey, PositionId, address));
 
             _validateVe33Pool(poolKey);
-            result = abi.encode(_claimRewards(poolKey, positionId_, recipient));
+            uint128 rewardAmount = uint128(Ve33Lib.claimRewards(CORE, ve33, poolKey, positionId_));
+            if (rewardAmount != 0) {
+                ACCOUNTANT.withdraw(stakeToken, recipient, rewardAmount);
+            }
+            result = abi.encode(rewardAmount);
         } else {
             revert();
-        }
-    }
-
-    function _claimRewards(PoolKey memory poolKey, PositionId positionId_, address recipient)
-        private
-        returns (uint128 amount)
-    {
-        amount = uint128(Ve33Lib.claimRewards(CORE, ve33, poolKey, positionId_));
-        if (amount != 0) {
-            ACCOUNTANT.withdraw(stakeToken, recipient, amount);
         }
     }
 

--- a/test/extensions/Ve33.t.sol
+++ b/test/extensions/Ve33.t.sol
@@ -1482,12 +1482,29 @@ contract Ve33Test is FullTest {
         uint256 token1BalanceBefore = token1.balanceOf(recipient);
         uint256 rewardBalanceBefore = stakeToken.balanceOf(recipient);
 
+        vm.recordLogs();
         (uint128 amount0, uint128 amount1, uint256 rewardAmount) =
             vePositions.withdrawAndClaimRewards(id, poolKey, tickLower, tickUpper, liquidity, recipient);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        address[3] memory expectedTransferOrder = [poolKey.token0, poolKey.token1, address(stakeToken)];
+        uint256 recipientTransferCount;
+        bytes32 transferEventSignature = keccak256("Transfer(address,address,uint256)");
+        for (uint256 i = 0; i < logs.length; i++) {
+            Vm.Log memory log = logs[i];
+            if (
+                log.topics.length == 3 && log.topics[0] == transferEventSignature
+                    && address(uint160(uint256(log.topics[2]))) == recipient
+            ) {
+                assertEq(log.emitter, expectedTransferOrder[recipientTransferCount]);
+                recipientTransferCount++;
+            }
+        }
 
         assertGt(amount0, 0);
         assertGt(amount1, 0);
         assertEq(rewardAmount, claimableRewardAmount);
+        assertEq(recipientTransferCount, expectedTransferOrder.length);
         assertEq(token0.balanceOf(recipient), token0BalanceBefore + amount0);
         assertEq(token1.balanceOf(recipient), token1BalanceBefore + amount1);
         assertEq(stakeToken.balanceOf(recipient), rewardBalanceBefore + rewardAmount);


### PR DESCRIPTION
## Summary

- inline reward accounting in the combined Ve33Positions withdraw-and-claim path
- withdraw token0 and token1 before transferring the reward token
- preserve the standalone reward claim path
- assert the recipient transfer order is token0, token1, then reward

## Testing

- forge build --offline
- forge test --offline (973 tests passed)
- forge snapshot --offline (973 tests passed)