### PR TITLE
Add Ve33 quote data fetching

### DIFF
--- a/src/lens/Ve33DataFetcher.sol
+++ b/src/lens/Ve33DataFetcher.sol
@@ -6,6 +6,8 @@ import {IExposedStorage} from "../interfaces/IExposedStorage.sol";
 import {Ve33Lib} from "../libraries/Ve33Lib.sol";
 import {Ve33StorageLayout} from "../libraries/Ve33StorageLayout.sol";
 import {StorageSlot} from "../types/storageSlot.sol";
+import {PoolId} from "../types/poolId.sol";
+import {VePoolSwapFeeState} from "../types/vePoolSwapFeeState.sol";
 import {MAX_NUM_VALID_TIMES, nextValidTime} from "../math/time.sol";
 
 struct Ve33EmissionRateChange {
@@ -28,6 +30,17 @@ contract Ve33DataFetcher {
 
     constructor(Ve33 ve33) {
         VE33_EXTENSION = ve33;
+    }
+
+    /// @notice Returns the current voted swap fee for each requested pool.
+    /// @dev The returned fees use the same Q64 fixed-point representation consumed by Ve33 swaps.
+    function getPoolSwapFees(PoolId[] calldata poolIds) external view returns (uint64[] memory swapFees) {
+        Ve33 ve33 = VE33_EXTENSION;
+        swapFees = new uint64[](poolIds.length);
+
+        for (uint256 i = 0; i < poolIds.length; i++) {
+            swapFees[i] = ve33.poolSwapFeeState(poolIds[i]).swapFee();
+        }
     }
 
     function getEmissionState() public view returns (Ve33EmissionState memory state) {

--- a/src/lens/Ve33DataFetcher.sol
+++ b/src/lens/Ve33DataFetcher.sol
@@ -2,11 +2,14 @@
 pragma solidity =0.8.33;
 
 import {Ve33} from "../extensions/Ve33.sol";
+import {ICore} from "../interfaces/ICore.sol";
 import {IExposedStorage} from "../interfaces/IExposedStorage.sol";
 import {Ve33Lib} from "../libraries/Ve33Lib.sol";
 import {Ve33StorageLayout} from "../libraries/Ve33StorageLayout.sol";
+import {QuoteData, QuoteDataFetcher} from "./QuoteDataFetcher.sol";
 import {StorageSlot} from "../types/storageSlot.sol";
 import {PoolId} from "../types/poolId.sol";
+import {PoolKey} from "../types/poolKey.sol";
 import {VePoolSwapFeeState} from "../types/vePoolSwapFeeState.sol";
 import {MAX_NUM_VALID_TIMES, nextValidTime} from "../math/time.sol";
 
@@ -23,13 +26,42 @@ struct Ve33EmissionState {
     Ve33EmissionRateChange[] futureEmissionRateChanges;
 }
 
-contract Ve33DataFetcher {
+struct Ve33QuoteData {
+    QuoteData quoteData;
+    uint64 swapFee;
+}
+
+contract Ve33DataFetcher is QuoteDataFetcher {
     using Ve33Lib for Ve33;
+
+    error InvalidVe33Pool(PoolId poolId);
 
     Ve33 public immutable VE33_EXTENSION;
 
-    constructor(Ve33 ve33) {
+    constructor(ICore core, Ve33 ve33) QuoteDataFetcher(core) {
         VE33_EXTENSION = ve33;
+    }
+
+    /// @notice Returns all Core and Ve33 state needed to quote each requested pool.
+    /// @dev Reverts if a pool key does not use this fetcher's Ve33 extension or has a nonzero Core fee.
+    function getVe33QuoteData(PoolKey[] calldata poolKeys, uint32 minBitmapsSearched)
+        external
+        view
+        returns (Ve33QuoteData[] memory results)
+    {
+        QuoteData[] memory quoteData = this.getQuoteData(poolKeys, minBitmapsSearched);
+        Ve33 ve33 = VE33_EXTENSION;
+        results = new Ve33QuoteData[](poolKeys.length);
+
+        for (uint256 i = 0; i < poolKeys.length; i++) {
+            PoolKey calldata poolKey = poolKeys[i];
+            PoolId poolId = poolKey.toPoolId();
+            if (poolKey.config.extension() != address(ve33) || poolKey.config.fee() != 0) {
+                revert InvalidVe33Pool(poolId);
+            }
+
+            results[i] = Ve33QuoteData({quoteData: quoteData[i], swapFee: ve33.poolSwapFeeState(poolId).swapFee()});
+        }
     }
 
     /// @notice Returns the current voted swap fee for each requested pool.

--- a/test/ConfigureSTONX.t.sol
+++ b/test/ConfigureSTONX.t.sol
@@ -85,7 +85,7 @@ contract ConfigureSTONXTest is FullTest {
         ve33Positions = new Ve33Positions(core, ve33, address(deployer));
         deployer.setPositionsMetadata(ve33Positions);
         periphery = new Ve33Periphery(core, ve33);
-        dataFetcher = new Ve33DataFetcher(ve33);
+        dataFetcher = new Ve33DataFetcher(core, ve33);
         scheduler = new Ve33EmissionRateScheduler(address(deployer), core, ve33);
 
         stonx.mint(address(deployer), STONX_AMOUNT);

--- a/test/lens/Ve33DataFetcher.t.sol
+++ b/test/lens/Ve33DataFetcher.t.sol
@@ -7,7 +7,11 @@ import {Ve33Periphery} from "../../src/Ve33Periphery.sol";
 import {Ve33, ve33CallPoints} from "../../src/extensions/Ve33.sol";
 import {Ve33DataFetcher, Ve33EmissionRateChange, Ve33EmissionState} from "../../src/lens/Ve33DataFetcher.sol";
 import {Ve33Lib} from "../../src/libraries/Ve33Lib.sol";
+import {Ve33StorageLayout} from "../../src/libraries/Ve33StorageLayout.sol";
 import {nextValidTime} from "../../src/math/time.sol";
+import {PoolId} from "../../src/types/poolId.sol";
+import {StorageSlot} from "../../src/types/storageSlot.sol";
+import {createVePoolSwapFeeState, VePoolSwapFeeState} from "../../src/types/vePoolSwapFeeState.sol";
 
 contract Ve33DataFetcherTest is FullTest {
     using Ve33Lib for Ve33;
@@ -47,6 +51,33 @@ contract Ve33DataFetcherTest is FullTest {
         assertEq(state.currentEmissionRate, 0);
         assertEq(state.totalRemainingEmissions, 0);
         assertEq(state.futureEmissionRateChanges.length, 0);
+    }
+
+    function test_getPoolSwapFees() public {
+        PoolId[] memory poolIds = new PoolId[](3);
+        poolIds[0] = PoolId.wrap(bytes32(uint256(1)));
+        poolIds[1] = PoolId.wrap(bytes32(uint256(2)));
+        poolIds[2] = PoolId.wrap(bytes32(uint256(3)));
+
+        VePoolSwapFeeState state0 = createVePoolSwapFeeState(100, uint64(1 << 60));
+        VePoolSwapFeeState state2 = createVePoolSwapFeeState(300, uint64(3 << 60));
+        vm.store(
+            address(ve),
+            StorageSlot.unwrap(Ve33StorageLayout.poolSwapFeeStateSlot(poolIds[0])),
+            VePoolSwapFeeState.unwrap(state0)
+        );
+        vm.store(
+            address(ve),
+            StorageSlot.unwrap(Ve33StorageLayout.poolSwapFeeStateSlot(poolIds[2])),
+            VePoolSwapFeeState.unwrap(state2)
+        );
+
+        uint64[] memory swapFees = dataFetcher.getPoolSwapFees(poolIds);
+
+        assertEq(swapFees.length, 3);
+        assertEq(swapFees[0], uint64(1 << 60));
+        assertEq(swapFees[1], 0);
+        assertEq(swapFees[2], uint64(3 << 60));
     }
 
     function test_getEmissionState_immediateSchedule() public {

--- a/test/lens/Ve33DataFetcher.t.sol
+++ b/test/lens/Ve33DataFetcher.t.sol
@@ -5,11 +5,18 @@ import {FullTest} from "../FullTest.sol";
 import {TestToken} from "../TestToken.sol";
 import {Ve33Periphery} from "../../src/Ve33Periphery.sol";
 import {Ve33, ve33CallPoints} from "../../src/extensions/Ve33.sol";
-import {Ve33DataFetcher, Ve33EmissionRateChange, Ve33EmissionState} from "../../src/lens/Ve33DataFetcher.sol";
+import {
+    Ve33DataFetcher,
+    Ve33EmissionRateChange,
+    Ve33EmissionState,
+    Ve33QuoteData
+} from "../../src/lens/Ve33DataFetcher.sol";
 import {Ve33Lib} from "../../src/libraries/Ve33Lib.sol";
 import {Ve33StorageLayout} from "../../src/libraries/Ve33StorageLayout.sol";
 import {nextValidTime} from "../../src/math/time.sol";
 import {PoolId} from "../../src/types/poolId.sol";
+import {PoolKey} from "../../src/types/poolKey.sol";
+import {createConcentratedPoolConfig} from "../../src/types/poolConfig.sol";
 import {StorageSlot} from "../../src/types/storageSlot.sol";
 import {createVePoolSwapFeeState, VePoolSwapFeeState} from "../../src/types/vePoolSwapFeeState.sol";
 
@@ -29,7 +36,7 @@ contract Ve33DataFetcherTest is FullTest {
         deployCodeTo("Ve33.sol:Ve33", abi.encode(core, address(stakeToken)), deployAddress);
         ve = Ve33(payable(deployAddress));
         periphery = new Ve33Periphery(core, ve);
-        dataFetcher = new Ve33DataFetcher(ve);
+        dataFetcher = new Ve33DataFetcher(core, ve);
 
         stakeToken.approve(address(periphery), type(uint256).max);
     }
@@ -78,6 +85,43 @@ contract Ve33DataFetcherTest is FullTest {
         assertEq(swapFees[0], uint64(1 << 60));
         assertEq(swapFees[1], 0);
         assertEq(swapFees[2], uint64(3 << 60));
+    }
+
+    function test_getVe33QuoteData() public {
+        PoolKey memory poolKey = createPool({
+            _token0: address(token0),
+            _token1: address(token1),
+            tick: 10,
+            config: createConcentratedPoolConfig(0, 4, address(ve))
+        });
+        (, uint128 liquidity) = createPosition(poolKey, -40, 40, 1_000, 1_000);
+        uint64 swapFee = uint64(1 << 60);
+        vm.store(
+            address(ve),
+            StorageSlot.unwrap(Ve33StorageLayout.poolSwapFeeStateSlot(poolKey.toPoolId())),
+            VePoolSwapFeeState.unwrap(createVePoolSwapFeeState(100, swapFee))
+        );
+
+        PoolKey[] memory poolKeys = new PoolKey[](1);
+        poolKeys[0] = poolKey;
+        Ve33QuoteData[] memory quoteData = dataFetcher.getVe33QuoteData(poolKeys, 1);
+
+        assertEq(quoteData.length, 1);
+        assertEq(quoteData[0].swapFee, swapFee);
+        assertEq(quoteData[0].quoteData.tick, 10);
+        assertEq(quoteData[0].quoteData.liquidity, liquidity);
+        assertEq(quoteData[0].quoteData.ticks.length, 2);
+        assertEq(quoteData[0].quoteData.ticks[0].number, -40);
+        assertEq(quoteData[0].quoteData.ticks[1].number, 40);
+    }
+
+    function test_getVe33QuoteData_revertsForNonVe33Pool() public {
+        PoolKey memory poolKey = createPool({tick: 10, fee: 0, tickSpacing: 4});
+        PoolKey[] memory poolKeys = new PoolKey[](1);
+        poolKeys[0] = poolKey;
+
+        vm.expectRevert(abi.encodeWithSelector(Ve33DataFetcher.InvalidVe33Pool.selector, poolKey.toPoolId()));
+        dataFetcher.getVe33QuoteData(poolKeys, 1);
     }
 
     function test_getEmissionState_immediateSchedule() public {


### PR DESCRIPTION
## Summary

- make `Ve33DataFetcher` inherit the byte-for-byte unchanged core `QuoteDataFetcher`
- add batched `getVe33QuoteData(poolKeys, minBitmapsSearched)` returning each pool’s complete Core quote state and current Q64 Ve33 swap fee
- retain `getPoolSwapFees(poolIds)` for lightweight fee-only refreshes
- reject pool keys that do not use the configured Ve33 extension or use a nonzero Core fee
- cover unified quoting data, ordered fee reads, invalid pools, and zero-fee pools

This makes one Ve33 lens sufficient to initialize off-chain pool quoting while keeping the deployed generic quote lens bytecode and deterministic `DeployAll` address unchanged. The derived lens invokes the inherited external getter through a view self-call, so no base-contract helper or metadata change is required.

## Testing

- `forge fmt`
- `forge build --offline`
- `forge snapshot --offline`
- `forge test --offline` (982 tests passed)
- `QuoteDataFetcher.sol` SHA-256 matches the parent commit exactly
- CI: Foundry project passed
- `forge script script/DeployAll.s.sol:DeployAll --offline` (canonical `QuoteDataFetcher` address remains `0x5a3F…03f1`)