### PR TITLE
Schedule initial STONX emissions through Ve33 periphery

### DIFF
--- a/script/DeploySTONX.s.sol
+++ b/script/DeploySTONX.s.sol
@@ -9,10 +9,12 @@ import {MintableERC20} from "../src/MintableERC20.sol";
 import {Ve33} from "../src/extensions/Ve33.sol";
 import {ICore} from "../src/interfaces/ICore.sol";
 import {Ve33EmissionRateScheduler} from "../src/Ve33EmissionRateScheduler.sol";
+import {Ve33Periphery} from "../src/Ve33Periphery.sol";
 import {Ve33Positions} from "../src/Ve33Positions.sol";
 import {VeToken} from "../src/VeToken.sol";
 import {CoreLib} from "../src/libraries/CoreLib.sol";
 import {sqrtRatioToTick} from "../src/math/ticks.sol";
+import {nextValidTime} from "../src/math/time.sol";
 import {PoolKey} from "../src/types/poolKey.sol";
 import {createConcentratedPoolConfig} from "../src/types/poolConfig.sol";
 import {toSqrtRatio} from "../src/types/sqrtRatio.sol";
@@ -36,12 +38,16 @@ contract DeploySTONX is DeployVe33 {
     int32 internal constant POSITION_TICK_LOWER = -88_722_432;
     int32 internal constant POSITION_TICK_UPPER = 88_722_432;
     uint64 internal constant SWAP_FEE = uint64((uint256(type(uint64).max) * 30) / 10_000);
+    uint128 internal constant INITIAL_EMISSION_AMOUNT = 333_333e18;
+    uint32 internal constant INITIAL_EMISSION_DURATION = 100 days;
     uint32 internal constant EMISSION_SCHEDULE_DURATION = 3 days;
-    uint160 internal constant EMISSION_RATE = uint160(uint256(333_333e15) * (1 << 32) / 1 days);
+    uint160 internal constant INITIAL_EMISSION_RATE =
+        uint160((uint256(INITIAL_EMISSION_AMOUNT) << 32) / INITIAL_EMISSION_DURATION);
 
     error InvalidChainId(uint256 chainId);
     error PoolHasNoLiquidity();
     error NoEmissionsScheduled();
+    error UnexpectedScheduledEmissionAmount(uint128 expected, uint128 actual);
     error USDGNotFullySpent(uint128 spent);
 
     function run() public override {
@@ -60,6 +66,7 @@ contract DeploySTONX is DeployVe33 {
 
         Ve33Deployment memory deployment = _deployVe33(core, deployer, salt);
         MintableERC20 stonx = MintableERC20(deployment.stakeToken);
+        Ve33Periphery periphery = Ve33Periphery(payable(_ve33PeripheryAddress(core, deployment.ve33, salt)));
 
         stonx.mint(deployer, DEPLOYER_TOKEN_AMOUNT);
         stonx.mint(deployer, LIQUIDITY_TOKEN_AMOUNT);
@@ -69,7 +76,7 @@ contract DeploySTONX is DeployVe33 {
         uint256 veId = _stakeAndVote(stonx, deployment.veToken, core, poolKey, nftSalt);
         deployment.positions.transferOwnership(governance);
         (address schedulerAddress, uint128 scheduledAmount) =
-            _deployScheduler(stonx, deployment.ve33, core, salt, deployer, governance);
+            _deployScheduler(stonx, deployment.ve33, periphery, core, salt, deployer, governance);
 
         console2.log("STONX", address(stonx));
         console2.log("STONX/USDG Ve33 position", positionId);
@@ -132,6 +139,7 @@ contract DeploySTONX is DeployVe33 {
     function _deployScheduler(
         MintableERC20 stonx,
         Ve33 ve33,
+        Ve33Periphery periphery,
         ICore core,
         bytes32 salt,
         address deployer,
@@ -144,22 +152,37 @@ contract DeploySTONX is DeployVe33 {
             "Ve33EmissionRateScheduler"
         );
         Ve33EmissionRateScheduler scheduler = Ve33EmissionRateScheduler(payable(schedulerAddress));
-        scheduledAmount = _configureAndStartScheduler(stonx, scheduler, governance);
+        scheduledAmount = _scheduleInitialEmissions(stonx, periphery, deployer);
+        _configureScheduler(stonx, scheduler, governance);
     }
 
-    function _configureAndStartScheduler(MintableERC20 stonx, Ve33EmissionRateScheduler scheduler, address governance)
+    function _scheduleInitialEmissions(MintableERC20 stonx, Ve33Periphery periphery, address emissionFunder)
         internal
         returns (uint128 scheduledAmount)
     {
-        bytes[] memory calls = new bytes[](3);
-        calls[0] = abi.encodeCall(scheduler.setConfig, (EMISSION_RATE, EMISSION_SCHEDULE_DURATION));
+        uint64 emissionEnd =
+            uint64(nextValidTime(block.timestamp, block.timestamp + uint256(INITIAL_EMISSION_DURATION) - 1));
+        uint128 emissionAmount =
+            uint128((((emissionEnd - block.timestamp) * uint256(INITIAL_EMISSION_RATE)) + type(uint32).max) >> 32);
+
+        stonx.mint(emissionFunder, emissionAmount);
+        stonx.approve(address(periphery), emissionAmount);
+        scheduledAmount = periphery.scheduleEmissions(0, emissionEnd, INITIAL_EMISSION_RATE);
+        if (scheduledAmount == 0) revert NoEmissionsScheduled();
+        if (scheduledAmount != emissionAmount) {
+            revert UnexpectedScheduledEmissionAmount(emissionAmount, scheduledAmount);
+        }
+    }
+
+    function _configureScheduler(MintableERC20 stonx, Ve33EmissionRateScheduler scheduler, address governance)
+        internal
+    {
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeCall(scheduler.setConfig, (INITIAL_EMISSION_RATE, EMISSION_SCHEDULE_DURATION));
         calls[1] = abi.encodeCall(scheduler.transferOwnership, (governance));
-        calls[2] = abi.encodeCall(scheduler.mintAndSchedule, ());
 
         stonx.transferOwnership(address(scheduler));
-        bytes[] memory results = scheduler.multicall(calls);
-        scheduledAmount = abi.decode(results[2], (uint128));
-        if (scheduledAmount == 0) revert NoEmissionsScheduled();
+        scheduler.multicall(calls);
     }
 
     function _stakeToken(address owner, bytes32 salt)

--- a/script/DeploySTONX.s.sol
+++ b/script/DeploySTONX.s.sol
@@ -43,6 +43,9 @@ contract DeploySTONX is DeployVe33 {
     uint32 internal constant EMISSION_SCHEDULE_DURATION = 3 days;
     uint160 internal constant INITIAL_EMISSION_RATE =
         uint160((uint256(INITIAL_EMISSION_AMOUNT) << 32) / INITIAL_EMISSION_DURATION);
+    uint128 internal constant SCHEDULER_DAILY_EMISSION_AMOUNT = 333_333e15;
+    uint160 internal constant SCHEDULER_EMISSION_RATE =
+        uint160((uint256(SCHEDULER_DAILY_EMISSION_AMOUNT) << 32) / 1 days);
 
     error InvalidChainId(uint256 chainId);
     error PoolHasNoLiquidity();
@@ -178,7 +181,7 @@ contract DeploySTONX is DeployVe33 {
         internal
     {
         bytes[] memory calls = new bytes[](2);
-        calls[0] = abi.encodeCall(scheduler.setConfig, (INITIAL_EMISSION_RATE, EMISSION_SCHEDULE_DURATION));
+        calls[0] = abi.encodeCall(scheduler.setConfig, (SCHEDULER_EMISSION_RATE, EMISSION_SCHEDULE_DURATION));
         calls[1] = abi.encodeCall(scheduler.transferOwnership, (governance));
 
         stonx.transferOwnership(address(scheduler));

--- a/script/DeploySTONX.s.sol
+++ b/script/DeploySTONX.s.sol
@@ -41,8 +41,6 @@ contract DeploySTONX is DeployVe33 {
     uint128 internal constant INITIAL_EMISSION_AMOUNT = 333_333e18;
     uint32 internal constant INITIAL_EMISSION_DURATION = 100 days;
     uint32 internal constant EMISSION_SCHEDULE_DURATION = 3 days;
-    uint160 internal constant INITIAL_EMISSION_RATE =
-        uint160((uint256(INITIAL_EMISSION_AMOUNT) << 32) / INITIAL_EMISSION_DURATION);
     uint128 internal constant SCHEDULER_DAILY_EMISSION_AMOUNT = 333_333e15;
     uint160 internal constant SCHEDULER_EMISSION_RATE =
         uint160((uint256(SCHEDULER_DAILY_EMISSION_AMOUNT) << 32) / 1 days);
@@ -165,15 +163,14 @@ contract DeploySTONX is DeployVe33 {
     {
         uint64 emissionEnd =
             uint64(nextValidTime(block.timestamp, block.timestamp + uint256(INITIAL_EMISSION_DURATION) - 1));
-        uint128 emissionAmount =
-            uint128((((emissionEnd - block.timestamp) * uint256(INITIAL_EMISSION_RATE)) + type(uint32).max) >> 32);
+        uint160 emissionRate = uint160((uint256(INITIAL_EMISSION_AMOUNT) << 32) / (emissionEnd - block.timestamp));
 
-        stonx.mint(emissionFunder, emissionAmount);
-        stonx.approve(address(periphery), emissionAmount);
-        scheduledAmount = periphery.scheduleEmissions(0, emissionEnd, INITIAL_EMISSION_RATE);
+        stonx.mint(emissionFunder, INITIAL_EMISSION_AMOUNT);
+        stonx.approve(address(periphery), INITIAL_EMISSION_AMOUNT);
+        scheduledAmount = periphery.scheduleEmissions(0, emissionEnd, emissionRate);
         if (scheduledAmount == 0) revert NoEmissionsScheduled();
-        if (scheduledAmount != emissionAmount) {
-            revert UnexpectedScheduledEmissionAmount(emissionAmount, scheduledAmount);
+        if (scheduledAmount != INITIAL_EMISSION_AMOUNT) {
+            revert UnexpectedScheduledEmissionAmount(INITIAL_EMISSION_AMOUNT, scheduledAmount);
         }
     }
 

--- a/script/DeployVe33.s.sol
+++ b/script/DeployVe33.s.sol
@@ -12,7 +12,7 @@ import {VeTokenMetadata} from "../src/VeTokenMetadata.sol";
 import {Ve33DataFetcher} from "../src/lens/Ve33DataFetcher.sol";
 import {MintableERC20} from "../src/MintableERC20.sol";
 import {NATIVE_TOKEN_ADDRESS} from "../src/math/constants.sol";
-import {deployExtension, deployIfNeeded} from "./DeployAll.s.sol";
+import {deployExtension, deployIfNeeded, getCreate2Address} from "./DeployAll.s.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 
 struct Ve33Deployment {
@@ -130,16 +130,28 @@ contract DeployVe33 is Script {
     }
 
     function _deployVe33Support(ICore core, Ve33 ve33, bytes32 salt) internal {
+        _deployVe33Periphery(core, ve33, salt);
+
         deployIfNeeded(
+            abi.encodePacked(type(Ve33DataFetcher).creationCode, abi.encode(ve33)), salt, address(0), "Ve33DataFetcher"
+        );
+    }
+
+    function _deployVe33Periphery(ICore core, Ve33 ve33, bytes32 salt) internal returns (Ve33Periphery periphery) {
+        (address peripheryAddress,) = deployIfNeeded(
             abi.encodePacked(type(Ve33Periphery).creationCode, abi.encode(core, ve33)),
             salt,
             address(0),
             "Ve33Periphery"
         );
+        periphery = Ve33Periphery(payable(peripheryAddress));
+    }
 
-        deployIfNeeded(
-            abi.encodePacked(type(Ve33DataFetcher).creationCode, abi.encode(ve33)), salt, address(0), "Ve33DataFetcher"
-        );
+    function _ve33PeripheryAddress(ICore core, Ve33 ve33, bytes32 salt) internal pure returns (address) {
+        return
+            getCreate2Address(
+                salt, keccak256(abi.encodePacked(type(Ve33Periphery).creationCode, abi.encode(core, ve33)))
+            );
     }
 
     function _stakeToken(address owner, bytes32 salt)

--- a/snapshots/Ve33Test.json
+++ b/snapshots/Ve33Test.json
@@ -13,7 +13,7 @@
   "Ve33#vote one pool": "139863",
   "Ve33Forwarder#moveStake": "39275",
   "Ve33Forwarder#stake": "101642",
-  "Ve33Periphery#scheduleEmissions": "125470",
+  "Ve33Periphery#scheduleEmissions": "125383",
   "Ve33Positions#claimAccruedEmissions": "118257",
   "Ve33Positions#claimRewards": "46119",
   "Ve33Positions#deposit": "404962",

--- a/src/Ve33EmissionRateScheduler.sol
+++ b/src/Ve33EmissionRateScheduler.sol
@@ -8,7 +8,7 @@ import {ICore} from "./interfaces/ICore.sol";
 import {IFlashAccountant} from "./interfaces/IFlashAccountant.sol";
 import {IMintableERC20} from "./interfaces/IMintableERC20.sol";
 import {Ve33Lib} from "./libraries/Ve33Lib.sol";
-import {nextValidTime} from "./math/time.sol";
+import {computeStepSize} from "./math/time.sol";
 import {Ve33EmissionRateConfig, createVe33EmissionRateConfig} from "./types/ve33EmissionRateConfig.sol";
 
 /// @title Ve33 Emission Rate Scheduler
@@ -28,14 +28,11 @@ contract Ve33EmissionRateScheduler is BaseLocker, BaseOwnableExecutor {
     /// @notice Mintable token used as the Ve33 stake/reward token.
     IMintableERC20 public immutable token;
 
-    /// @notice Packed target emission rate and schedule duration.
+    /// @notice Packed target emission rate and maximum schedule duration.
     Ve33EmissionRateConfig public config;
 
     /// @notice Emitted when the owner updates scheduler config.
     event ConfigSet(uint160 targetRate, uint32 scheduleDuration);
-
-    /// @notice Emitted when tokens are minted and scheduled to cover a rate shortfall.
-    event EmissionsMintedAndScheduled(uint64 endTime, uint160 rewardRate, uint128 amount);
 
     /// @notice Initializes the scheduler.
     /// @param owner Initial owner authorized to configure the target rate and duration.
@@ -47,9 +44,9 @@ contract Ve33EmissionRateScheduler is BaseLocker, BaseOwnableExecutor {
         token = IMintableERC20(_ve33.stakeToken());
     }
 
-    /// @notice Sets the target global Q32 emission rate and schedule duration.
+    /// @notice Sets the target global Q32 emission rate and maximum schedule duration.
     /// @param targetRate Target global Q32 emission rate.
-    /// @param scheduleDuration Schedule duration in seconds.
+    /// @param scheduleDuration Maximum schedule duration in seconds.
     function setConfig(uint160 targetRate, uint32 scheduleDuration) external onlyOwner {
         if (targetRate != 0 && scheduleDuration == 0) revert InvalidScheduleDuration();
 
@@ -76,7 +73,10 @@ contract Ve33EmissionRateScheduler is BaseLocker, BaseOwnableExecutor {
         if (duration == 0) revert InvalidScheduleDuration();
 
         uint64 nowTime = uint64(block.timestamp);
-        uint64 horizon = uint64(nextValidTime(nowTime, nowTime + uint256(duration) - 1));
+        uint256 maxEndTime = block.timestamp + uint256(duration);
+        uint256 stepSize = computeStepSize(block.timestamp, maxEndTime);
+        uint64 horizon = uint64(maxEndTime - (maxEndTime % stepSize));
+        if (horizon <= nowTime) return abi.encode(uint128(0));
 
         ve33.accrueEmissions();
 
@@ -97,7 +97,6 @@ contract Ve33EmissionRateScheduler is BaseLocker, BaseOwnableExecutor {
                 uint64 startTime = cursor == nowTime ? 0 : cursor;
                 uint128 scheduleAmount = Ve33Lib.scheduleEmissions(core, ve33, startTime, intervalEnd, shortfall);
                 totalAmount += scheduleAmount;
-                emit EmissionsMintedAndScheduled(intervalEnd, shortfall, scheduleAmount);
                 projectedRate = target;
             }
 

--- a/src/Ve33Periphery.sol
+++ b/src/Ve33Periphery.sol
@@ -15,8 +15,6 @@ import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 contract Ve33Periphery is PayableMulticallable, BaseLocker {
     using FlashAccountantLib for *;
 
-    uint256 private constant CALL_TYPE_SCHEDULE_EMISSIONS = 0;
-
     ICore private immutable CORE_REF;
 
     Ve33 public immutable ve33;
@@ -45,28 +43,17 @@ contract Ve33Periphery is PayableMulticallable, BaseLocker {
         payable
         returns (uint128 amount)
     {
-        amount = abi.decode(
-            lock(abi.encode(CALL_TYPE_SCHEDULE_EMISSIONS, msg.sender, startTime, endTime, rewardRate)), (uint128)
-        );
+        amount = abi.decode(lock(abi.encode(msg.sender, startTime, endTime, rewardRate)), (uint128));
     }
 
     /// @inheritdoc BaseLocker
     function handleLockData(uint256, bytes memory data) internal override returns (bytes memory result) {
-        uint256 callType = abi.decode(data, (uint256));
+        (address payer, uint64 startTime, uint64 endTime, uint160 rewardRate) =
+            abi.decode(data, (address, uint64, uint64, uint160));
+        uint128 amount = Ve33Lib.scheduleEmissions(CORE_REF, ve33, startTime, endTime, rewardRate);
+        result = abi.encode(amount);
 
-        if (callType == CALL_TYPE_SCHEDULE_EMISSIONS) {
-            (, address payer, uint64 startTime, uint64 endTime, uint160 rewardRate) =
-                abi.decode(data, (uint256, address, uint64, uint64, uint160));
-            uint128 amount = Ve33Lib.scheduleEmissions(CORE_REF, ve33, startTime, endTime, rewardRate);
-            result = abi.encode(amount);
-            _payStakeToken(payer, amount);
-        } else {
-            revert();
-        }
-    }
-
-    function _payStakeToken(address payer, uint128 amount) private {
-        if (amount == 0) return;
+        if (amount == 0) return result;
 
         if (stakeToken == NATIVE_TOKEN_ADDRESS) {
             SafeTransferLib.safeTransferETH(address(ACCOUNTANT), amount);

--- a/test/DeploySTONX.t.sol
+++ b/test/DeploySTONX.t.sol
@@ -58,6 +58,9 @@ contract DeploySTONXTest is FullTest {
     uint32 private constant INITIAL_EMISSION_DURATION = 100 days;
     uint160 private constant INITIAL_EMISSION_RATE =
         uint160((uint256(INITIAL_EMISSION_AMOUNT) << 32) / INITIAL_EMISSION_DURATION);
+    uint128 private constant SCHEDULER_DAILY_EMISSION_AMOUNT = 333_333e15;
+    uint160 private constant SCHEDULER_EMISSION_RATE =
+        uint160((uint256(SCHEDULER_DAILY_EMISSION_AMOUNT) << 32) / 1 days);
 
     DeploySTONXHarness private deployer;
     MintableERC20 private stonx;
@@ -194,18 +197,20 @@ contract DeploySTONXTest is FullTest {
 
         assertEq(scheduledAmount, expectedScheduledAmount);
         assertEq(savedStakeAndEmissions, STONX_AMOUNT + scheduledAmount);
-        assertEq(config.targetRate(), INITIAL_EMISSION_RATE);
+        assertEq(config.targetRate(), SCHEDULER_EMISSION_RATE);
         assertEq(config.scheduleDuration(), 3 days);
         assertEq(ve33.emissionRate(), INITIAL_EMISSION_RATE);
         assertGe(emissionEnd, block.timestamp + INITIAL_EMISSION_DURATION);
         assertEq(rateDelta, -int256(uint256(INITIAL_EMISSION_RATE)));
         assertApproxEqAbs((uint256(INITIAL_EMISSION_RATE) * 1 days) >> 32, 3_333_33e16, 1);
+        assertApproxEqAbs((uint256(SCHEDULER_EMISSION_RATE) * 1 days) >> 32, SCHEDULER_DAILY_EMISSION_AMOUNT, 1);
         assertEq(stonx.totalSupply(), uint256(STONX_AMOUNT) * 2 + scheduledAmount);
     }
 
     function _assertSchedulerInitiallyNoops() private {
         uint256 initialTimestamp = block.timestamp;
         uint256 initialSupply = stonx.totalSupply();
+        (uint64 initialEmissionEnd,) = ve33.nextEmissionRateChangeTime(initialTimestamp);
 
         assertEq(scheduler.mintAndSchedule(), 0);
 
@@ -213,6 +218,10 @@ contract DeploySTONXTest is FullTest {
         assertEq(scheduler.mintAndSchedule(), 0);
         assertEq(stonx.totalSupply(), initialSupply);
         assertEq(ve33.emissionRate(), INITIAL_EMISSION_RATE);
+
+        vm.warp(initialEmissionEnd);
+        assertGt(scheduler.mintAndSchedule(), 0);
+        assertEq(ve33.emissionRate(), SCHEDULER_EMISSION_RATE);
     }
 
     function _assertEmissionsReachPosition(PoolKey memory poolKey, uint256 positionId) private {

--- a/test/DeploySTONX.t.sol
+++ b/test/DeploySTONX.t.sol
@@ -5,7 +5,7 @@ import {FullTest} from "./FullTest.sol";
 import {DeploySTONX} from "../script/DeploySTONX.s.sol";
 import {MintableERC20} from "../src/MintableERC20.sol";
 import {BaseNonfungibleToken} from "../src/base/BaseNonfungibleToken.sol";
-import {Ve33, ve33CallPoints} from "../src/extensions/Ve33.sol";
+import {Ve33, VE33_STAKE_TOKEN_SAVED_BALANCE_ID, ve33CallPoints} from "../src/extensions/Ve33.sol";
 import {ICore} from "../src/interfaces/ICore.sol";
 import {CoreLib} from "../src/libraries/CoreLib.sol";
 import {Ve33Lib} from "../src/libraries/Ve33Lib.sol";
@@ -30,6 +30,7 @@ contract DeploySTONXHarness is DeploySTONX {
         Ve33 ve33,
         VeToken veToken,
         Ve33Positions positions,
+        Ve33Periphery periphery,
         Ve33EmissionRateScheduler scheduler,
         ICore core,
         address usdg,
@@ -39,7 +40,8 @@ contract DeploySTONXHarness is DeploySTONX {
         positionId = _seedLiquidity(stonx, positions, poolKey, usdg, address(this), governance, bytes32(0));
         veId = _stakeAndVote(stonx, veToken, core, poolKey, bytes32(0));
         positions.transferOwnership(governance);
-        scheduledAmount = _configureAndStartScheduler(stonx, scheduler, governance);
+        scheduledAmount = _scheduleInitialEmissions(stonx, periphery, address(this));
+        _configureScheduler(stonx, scheduler, governance);
     }
 }
 
@@ -52,7 +54,10 @@ contract DeploySTONXTest is FullTest {
     int32 private constant POSITION_TICK_LOWER = -88_722_432;
     int32 private constant POSITION_TICK_UPPER = 88_722_432;
     uint64 private constant SWAP_FEE = uint64((uint256(type(uint64).max) * 30) / 10_000);
-    uint160 private constant EMISSION_RATE = uint160(uint256(333_333e15) * (1 << 32) / 1 days);
+    uint128 private constant INITIAL_EMISSION_AMOUNT = 333_333e18;
+    uint32 private constant INITIAL_EMISSION_DURATION = 100 days;
+    uint160 private constant INITIAL_EMISSION_RATE =
+        uint160((uint256(INITIAL_EMISSION_AMOUNT) << 32) / INITIAL_EMISSION_DURATION);
 
     DeploySTONXHarness private deployer;
     MintableERC20 private stonx;
@@ -104,13 +109,14 @@ contract DeploySTONXTest is FullTest {
         uint128 scheduledAmount;
         PoolKey memory poolKey;
         (poolKey, positionId, veId, scheduledAmount) =
-            deployer.initialize(stonx, ve33, veToken, ve33Positions, scheduler, core, usdgAddress, owner);
+            deployer.initialize(stonx, ve33, veToken, ve33Positions, periphery, scheduler, core, usdgAddress, owner);
         PoolId poolId = poolKey.toPoolId();
 
         _assertDeploymentOwnership(positionId, veId);
         _assertPositionAndPoolState(poolKey, poolId, positionId, usdg);
         _assertStakeAndVoteState(poolId, veId);
         _assertEmissionState(scheduledAmount);
+        _assertSchedulerInitiallyNoops();
         _assertEmissionsReachPosition(poolKey, positionId);
     }
 
@@ -179,12 +185,34 @@ contract DeploySTONXTest is FullTest {
 
     function _assertEmissionState(uint128 scheduledAmount) private view {
         Ve33EmissionRateConfig config = scheduler.config();
+        (uint64 emissionEnd, int256 rateDelta) = ve33.nextEmissionRateChangeTime(block.timestamp);
+        uint128 expectedScheduledAmount =
+            uint128((((emissionEnd - block.timestamp) * uint256(INITIAL_EMISSION_RATE)) + type(uint32).max) >> 32);
+        (uint128 savedStakeAndEmissions,) = core.savedBalances(
+            address(ve33), address(stonx), address(type(uint160).max), VE33_STAKE_TOKEN_SAVED_BALANCE_ID
+        );
 
-        assertGt(scheduledAmount, 0);
-        assertEq(config.targetRate(), EMISSION_RATE);
+        assertEq(scheduledAmount, expectedScheduledAmount);
+        assertEq(savedStakeAndEmissions, STONX_AMOUNT + scheduledAmount);
+        assertEq(config.targetRate(), INITIAL_EMISSION_RATE);
         assertEq(config.scheduleDuration(), 3 days);
-        assertEq(ve33.emissionRate(), EMISSION_RATE);
+        assertEq(ve33.emissionRate(), INITIAL_EMISSION_RATE);
+        assertGe(emissionEnd, block.timestamp + INITIAL_EMISSION_DURATION);
+        assertEq(rateDelta, -int256(uint256(INITIAL_EMISSION_RATE)));
+        assertApproxEqAbs((uint256(INITIAL_EMISSION_RATE) * 1 days) >> 32, 3_333_33e16, 1);
         assertEq(stonx.totalSupply(), uint256(STONX_AMOUNT) * 2 + scheduledAmount);
+    }
+
+    function _assertSchedulerInitiallyNoops() private {
+        uint256 initialTimestamp = block.timestamp;
+        uint256 initialSupply = stonx.totalSupply();
+
+        assertEq(scheduler.mintAndSchedule(), 0);
+
+        vm.warp(initialTimestamp + INITIAL_EMISSION_DURATION - 3 days);
+        assertEq(scheduler.mintAndSchedule(), 0);
+        assertEq(stonx.totalSupply(), initialSupply);
+        assertEq(ve33.emissionRate(), INITIAL_EMISSION_RATE);
     }
 
     function _assertEmissionsReachPosition(PoolKey memory poolKey, uint256 positionId) private {

--- a/test/DeploySTONX.t.sol
+++ b/test/DeploySTONX.t.sol
@@ -56,8 +56,6 @@ contract DeploySTONXTest is FullTest {
     uint64 private constant SWAP_FEE = uint64((uint256(type(uint64).max) * 30) / 10_000);
     uint128 private constant INITIAL_EMISSION_AMOUNT = 333_333e18;
     uint32 private constant INITIAL_EMISSION_DURATION = 100 days;
-    uint160 private constant INITIAL_EMISSION_RATE =
-        uint160((uint256(INITIAL_EMISSION_AMOUNT) << 32) / INITIAL_EMISSION_DURATION);
     uint128 private constant SCHEDULER_DAILY_EMISSION_AMOUNT = 333_333e15;
     uint160 private constant SCHEDULER_EMISSION_RATE =
         uint160((uint256(SCHEDULER_DAILY_EMISSION_AMOUNT) << 32) / 1 days);
@@ -189,20 +187,20 @@ contract DeploySTONXTest is FullTest {
     function _assertEmissionState(uint128 scheduledAmount) private view {
         Ve33EmissionRateConfig config = scheduler.config();
         (uint64 emissionEnd, int256 rateDelta) = ve33.nextEmissionRateChangeTime(block.timestamp);
-        uint128 expectedScheduledAmount =
-            uint128((((emissionEnd - block.timestamp) * uint256(INITIAL_EMISSION_RATE)) + type(uint32).max) >> 32);
+        uint160 initialEmissionRate = ve33.emissionRate();
         (uint128 savedStakeAndEmissions,) = core.savedBalances(
             address(ve33), address(stonx), address(type(uint160).max), VE33_STAKE_TOKEN_SAVED_BALANCE_ID
         );
 
-        assertEq(scheduledAmount, expectedScheduledAmount);
+        assertEq(scheduledAmount, INITIAL_EMISSION_AMOUNT);
         assertEq(savedStakeAndEmissions, STONX_AMOUNT + scheduledAmount);
         assertEq(config.targetRate(), SCHEDULER_EMISSION_RATE);
         assertEq(config.scheduleDuration(), 3 days);
-        assertEq(ve33.emissionRate(), INITIAL_EMISSION_RATE);
         assertGe(emissionEnd, block.timestamp + INITIAL_EMISSION_DURATION);
-        assertEq(rateDelta, -int256(uint256(INITIAL_EMISSION_RATE)));
-        assertApproxEqAbs((uint256(INITIAL_EMISSION_RATE) * 1 days) >> 32, 3_333_33e16, 1);
+        assertEq(
+            initialEmissionRate, uint160((uint256(INITIAL_EMISSION_AMOUNT) << 32) / (emissionEnd - block.timestamp))
+        );
+        assertEq(rateDelta, -int256(uint256(initialEmissionRate)));
         assertApproxEqAbs((uint256(SCHEDULER_EMISSION_RATE) * 1 days) >> 32, SCHEDULER_DAILY_EMISSION_AMOUNT, 1);
         assertEq(stonx.totalSupply(), uint256(STONX_AMOUNT) * 2 + scheduledAmount);
     }
@@ -211,15 +209,19 @@ contract DeploySTONXTest is FullTest {
         uint256 initialTimestamp = block.timestamp;
         uint256 initialSupply = stonx.totalSupply();
         (uint64 initialEmissionEnd,) = ve33.nextEmissionRateChangeTime(initialTimestamp);
+        uint160 initialEmissionRate = ve33.emissionRate();
 
         assertEq(scheduler.mintAndSchedule(), 0);
 
         vm.warp(initialTimestamp + INITIAL_EMISSION_DURATION - 3 days);
         assertEq(scheduler.mintAndSchedule(), 0);
         assertEq(stonx.totalSupply(), initialSupply);
-        assertEq(ve33.emissionRate(), INITIAL_EMISSION_RATE);
+        assertEq(ve33.emissionRate(), initialEmissionRate);
 
         vm.warp(initialEmissionEnd);
+        ve33.accrueEmissions();
+        assertEq(ve33.emissionRate(), 0);
+
         assertGt(scheduler.mintAndSchedule(), 0);
         assertEq(ve33.emissionRate(), SCHEDULER_EMISSION_RATE);
     }

--- a/test/Ve33EmissionRateScheduler.t.sol
+++ b/test/Ve33EmissionRateScheduler.t.sol
@@ -10,7 +10,7 @@ import {BaseLocker} from "../src/base/BaseLocker.sol";
 import {Ve33, VE33_STAKE_TOKEN_SAVED_BALANCE_ID, ve33CallPoints} from "../src/extensions/Ve33.sol";
 import {CoreLib} from "../src/libraries/CoreLib.sol";
 import {Ve33Lib} from "../src/libraries/Ve33Lib.sol";
-import {nextValidTime} from "../src/math/time.sol";
+import {computeStepSize, isTimeValid} from "../src/math/time.sol";
 import {Ve33EmissionRateConfig} from "../src/types/ve33EmissionRateConfig.sol";
 
 contract SchedulerCallRevertTarget {
@@ -97,6 +97,18 @@ contract Ve33EmissionRateSchedulerTest is FullTest {
         assertEq(ve.emissionRateDeltaAtTime(expectedEndTime), -int256(uint256(TARGET_RATE)));
     }
 
+    function test_mintAndScheduleNeverSchedulesPastConfiguredDuration() public {
+        vm.prank(owner);
+        scheduler.setConfig(TARGET_RATE, SCHEDULE_DURATION);
+
+        uint64 nowTime = uint64(vm.getBlockTimestamp());
+        scheduler.mintAndSchedule();
+
+        (uint64 endTime,) = ve.nextEmissionRateChangeTime(nowTime);
+        assertLe(endTime, nowTime + SCHEDULE_DURATION);
+        assertTrue(isTimeValid(nowTime, endTime));
+    }
+
     function test_mintAndScheduleReturnsZeroWhenCurrentRateAlreadyAtTarget() public {
         vm.prank(owner);
         scheduler.setConfig(TARGET_RATE, SCHEDULE_DURATION);
@@ -155,7 +167,9 @@ contract Ve33EmissionRateSchedulerTest is FullTest {
     }
 
     function _expectedEndTime(uint32 scheduleDuration) internal view returns (uint64) {
-        return uint64(nextValidTime(vm.getBlockTimestamp(), vm.getBlockTimestamp() + uint256(scheduleDuration) - 1));
+        uint256 maxEndTime = vm.getBlockTimestamp() + uint256(scheduleDuration);
+        uint256 stepSize = computeStepSize(vm.getBlockTimestamp(), maxEndTime);
+        return uint64(maxEndTime - (maxEndTime % stepSize));
     }
 
     function _scheduleAmount(uint160 rewardRate, uint64 endTime) internal view returns (uint128) {


### PR DESCRIPTION
## Summary
- schedule exactly 333,333 STONX through `Ve33Periphery` over the first valid emission window lasting at least 100 days
- derive the initial Q32 rate from the exact allocation and valid end timestamp
- configure the emission scheduler for 333.333 STONX per day with a three-day maximum horizon, leaving it as a no-op through the first 97 days
- require governance to explicitly raise the scheduler target if the initial emission rate should continue
- verify the global rate falls to zero when the initial schedule ends, then rises to the scheduler target only after `mintAndSchedule()` is called
- ensure scheduler-created schedules never end after `block.timestamp + scheduleDuration`
- remove the redundant scheduler emission event and simplify the single-purpose Ve33 periphery lock payload

## Verification
- `forge fmt`
- `forge build --offline`
- `forge test --offline` (976 tests)
- `forge script --offline DeployAll`
- `forge snapshot --offline`
