### PR TITLE
feat: add maximum-liquidity routed position deposits

### DIFF
--- a/script/ConfigureSTONX.s.sol
+++ b/script/ConfigureSTONX.s.sol
@@ -134,7 +134,7 @@ contract ConfigureSTONX is Script {
         bytes[] memory results = positions.multicall(calls);
         int256 amount0;
         int256 amount1;
-        (positionId,, amount0, amount1) = abi.decode(results[1], (uint256, uint128, int256, int256));
+        (positionId, amount0, amount1) = abi.decode(results[1], (uint256, int256, int256));
         uint128 usdgSpent = uint128(uint256(address(stonx) < usdg ? amount1 : amount0));
         if (usdgSpent != LIQUIDITY_USDG_AMOUNT) revert USDGNotFullySpent(usdgSpent);
         positions.transferFrom(deployer, governance, positionId);
@@ -159,10 +159,8 @@ contract ConfigureSTONX is Script {
             targetSqrtRatio: sqrtRatio,
             maxAmount0: maxAmount0,
             maxAmount1: maxAmount1,
-            swapRecipient: address(0),
-            routeAfterDeposit: false,
             router: address(0),
-            route: bytes("")
+            routerData: bytes("")
         });
     }
 

--- a/script/ConfigureSTONX.s.sol
+++ b/script/ConfigureSTONX.s.sol
@@ -134,7 +134,7 @@ contract ConfigureSTONX is Script {
         bytes[] memory results = positions.multicall(calls);
         int256 amount0;
         int256 amount1;
-        (positionId, amount0, amount1) = abi.decode(results[1], (uint256, int256, int256));
+        (positionId,, amount0, amount1) = abi.decode(results[1], (uint256, uint128, int256, int256));
         uint128 usdgSpent = uint128(uint256(address(stonx) < usdg ? amount1 : amount0));
         if (usdgSpent != LIQUIDITY_USDG_AMOUNT) revert USDGNotFullySpent(usdgSpent);
         positions.transferFrom(deployer, governance, positionId);
@@ -145,20 +145,21 @@ contract ConfigureSTONX is Script {
         pure
         returns (PositionDeposit memory parameters)
     {
+        uint128 liquidity = maxLiquidity(
+            sqrtRatio,
+            tickToSqrtRatio(POSITION_TICK_LOWER),
+            tickToSqrtRatio(POSITION_TICK_UPPER),
+            maxAmount0,
+            maxAmount1
+        );
         parameters = PositionDeposit({
             poolKey: poolKey,
             tickLower: POSITION_TICK_LOWER,
             tickUpper: POSITION_TICK_UPPER,
-            liquidity: maxLiquidity(
-                sqrtRatio,
-                tickToSqrtRatio(POSITION_TICK_LOWER),
-                tickToSqrtRatio(POSITION_TICK_UPPER),
-                maxAmount0,
-                maxAmount1
-            ),
-            targetSqrtRatio: sqrtRatio,
             maxAmount0: maxAmount0,
             maxAmount1: maxAmount1,
+            minLiquidity: liquidity,
+            targetSqrtRatio: sqrtRatio,
             router: address(0),
             routerData: bytes("")
         });

--- a/script/ConfigureSTONX.s.sol
+++ b/script/ConfigureSTONX.s.sol
@@ -9,16 +9,18 @@ import {deployIfNeeded} from "./DeployAll.s.sol";
 import {MintableERC20} from "../src/MintableERC20.sol";
 import {Ve33} from "../src/extensions/Ve33.sol";
 import {ICore} from "../src/interfaces/ICore.sol";
+import {PositionDeposit} from "../src/interfaces/IPositionDepositor.sol";
 import {Ve33EmissionRateScheduler} from "../src/Ve33EmissionRateScheduler.sol";
 import {Ve33Periphery} from "../src/Ve33Periphery.sol";
 import {Ve33Positions} from "../src/Ve33Positions.sol";
 import {VeToken} from "../src/VeToken.sol";
 import {CoreLib} from "../src/libraries/CoreLib.sol";
-import {sqrtRatioToTick} from "../src/math/ticks.sol";
+import {maxLiquidity} from "../src/math/liquidity.sol";
+import {sqrtRatioToTick, tickToSqrtRatio} from "../src/math/ticks.sol";
 import {nextValidTime} from "../src/math/time.sol";
 import {PoolKey} from "../src/types/poolKey.sol";
 import {createConcentratedPoolConfig} from "../src/types/poolConfig.sol";
-import {toSqrtRatio} from "../src/types/sqrtRatio.sol";
+import {SqrtRatio, toSqrtRatio} from "../src/types/sqrtRatio.sol";
 
 struct StonxVe33System {
     Ve33 ve33;
@@ -83,7 +85,7 @@ contract ConfigureSTONX is Script {
         stonx.mint(deployer, LIQUIDITY_TOKEN_AMOUNT);
 
         PoolKey memory poolKey = _stonxPoolKey(address(stonx), usdg, address(system.ve33));
-        uint256 positionId = _seedLiquidity(stonx, system.positions, poolKey, usdg, deployer, governance, nftSalt);
+        uint256 positionId = _seedLiquidity(stonx, system.positions, core, poolKey, usdg, deployer, governance, nftSalt);
         uint256 veId = _stakeAndVote(stonx, system.veToken, core, poolKey, nftSalt);
         system.positions.transferOwnership(governance);
         (address schedulerAddress, uint128 scheduledAmount) =
@@ -108,41 +110,60 @@ contract ConfigureSTONX is Script {
     function _seedLiquidity(
         MintableERC20 stonx,
         Ve33Positions positions,
+        ICore core,
         PoolKey memory poolKey,
         address usdg,
         address deployer,
         address governance,
         bytes32 nftSalt
     ) internal returns (uint256 positionId) {
+        int32 poolInitialTick = initialTick(address(stonx), stonx.decimals(), usdg, IERC20(usdg).decimals());
+        SqrtRatio sqrtRatio = core.poolState(poolKey.toPoolId()).sqrtRatio();
+        if (sqrtRatio.isZero()) sqrtRatio = tickToSqrtRatio(poolInitialTick);
         stonx.approve(address(positions), LIQUIDITY_TOKEN_AMOUNT);
         IERC20(usdg).approve(address(positions), LIQUIDITY_USDG_AMOUNT);
 
+        uint128 maxAmount0 = address(stonx) < usdg ? LIQUIDITY_TOKEN_AMOUNT : LIQUIDITY_USDG_AMOUNT;
+        uint128 maxAmount1 = address(stonx) < usdg ? LIQUIDITY_USDG_AMOUNT : LIQUIDITY_TOKEN_AMOUNT;
         bytes[] memory calls = new bytes[](2);
-        calls[0] = abi.encodeCall(
-            positions.maybeInitializePool,
-            (poolKey, initialTick(address(stonx), stonx.decimals(), usdg, IERC20(usdg).decimals()))
-        );
+        calls[0] = abi.encodeCall(positions.maybeInitializePool, (poolKey, poolInitialTick));
         calls[1] = abi.encodeCall(
-            positions.mintAndDepositWithSalt,
-            (
-                nftSalt,
-                poolKey,
-                POSITION_TICK_LOWER,
-                POSITION_TICK_UPPER,
-                address(stonx) < usdg ? LIQUIDITY_TOKEN_AMOUNT : LIQUIDITY_USDG_AMOUNT,
-                address(stonx) < usdg ? LIQUIDITY_USDG_AMOUNT : LIQUIDITY_TOKEN_AMOUNT,
-                0
-            )
+            positions.mintAndDepositWithSalt, (nftSalt, _positionDeposit(poolKey, sqrtRatio, maxAmount0, maxAmount1))
         );
 
         bytes[] memory results = positions.multicall(calls);
-        uint128 amount0;
-        uint128 amount1;
-        (positionId,, amount0, amount1) = abi.decode(results[1], (uint256, uint128, uint128, uint128));
-
-        uint128 usdgSpent = address(stonx) < usdg ? amount1 : amount0;
+        int256 amount0;
+        int256 amount1;
+        (positionId,, amount0, amount1) = abi.decode(results[1], (uint256, uint128, int256, int256));
+        uint128 usdgSpent = uint128(uint256(address(stonx) < usdg ? amount1 : amount0));
         if (usdgSpent != LIQUIDITY_USDG_AMOUNT) revert USDGNotFullySpent(usdgSpent);
         positions.transferFrom(deployer, governance, positionId);
+    }
+
+    function _positionDeposit(PoolKey memory poolKey, SqrtRatio sqrtRatio, uint128 maxAmount0, uint128 maxAmount1)
+        internal
+        pure
+        returns (PositionDeposit memory parameters)
+    {
+        parameters = PositionDeposit({
+            poolKey: poolKey,
+            tickLower: POSITION_TICK_LOWER,
+            tickUpper: POSITION_TICK_UPPER,
+            liquidity: maxLiquidity(
+                sqrtRatio,
+                tickToSqrtRatio(POSITION_TICK_LOWER),
+                tickToSqrtRatio(POSITION_TICK_UPPER),
+                maxAmount0,
+                maxAmount1
+            ),
+            targetSqrtRatio: sqrtRatio,
+            maxAmount0: maxAmount0,
+            maxAmount1: maxAmount1,
+            swapRecipient: address(0),
+            routeAfterDeposit: false,
+            router: address(0),
+            route: bytes("")
+        });
     }
 
     function _stakeAndVote(MintableERC20 stonx, VeToken veToken, ICore core, PoolKey memory poolKey, bytes32 nftSalt)

--- a/snapshots/MEVCaptureTest.json
+++ b/snapshots/MEVCaptureTest.json
@@ -9,7 +9,7 @@
   "output_token0_no_movement": "119549",
   "output_token1_move_tick_spacings": "119150",
   "output_token1_no_movement": "119150",
-  "positions withdraw after fees accumulate": "159718",
+  "positions withdraw after fees accumulate": "159707",
   "second_swap_with_additional_fees_gas_price": "101704",
   "third_swap_accumulates_fees": "115631"
 }

--- a/snapshots/MEVCaptureTest.json
+++ b/snapshots/MEVCaptureTest.json
@@ -9,7 +9,7 @@
   "output_token0_no_movement": "119549",
   "output_token1_move_tick_spacings": "119150",
   "output_token1_no_movement": "119150",
-  "positions withdraw after fees accumulate": "159728",
+  "positions withdraw after fees accumulate": "159718",
   "second_swap_with_additional_fees_gas_price": "101704",
   "third_swap_accumulates_fees": "115631"
 }

--- a/snapshots/PositionsTest.json
+++ b/snapshots/PositionsTest.json
@@ -1,12 +1,12 @@
 {
-  "mintAndDeposit": "396779",
-  "mintAndDeposit eth": "369651",
-  "mintAndDeposit eth (free)": "369651",
-  "mintAndDeposit full range both tokens": "244988",
-  "mintAndDeposit full range max": "245240",
-  "mintAndDeposit full range min": "245180",
-  "withdraw": "133666",
-  "withdraw eth": "126995",
-  "withdraw eth (free)": "107025",
-  "withdraw full range both tokens": "116307"
+  "mintAndDeposit": "396399",
+  "mintAndDeposit eth": "369196",
+  "mintAndDeposit eth (free)": "369152",
+  "mintAndDeposit full range both tokens": "244608",
+  "mintAndDeposit full range max": "244860",
+  "mintAndDeposit full range min": "244800",
+  "withdraw": "133665",
+  "withdraw eth": "126984",
+  "withdraw eth (free)": "107022",
+  "withdraw full range both tokens": "116294"
 }

--- a/snapshots/PositionsTest.json
+++ b/snapshots/PositionsTest.json
@@ -1,12 +1,12 @@
 {
-  "mintAndDeposit": "394354",
-  "mintAndDeposit eth": "367099",
-  "mintAndDeposit eth (free)": "367077",
-  "mintAndDeposit full range both tokens": "244071",
-  "mintAndDeposit full range max": "244507",
-  "mintAndDeposit full range min": "244191",
-  "withdraw": "133657",
-  "withdraw eth": "126976",
-  "withdraw eth (free)": "107016",
-  "withdraw full range both tokens": "116272"
+  "mintAndDeposit": "396779",
+  "mintAndDeposit eth": "369651",
+  "mintAndDeposit eth (free)": "369651",
+  "mintAndDeposit full range both tokens": "244988",
+  "mintAndDeposit full range max": "245240",
+  "mintAndDeposit full range min": "245180",
+  "withdraw": "133666",
+  "withdraw eth": "126995",
+  "withdraw eth (free)": "107025",
+  "withdraw full range both tokens": "116307"
 }

--- a/snapshots/PositionsTest.json
+++ b/snapshots/PositionsTest.json
@@ -1,12 +1,12 @@
 {
-  "mintAndDeposit": "396399",
-  "mintAndDeposit eth": "369196",
-  "mintAndDeposit eth (free)": "369152",
-  "mintAndDeposit full range both tokens": "244608",
-  "mintAndDeposit full range max": "244860",
-  "mintAndDeposit full range min": "244800",
-  "withdraw": "133665",
-  "withdraw eth": "126984",
-  "withdraw eth (free)": "107022",
-  "withdraw full range both tokens": "116294"
+  "mintAndDeposit": "398475",
+  "mintAndDeposit eth": "371333",
+  "mintAndDeposit eth (free)": "371243",
+  "mintAndDeposit full range both tokens": "248228",
+  "mintAndDeposit full range max": "248796",
+  "mintAndDeposit full range min": "248420",
+  "withdraw": "133654",
+  "withdraw eth": "126973",
+  "withdraw eth (free)": "107004",
+  "withdraw full range both tokens": "116280"
 }

--- a/snapshots/Ve33Test.json
+++ b/snapshots/Ve33Test.json
@@ -14,9 +14,9 @@
   "Ve33Forwarder#moveStake": "39275",
   "Ve33Forwarder#stake": "101642",
   "Ve33Periphery#scheduleEmissions": "125383",
-  "Ve33Positions#claimAccruedEmissions": "118216",
-  "Ve33Positions#claimRewards": "46078",
-  "Ve33Positions#deposit": "406452",
+  "Ve33Positions#claimAccruedEmissions": "118194",
+  "Ve33Positions#claimRewards": "46056",
+  "Ve33Positions#deposit": "409053",
   "VeToken#claimPoolFees": "59715",
   "VeToken#vote": "139863"
 }

--- a/snapshots/Ve33Test.json
+++ b/snapshots/Ve33Test.json
@@ -14,9 +14,9 @@
   "Ve33Forwarder#moveStake": "39275",
   "Ve33Forwarder#stake": "101642",
   "Ve33Periphery#scheduleEmissions": "125383",
-  "Ve33Positions#claimAccruedEmissions": "118257",
-  "Ve33Positions#claimRewards": "46119",
-  "Ve33Positions#deposit": "404962",
+  "Ve33Positions#claimAccruedEmissions": "118183",
+  "Ve33Positions#claimRewards": "46045",
+  "Ve33Positions#deposit": "407000",
   "VeToken#claimPoolFees": "59715",
   "VeToken#vote": "139863"
 }

--- a/snapshots/Ve33Test.json
+++ b/snapshots/Ve33Test.json
@@ -14,9 +14,9 @@
   "Ve33Forwarder#moveStake": "39275",
   "Ve33Forwarder#stake": "101642",
   "Ve33Periphery#scheduleEmissions": "125383",
-  "Ve33Positions#claimAccruedEmissions": "118183",
-  "Ve33Positions#claimRewards": "46045",
-  "Ve33Positions#deposit": "407000",
+  "Ve33Positions#claimAccruedEmissions": "118216",
+  "Ve33Positions#claimRewards": "46078",
+  "Ve33Positions#deposit": "406452",
   "VeToken#claimPoolFees": "59715",
   "VeToken#vote": "139863"
 }

--- a/src/Ve33Positions.sol
+++ b/src/Ve33Positions.sol
@@ -298,7 +298,9 @@ contract Ve33Positions is BasePositionDepositor {
         override
     {
         uint128 existingLiquidity = Ve33Lib.positionLiquidity(CORE, poolKey.toPoolId(), address(this), positionId_);
-        if (existingLiquidity > uint128(type(int128).max) - liquidity) revert DepositOverflow();
+        if (existingLiquidity > uint128(type(int128).max) - liquidity) {
+            revert PositionLiquidityOverflow(existingLiquidity, liquidity);
+        }
     }
 
     function _positionRewardAmount(

--- a/src/Ve33Positions.sol
+++ b/src/Ve33Positions.sol
@@ -1,18 +1,14 @@
 // SPDX-License-Identifier: ekubo-license-v1.eth
 pragma solidity =0.8.33;
 
-import {BaseLocker} from "./base/BaseLocker.sol";
-import {BaseNonfungibleToken} from "./base/BaseNonfungibleToken.sol";
-import {PayableMulticallable} from "./base/PayableMulticallable.sol";
-import {UsesCore} from "./base/UsesCore.sol";
+import {BasePositionDepositor} from "./base/BasePositionDepositor.sol";
 import {Ve33} from "./extensions/Ve33.sol";
 import {ICore} from "./interfaces/ICore.sol";
 import {FlashAccountantLib} from "./libraries/FlashAccountantLib.sol";
 import {CoreLib} from "./libraries/CoreLib.sol";
 import {ExposedStorageLib} from "./libraries/ExposedStorageLib.sol";
 import {Ve33Lib} from "./libraries/Ve33Lib.sol";
-import {NATIVE_TOKEN_ADDRESS} from "./math/constants.sol";
-import {liquidityDeltaToAmountDelta, maxLiquidity} from "./math/liquidity.sol";
+import {liquidityDeltaToAmountDelta} from "./math/liquidity.sol";
 import {tickToSqrtRatio} from "./math/ticks.sol";
 import {PoolBalanceUpdate} from "./types/poolBalanceUpdate.sol";
 import {PoolId} from "./types/poolId.sol";
@@ -21,16 +17,14 @@ import {PositionId, createPositionId} from "./types/positionId.sol";
 import {SqrtRatio} from "./types/sqrtRatio.sol";
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
 import {SafeCastLib} from "solady/utils/SafeCastLib.sol";
-import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 
 /// @notice ERC721 position manager for Ve33 liquidity positions.
 /// @dev Ve33 LPs do not earn Core swap fees. This contract only manages liquidity principal and Ve33 reward claims.
-contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfungibleToken {
+contract Ve33Positions is BasePositionDepositor {
     using CoreLib for *;
     using ExposedStorageLib for *;
     using FlashAccountantLib for *;
 
-    uint256 private constant CALL_TYPE_DEPOSIT = 0;
     uint256 private constant CALL_TYPE_WITHDRAW = 1;
     uint256 private constant CALL_TYPE_CLAIM_REWARDS = 2;
     uint256 private constant CALL_TYPE_WITHDRAW_AND_CLAIM_REWARDS = 3;
@@ -40,17 +34,6 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
 
     /// @notice Token paid as LP rewards by Ve33.
     address public immutable stakeToken;
-
-    /// @notice Thrown when deposit fails due to insufficient liquidity for the given slippage tolerance.
-    /// @param liquidity The actual liquidity that would be provided.
-    /// @param minLiquidity The minimum liquidity required.
-    error DepositFailedDueToSlippage(uint128 liquidity, uint128 minLiquidity);
-
-    /// @notice Thrown when price movement causes the actual deposit amounts to exceed caller limits.
-    error DepositFailedDueToPriceMovement();
-
-    /// @notice Thrown when deposit liquidity cannot fit in the Core position update type.
-    error DepositOverflow();
 
     /// @notice Thrown when withdrawn liquidity cannot fit in the Core position update type.
     error WithdrawOverflow();
@@ -62,18 +45,12 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
     /// @param core Ekubo Core contract used for locks and position updates.
     /// @param _ve33 Ve33 extension whose pools are supported.
     /// @param owner Owner allowed to set collection metadata.
-    constructor(ICore core, Ve33 _ve33, address owner) BaseNonfungibleToken(owner) BaseLocker(core) UsesCore(core) {
+    constructor(ICore core, Ve33 _ve33, address owner) BasePositionDepositor(core, owner) {
         ve33 = _ve33;
         stakeToken = _ve33.stakeToken();
     }
 
     receive() external payable {}
-
-    /// @inheritdoc BaseNonfungibleToken
-    /// @dev Restricts generated token ids to 192 bits so the complete id is used as the Core position salt.
-    function saltToId(address minter, bytes32 salt) public view override returns (uint256 id) {
-        id = uint192(super.saltToId(minter, salt));
-    }
 
     /// @notice Computes the Core position id controlled by this NFT id and tick range.
     /// @param id ERC721 token id representing the position owner.
@@ -137,44 +114,6 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
         principal0 = uint128(-delta0);
         principal1 = uint128(-delta1);
         rewardAmount = _positionRewardAmount(poolKey, poolId, positionId_, tickLower, tickUpper, liquidity);
-    }
-
-    /// @notice Deposits tokens into a Ve33 liquidity position.
-    /// @param id ERC721 token id representing the position owner.
-    /// @param poolKey Pool receiving liquidity.
-    /// @param tickLower Lower position tick.
-    /// @param tickUpper Upper position tick.
-    /// @param maxAmount0 Maximum token0 to deposit.
-    /// @param maxAmount1 Maximum token1 to deposit.
-    /// @param minLiquidity Minimum liquidity to receive.
-    /// @return liquidity Amount of liquidity added.
-    /// @return amount0 Actual token0 deposited.
-    /// @return amount1 Actual token1 deposited.
-    function deposit(
-        uint256 id,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        uint128 minLiquidity
-    ) public payable authorizedForNft(id) returns (uint128 liquidity, uint128 amount0, uint128 amount1) {
-        (liquidity, amount0, amount1) = abi.decode(
-            lock(
-                abi.encode(
-                    CALL_TYPE_DEPOSIT,
-                    msg.sender,
-                    id,
-                    poolKey,
-                    tickLower,
-                    tickUpper,
-                    maxAmount0,
-                    maxAmount1,
-                    minLiquidity
-                )
-            ),
-            (uint128, uint128, uint128)
-        );
     }
 
     /// @notice Withdraws liquidity principal from a Ve33 position.
@@ -277,95 +216,12 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
         amount = claimRewards(id, poolKey, tickLower, tickUpper, msg.sender);
     }
 
-    /// @notice Initializes a Ve33 pool if it has not been initialized yet.
-    /// @param poolKey Pool to initialize.
-    /// @param tick Initial tick if initialization is needed.
-    /// @return initialized Whether this call initialized the pool.
-    /// @return sqrtRatio Existing or newly initialized sqrt ratio.
-    function maybeInitializePool(PoolKey memory poolKey, int32 tick)
-        external
-        payable
-        returns (bool initialized, SqrtRatio sqrtRatio)
-    {
-        _validateVe33Pool(poolKey);
-        sqrtRatio = CORE.poolState(poolKey.toPoolId()).sqrtRatio();
-        if (sqrtRatio.isZero()) {
-            initialized = true;
-            sqrtRatio = CORE.initializePool(poolKey, tick);
-        }
-    }
-
-    /// @notice Mints a new NFT and deposits liquidity.
-    function mintAndDeposit(
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        uint128 minLiquidity
-    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
-        id = mint();
-        (liquidity, amount0, amount1) = deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minLiquidity);
-    }
-
-    /// @notice Mints a new deterministic NFT and deposits liquidity.
-    function mintAndDepositWithSalt(
-        bytes32 salt,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        uint128 minLiquidity
-    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
-        id = mint(salt);
-        (liquidity, amount0, amount1) = deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minLiquidity);
-    }
-
-    /// @inheritdoc BaseLocker
+    /// @notice Handles position-manager operations while the Core lock is held.
     function handleLockData(uint256, bytes memory data) internal override returns (bytes memory result) {
         uint256 callType = abi.decode(data, (uint256));
 
         if (callType == CALL_TYPE_DEPOSIT) {
-            (
-                ,
-                address caller,
-                uint256 id,
-                PoolKey memory poolKey,
-                int32 tickLower,
-                int32 tickUpper,
-                uint128 maxAmount0,
-                uint128 maxAmount1,
-                uint128 minLiquidity
-            ) = abi.decode(data, (uint256, address, uint256, PoolKey, int32, int32, uint128, uint128, uint128));
-
-            _validateVe33Pool(poolKey);
-            SqrtRatio sqrtRatio = CORE.poolState(poolKey.toPoolId()).sqrtRatio();
-            uint128 liquidity =
-                maxLiquidity(sqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), maxAmount0, maxAmount1);
-
-            if (liquidity < minLiquidity) revert DepositFailedDueToSlippage(liquidity, minLiquidity);
-            if (liquidity > uint128(type(int128).max)) revert DepositOverflow();
-
-            PoolId poolId = poolKey.toPoolId();
-            PositionId positionId_ = positionId(id, tickLower, tickUpper);
-            uint128 existingLiquidity = Ve33Lib.positionLiquidity(CORE, poolId, address(this), positionId_);
-            if (existingLiquidity > uint128(type(int128).max) - liquidity) revert DepositOverflow();
-
-            PoolBalanceUpdate balanceUpdate = CORE.updatePosition(poolKey, positionId_, int128(liquidity));
-            uint128 amount0 = uint128(balanceUpdate.delta0());
-            uint128 amount1 = uint128(balanceUpdate.delta1());
-
-            if (amount0 > maxAmount0 || amount1 > maxAmount1) revert DepositFailedDueToPriceMovement();
-
-            if (poolKey.token0 != NATIVE_TOKEN_ADDRESS) {
-                ACCOUNTANT.payTwoFrom(caller, poolKey.token0, poolKey.token1, amount0, amount1);
-            } else {
-                if (amount0 != 0) SafeTransferLib.safeTransferETH(address(ACCOUNTANT), amount0);
-                if (amount1 != 0) ACCOUNTANT.payFrom(caller, poolKey.token1, amount1);
-            }
-
-            result = abi.encode(liquidity, amount0, amount1);
+            result = _handleDeposit(data);
         } else if (callType == CALL_TYPE_WITHDRAW) {
             (
                 ,
@@ -430,6 +286,19 @@ contract Ve33Positions is UsesCore, PayableMulticallable, BaseLocker, BaseNonfun
 
     function _validateVe33Pool(PoolKey memory poolKey) private view {
         if (poolKey.config.extension() != address(ve33)) revert InvalidPoolExtension();
+    }
+
+    function _validatePool(PoolKey memory poolKey) internal view override {
+        _validateVe33Pool(poolKey);
+    }
+
+    function _validateDepositLiquidity(PoolKey memory poolKey, PositionId positionId_, uint128 liquidity)
+        internal
+        view
+        override
+    {
+        uint128 existingLiquidity = Ve33Lib.positionLiquidity(CORE, poolKey.toPoolId(), address(this), positionId_);
+        if (existingLiquidity > uint128(type(int128).max) - liquidity) revert DepositOverflow();
     }
 
     function _positionRewardAmount(

--- a/src/base/BasePositionDepositor.sol
+++ b/src/base/BasePositionDepositor.sol
@@ -51,10 +51,10 @@ abstract contract BasePositionDepositor is
         virtual
         override
         authorizedForNft(id)
-        returns (uint128 liquidity, int256 amount0, int256 amount1)
+        returns (int256 amount0, int256 amount1)
     {
-        (liquidity, amount0, amount1) = abi.decode(
-            lock(abi.encode(CALL_TYPE_DEPOSIT, msg.sender, id, parameters)), (uint128, int256, int256)
+        (amount0, amount1) = abi.decode(
+            lock(abi.encode(CALL_TYPE_DEPOSIT, msg.sender, id, parameters)), (int256, int256)
         );
     }
 
@@ -80,10 +80,10 @@ abstract contract BasePositionDepositor is
         payable
         virtual
         override
-        returns (uint256 id, uint128 liquidity, int256 amount0, int256 amount1)
+        returns (uint256 id, int256 amount0, int256 amount1)
     {
         id = mint();
-        (liquidity, amount0, amount1) = deposit(id, parameters);
+        (amount0, amount1) = deposit(id, parameters);
     }
 
     /// @inheritdoc IPositionDepositor
@@ -92,10 +92,10 @@ abstract contract BasePositionDepositor is
         payable
         virtual
         override
-        returns (uint256 id, uint128 liquidity, int256 amount0, int256 amount1)
+        returns (uint256 id, int256 amount0, int256 amount1)
     {
         id = mint(salt);
-        (liquidity, amount0, amount1) = deposit(id, parameters);
+        (amount0, amount1) = deposit(id, parameters);
     }
 
     function _handleDeposit(bytes memory data) internal returns (bytes memory result) {
@@ -105,8 +105,7 @@ abstract contract BasePositionDepositor is
         _validatePool(parameters.poolKey);
 
         uint128 liquidity = parameters.liquidity;
-        if (liquidity == 0) revert ZeroDepositLiquidity();
-        if (liquidity > uint128(type(int128).max)) revert DepositOverflow();
+        if (liquidity == 0 || liquidity > uint128(type(int128).max)) revert InvalidDepositLiquidity(liquidity);
         if (!parameters.targetSqrtRatio.isValid()) {
             revert InvalidTargetSqrtRatio(parameters.targetSqrtRatio);
         }
@@ -116,7 +115,9 @@ abstract contract BasePositionDepositor is
 
         int256 routeAmount0;
         int256 routeAmount1;
-        if (!parameters.routeAfterDeposit) {
+        bool routeAfterDeposit =
+            parameters.router != address(0) && CORE.poolState(parameters.poolKey.toPoolId()).liquidity() == 0;
+        if (!routeAfterDeposit) {
             (routeAmount0, routeAmount1) = _route(parameters);
 
             SqrtRatio routedSqrtRatio = CORE.poolState(parameters.poolKey.toPoolId()).sqrtRatio();
@@ -127,16 +128,13 @@ abstract contract BasePositionDepositor is
 
         PoolBalanceUpdate depositBalanceUpdate = CORE.updatePosition(parameters.poolKey, positionId, int128(liquidity));
 
-        if (parameters.routeAfterDeposit) {
+        if (routeAfterDeposit) {
             (routeAmount0, routeAmount1) = _route(parameters);
         }
 
         SqrtRatio finalSqrtRatio = CORE.poolState(parameters.poolKey.toPoolId()).sqrtRatio();
         if (finalSqrtRatio != parameters.targetSqrtRatio) {
-            if (parameters.routeAfterDeposit) {
-                revert TargetSqrtRatioNotReached(parameters.targetSqrtRatio, finalSqrtRatio);
-            }
-            revert DepositSqrtRatioChanged(parameters.targetSqrtRatio, finalSqrtRatio);
+            revert TargetSqrtRatioNotReached(parameters.targetSqrtRatio, finalSqrtRatio);
         }
 
         int256 amount0 = routeAmount0 + int256(depositBalanceUpdate.delta0());
@@ -145,18 +143,17 @@ abstract contract BasePositionDepositor is
             revert DepositExceedsMaxAmounts(amount0, amount1, parameters.maxAmount0, parameters.maxAmount1);
         }
 
-        address swapRecipient = parameters.swapRecipient == address(0) ? caller : parameters.swapRecipient;
-        _settle(caller, swapRecipient, parameters.poolKey, amount0, amount1);
-        result = abi.encode(liquidity, amount0, amount1);
+        _settle(caller, parameters.poolKey, amount0, amount1);
+        result = abi.encode(amount0, amount1);
     }
 
     function _route(PositionDeposit memory parameters) private returns (int256 amount0, int256 amount1) {
         if (parameters.router == address(0)) {
-            if (parameters.route.length != 0) revert RouterRequired();
+            if (parameters.routerData.length != 0) revert RouterRequired();
             return (0, 0);
         }
 
-        bytes memory routeResult = ACCOUNTANT.forward(parameters.router, parameters.route);
+        bytes memory routeResult = ACCOUNTANT.forward(parameters.router, parameters.routerData);
         (address specifiedToken, address calculatedToken, int256 specifiedDelta, int256 calculatedDelta) =
             abi.decode(routeResult, (address, address, int256, int256));
 
@@ -169,18 +166,16 @@ abstract contract BasePositionDepositor is
         revert InvalidRouteTokens(specifiedToken, calculatedToken, parameters.poolKey.token0, parameters.poolKey.token1);
     }
 
-    function _settle(address caller, address swapRecipient, PoolKey memory poolKey, int256 delta0, int256 delta1)
-        private
-    {
+    function _settle(address caller, PoolKey memory poolKey, int256 delta0, int256 delta1) private {
         if (delta0 >= 0 && delta1 >= 0 && poolKey.token0 != NATIVE_TOKEN_ADDRESS) {
             ACCOUNTANT.payTwoFrom(caller, poolKey.token0, poolKey.token1, uint256(delta0), uint256(delta1));
         } else {
-            _settleToken(caller, swapRecipient, poolKey.token0, delta0);
-            _settleToken(caller, swapRecipient, poolKey.token1, delta1);
+            _settleToken(caller, poolKey.token0, delta0);
+            _settleToken(caller, poolKey.token1, delta1);
         }
     }
 
-    function _settleToken(address caller, address swapRecipient, address token, int256 delta) private {
+    function _settleToken(address caller, address token, int256 delta) private {
         if (delta > 0) {
             uint128 amount = uint128(uint256(delta));
             if (token == NATIVE_TOKEN_ADDRESS) {
@@ -190,7 +185,7 @@ abstract contract BasePositionDepositor is
             }
         } else if (delta < 0) {
             if (delta < -int256(uint256(type(uint128).max))) revert RouteOutputOverflow(token, delta);
-            ACCOUNTANT.withdraw(token, swapRecipient, uint128(uint256(-delta)));
+            ACCOUNTANT.withdraw(token, caller, uint128(uint256(-delta)));
         }
     }
 

--- a/src/base/BasePositionDepositor.sol
+++ b/src/base/BasePositionDepositor.sol
@@ -11,13 +11,15 @@ import {IPositionDepositor, PositionDeposit} from "../interfaces/IPositionDeposi
 import {CoreLib} from "../libraries/CoreLib.sol";
 import {FlashAccountantLib} from "../libraries/FlashAccountantLib.sol";
 import {NATIVE_TOKEN_ADDRESS} from "../math/constants.sol";
+import {maxLiquidity} from "../math/liquidity.sol";
+import {tickToSqrtRatio} from "../math/ticks.sol";
 import {PoolBalanceUpdate} from "../types/poolBalanceUpdate.sol";
 import {PoolKey} from "../types/poolKey.sol";
 import {PositionId, createPositionId} from "../types/positionId.sol";
 import {SqrtRatio} from "../types/sqrtRatio.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 
-/// @notice Shared exact-price deposit flow for regular and extension-specific position managers.
+/// @notice Shared maximum-liquidity deposit flow for regular and extension-specific position managers.
 abstract contract BasePositionDepositor is
     IPositionDepositor,
     UsesCore,
@@ -51,10 +53,10 @@ abstract contract BasePositionDepositor is
         virtual
         override
         authorizedForNft(id)
-        returns (int256 amount0, int256 amount1)
+        returns (uint128 liquidity, int256 amount0, int256 amount1)
     {
-        (amount0, amount1) = abi.decode(
-            lock(abi.encode(CALL_TYPE_DEPOSIT, msg.sender, id, parameters)), (int256, int256)
+        (liquidity, amount0, amount1) = abi.decode(
+            lock(abi.encode(CALL_TYPE_DEPOSIT, msg.sender, id, parameters)), (uint128, int256, int256)
         );
     }
 
@@ -80,10 +82,10 @@ abstract contract BasePositionDepositor is
         payable
         virtual
         override
-        returns (uint256 id, int256 amount0, int256 amount1)
+        returns (uint256 id, uint128 liquidity, int256 amount0, int256 amount1)
     {
         id = mint();
-        (amount0, amount1) = deposit(id, parameters);
+        (liquidity, amount0, amount1) = deposit(id, parameters);
     }
 
     /// @inheritdoc IPositionDepositor
@@ -92,10 +94,10 @@ abstract contract BasePositionDepositor is
         payable
         virtual
         override
-        returns (uint256 id, int256 amount0, int256 amount1)
+        returns (uint256 id, uint128 liquidity, int256 amount0, int256 amount1)
     {
         id = mint(salt);
-        (amount0, amount1) = deposit(id, parameters);
+        (liquidity, amount0, amount1) = deposit(id, parameters);
     }
 
     function _handleDeposit(bytes memory data) internal returns (bytes memory result) {
@@ -104,47 +106,59 @@ abstract contract BasePositionDepositor is
 
         _validatePool(parameters.poolKey);
 
-        uint128 liquidity = parameters.liquidity;
-        if (liquidity == 0 || liquidity > uint128(type(int128).max)) revert InvalidDepositLiquidity(liquidity);
         if (!parameters.targetSqrtRatio.isValid()) {
             revert InvalidTargetSqrtRatio(parameters.targetSqrtRatio);
         }
 
+        (int256 routeAmount0, int256 routeAmount1) = _route(parameters);
+        SqrtRatio routedSqrtRatio = CORE.poolState(parameters.poolKey.toPoolId()).sqrtRatio();
+        if (routedSqrtRatio != parameters.targetSqrtRatio) {
+            revert TargetSqrtRatioNotReached(parameters.targetSqrtRatio, routedSqrtRatio);
+        }
+
+        uint128 liquidity = maxLiquidity(
+            routedSqrtRatio,
+            tickToSqrtRatio(parameters.tickLower),
+            tickToSqrtRatio(parameters.tickUpper),
+            _availableAmount(parameters.maxAmount0, routeAmount0),
+            _availableAmount(parameters.maxAmount1, routeAmount1)
+        );
+
+        if (liquidity < parameters.minLiquidity) {
+            revert DepositLiquidityBelowMinimum(liquidity, parameters.minLiquidity);
+        }
+        if (liquidity > uint128(type(int128).max)) revert DepositLiquidityOverflow(liquidity);
+
         PositionId positionId = createPositionId(bytes24(uint192(id)), parameters.tickLower, parameters.tickUpper);
         _validateDepositLiquidity(parameters.poolKey, positionId, liquidity);
-
-        int256 routeAmount0;
-        int256 routeAmount1;
-        bool routeAfterDeposit =
-            parameters.router != address(0) && CORE.poolState(parameters.poolKey.toPoolId()).liquidity() == 0;
-        if (!routeAfterDeposit) {
-            (routeAmount0, routeAmount1) = _route(parameters);
-
-            SqrtRatio routedSqrtRatio = CORE.poolState(parameters.poolKey.toPoolId()).sqrtRatio();
-            if (routedSqrtRatio != parameters.targetSqrtRatio) {
-                revert TargetSqrtRatioNotReached(parameters.targetSqrtRatio, routedSqrtRatio);
-            }
-        }
-
         PoolBalanceUpdate depositBalanceUpdate = CORE.updatePosition(parameters.poolKey, positionId, int128(liquidity));
-
-        if (routeAfterDeposit) {
-            (routeAmount0, routeAmount1) = _route(parameters);
-        }
-
-        SqrtRatio finalSqrtRatio = CORE.poolState(parameters.poolKey.toPoolId()).sqrtRatio();
-        if (finalSqrtRatio != parameters.targetSqrtRatio) {
-            revert TargetSqrtRatioNotReached(parameters.targetSqrtRatio, finalSqrtRatio);
-        }
 
         int256 amount0 = routeAmount0 + int256(depositBalanceUpdate.delta0());
         int256 amount1 = routeAmount1 + int256(depositBalanceUpdate.delta1());
-        if (amount0 > int256(uint256(parameters.maxAmount0)) || amount1 > int256(uint256(parameters.maxAmount1))) {
+        SqrtRatio finalSqrtRatio = CORE.poolState(parameters.poolKey.toPoolId()).sqrtRatio();
+        if (finalSqrtRatio != parameters.targetSqrtRatio) {
+            revert TargetSqrtRatioNotReached(parameters.targetSqrtRatio, finalSqrtRatio);
+        } else if (amount0 > int256(uint256(parameters.maxAmount0)) || amount1 > int256(uint256(parameters.maxAmount1)))
+        {
             revert DepositExceedsMaxAmounts(amount0, amount1, parameters.maxAmount0, parameters.maxAmount1);
         }
 
         _settle(caller, parameters.poolKey, amount0, amount1);
-        result = abi.encode(amount0, amount1);
+        result = abi.encode(liquidity, amount0, amount1);
+    }
+
+    function _availableAmount(uint128 maxAmount, int256 routeAmount) private pure returns (uint128 amount) {
+        if (routeAmount >= 0) {
+            uint256 spent = uint256(routeAmount);
+            return spent >= maxAmount ? 0 : maxAmount - uint128(spent);
+        }
+
+        uint256 received;
+        assembly ("memory-safe") {
+            received := sub(0, routeAmount)
+        }
+        uint256 room = type(uint128).max - uint256(maxAmount);
+        amount = received >= room ? type(uint128).max : maxAmount + uint128(received);
     }
 
     function _route(PositionDeposit memory parameters) private returns (int256 amount0, int256 amount1) {

--- a/src/base/BasePositionDepositor.sol
+++ b/src/base/BasePositionDepositor.sol
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: ekubo-license-v1.eth
+pragma solidity =0.8.33;
+
+import {BaseLocker} from "./BaseLocker.sol";
+import {BaseNonfungibleToken} from "./BaseNonfungibleToken.sol";
+import {PayableMulticallable} from "./PayableMulticallable.sol";
+import {UsesCore} from "./UsesCore.sol";
+import {ICore} from "../interfaces/ICore.sol";
+import {IBaseNonfungibleToken} from "../interfaces/IBaseNonfungibleToken.sol";
+import {IPositionDepositor, PositionDeposit} from "../interfaces/IPositionDepositor.sol";
+import {CoreLib} from "../libraries/CoreLib.sol";
+import {FlashAccountantLib} from "../libraries/FlashAccountantLib.sol";
+import {NATIVE_TOKEN_ADDRESS} from "../math/constants.sol";
+import {PoolBalanceUpdate} from "../types/poolBalanceUpdate.sol";
+import {PoolKey} from "../types/poolKey.sol";
+import {PositionId, createPositionId} from "../types/positionId.sol";
+import {SqrtRatio} from "../types/sqrtRatio.sol";
+import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
+
+/// @notice Shared exact-price deposit flow for regular and extension-specific position managers.
+abstract contract BasePositionDepositor is
+    IPositionDepositor,
+    UsesCore,
+    PayableMulticallable,
+    BaseLocker,
+    BaseNonfungibleToken
+{
+    using CoreLib for *;
+    using FlashAccountantLib for *;
+
+    uint256 internal constant CALL_TYPE_DEPOSIT = 0;
+
+    constructor(ICore core, address owner) BaseNonfungibleToken(owner) BaseLocker(core) UsesCore(core) {}
+
+    /// @inheritdoc BaseNonfungibleToken
+    /// @dev Restricts generated token ids to 192 bits so the complete id is used as the Core position salt.
+    function saltToId(address minter, bytes32 salt)
+        public
+        view
+        virtual
+        override(BaseNonfungibleToken, IBaseNonfungibleToken)
+        returns (uint256 id)
+    {
+        id = uint192(super.saltToId(minter, salt));
+    }
+
+    /// @inheritdoc IPositionDepositor
+    function deposit(uint256 id, PositionDeposit memory parameters)
+        public
+        payable
+        virtual
+        override
+        authorizedForNft(id)
+        returns (uint128 liquidity, int256 amount0, int256 amount1)
+    {
+        (liquidity, amount0, amount1) = abi.decode(
+            lock(abi.encode(CALL_TYPE_DEPOSIT, msg.sender, id, parameters)), (uint128, int256, int256)
+        );
+    }
+
+    /// @inheritdoc IPositionDepositor
+    function maybeInitializePool(PoolKey memory poolKey, int32 tick)
+        public
+        payable
+        virtual
+        override
+        returns (bool initialized, SqrtRatio sqrtRatio)
+    {
+        _validatePool(poolKey);
+        sqrtRatio = CORE.poolState(poolKey.toPoolId()).sqrtRatio();
+        if (sqrtRatio.isZero()) {
+            initialized = true;
+            sqrtRatio = CORE.initializePool(poolKey, tick);
+        }
+    }
+
+    /// @inheritdoc IPositionDepositor
+    function mintAndDeposit(PositionDeposit memory parameters)
+        public
+        payable
+        virtual
+        override
+        returns (uint256 id, uint128 liquidity, int256 amount0, int256 amount1)
+    {
+        id = mint();
+        (liquidity, amount0, amount1) = deposit(id, parameters);
+    }
+
+    /// @inheritdoc IPositionDepositor
+    function mintAndDepositWithSalt(bytes32 salt, PositionDeposit memory parameters)
+        public
+        payable
+        virtual
+        override
+        returns (uint256 id, uint128 liquidity, int256 amount0, int256 amount1)
+    {
+        id = mint(salt);
+        (liquidity, amount0, amount1) = deposit(id, parameters);
+    }
+
+    function _handleDeposit(bytes memory data) internal returns (bytes memory result) {
+        (, address caller, uint256 id, PositionDeposit memory parameters) =
+            abi.decode(data, (uint256, address, uint256, PositionDeposit));
+
+        _validatePool(parameters.poolKey);
+
+        uint128 liquidity = parameters.liquidity;
+        if (liquidity == 0) revert ZeroDepositLiquidity();
+        if (liquidity > uint128(type(int128).max)) revert DepositOverflow();
+        if (!parameters.targetSqrtRatio.isValid()) {
+            revert InvalidTargetSqrtRatio(parameters.targetSqrtRatio);
+        }
+
+        PositionId positionId = createPositionId(bytes24(uint192(id)), parameters.tickLower, parameters.tickUpper);
+        _validateDepositLiquidity(parameters.poolKey, positionId, liquidity);
+
+        int256 routeAmount0;
+        int256 routeAmount1;
+        if (!parameters.routeAfterDeposit) {
+            (routeAmount0, routeAmount1) = _route(parameters);
+
+            SqrtRatio routedSqrtRatio = CORE.poolState(parameters.poolKey.toPoolId()).sqrtRatio();
+            if (routedSqrtRatio != parameters.targetSqrtRatio) {
+                revert TargetSqrtRatioNotReached(parameters.targetSqrtRatio, routedSqrtRatio);
+            }
+        }
+
+        PoolBalanceUpdate depositBalanceUpdate = CORE.updatePosition(parameters.poolKey, positionId, int128(liquidity));
+
+        if (parameters.routeAfterDeposit) {
+            (routeAmount0, routeAmount1) = _route(parameters);
+        }
+
+        SqrtRatio finalSqrtRatio = CORE.poolState(parameters.poolKey.toPoolId()).sqrtRatio();
+        if (finalSqrtRatio != parameters.targetSqrtRatio) {
+            if (parameters.routeAfterDeposit) {
+                revert TargetSqrtRatioNotReached(parameters.targetSqrtRatio, finalSqrtRatio);
+            }
+            revert DepositSqrtRatioChanged(parameters.targetSqrtRatio, finalSqrtRatio);
+        }
+
+        int256 amount0 = routeAmount0 + int256(depositBalanceUpdate.delta0());
+        int256 amount1 = routeAmount1 + int256(depositBalanceUpdate.delta1());
+        if (amount0 > int256(uint256(parameters.maxAmount0)) || amount1 > int256(uint256(parameters.maxAmount1))) {
+            revert DepositExceedsMaxAmounts(amount0, amount1, parameters.maxAmount0, parameters.maxAmount1);
+        }
+
+        address swapRecipient = parameters.swapRecipient == address(0) ? caller : parameters.swapRecipient;
+        _settle(caller, swapRecipient, parameters.poolKey, amount0, amount1);
+        result = abi.encode(liquidity, amount0, amount1);
+    }
+
+    function _route(PositionDeposit memory parameters) private returns (int256 amount0, int256 amount1) {
+        if (parameters.router == address(0)) {
+            if (parameters.route.length != 0) revert RouterRequired();
+            return (0, 0);
+        }
+
+        bytes memory routeResult = ACCOUNTANT.forward(parameters.router, parameters.route);
+        (address specifiedToken, address calculatedToken, int256 specifiedDelta, int256 calculatedDelta) =
+            abi.decode(routeResult, (address, address, int256, int256));
+
+        if (specifiedToken == parameters.poolKey.token0 && calculatedToken == parameters.poolKey.token1) {
+            return (specifiedDelta, calculatedDelta);
+        }
+        if (specifiedToken == parameters.poolKey.token1 && calculatedToken == parameters.poolKey.token0) {
+            return (calculatedDelta, specifiedDelta);
+        }
+        revert InvalidRouteTokens(specifiedToken, calculatedToken, parameters.poolKey.token0, parameters.poolKey.token1);
+    }
+
+    function _settle(address caller, address swapRecipient, PoolKey memory poolKey, int256 delta0, int256 delta1)
+        private
+    {
+        if (delta0 >= 0 && delta1 >= 0 && poolKey.token0 != NATIVE_TOKEN_ADDRESS) {
+            ACCOUNTANT.payTwoFrom(caller, poolKey.token0, poolKey.token1, uint256(delta0), uint256(delta1));
+        } else {
+            _settleToken(caller, swapRecipient, poolKey.token0, delta0);
+            _settleToken(caller, swapRecipient, poolKey.token1, delta1);
+        }
+    }
+
+    function _settleToken(address caller, address swapRecipient, address token, int256 delta) private {
+        if (delta > 0) {
+            uint128 amount = uint128(uint256(delta));
+            if (token == NATIVE_TOKEN_ADDRESS) {
+                SafeTransferLib.safeTransferETH(address(ACCOUNTANT), amount);
+            } else {
+                ACCOUNTANT.payFrom(caller, token, amount);
+            }
+        } else if (delta < 0) {
+            if (delta < -int256(uint256(type(uint128).max))) revert RouteOutputOverflow(token, delta);
+            ACCOUNTANT.withdraw(token, swapRecipient, uint128(uint256(-delta)));
+        }
+    }
+
+    function _validatePool(PoolKey memory poolKey) internal view virtual {}
+
+    function _validateDepositLiquidity(PoolKey memory poolKey, PositionId positionId, uint128 liquidity)
+        internal
+        view
+        virtual {}
+}

--- a/src/base/BasePositions.sol
+++ b/src/base/BasePositions.sol
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: ekubo-license-v1.eth
 pragma solidity =0.8.33;
 
-import {BaseLocker} from "./BaseLocker.sol";
-import {UsesCore} from "./UsesCore.sol";
+import {BasePositionDepositor} from "./BasePositionDepositor.sol";
 import {ICore} from "../interfaces/ICore.sol";
-import {IBaseNonfungibleToken} from "../interfaces/IBaseNonfungibleToken.sol";
-import {IPositions} from "../interfaces/IPositions.sol";
+import {IPositionsV2} from "../interfaces/IPositionsV2.sol";
 import {CoreLib} from "../libraries/CoreLib.sol";
 import {FlashAccountantLib} from "../libraries/FlashAccountantLib.sol";
 import {PoolKey} from "../types/poolKey.sol";
@@ -13,13 +11,9 @@ import {PositionId, createPositionId} from "../types/positionId.sol";
 import {FeesPerLiquidity} from "../types/feesPerLiquidity.sol";
 import {Position} from "../types/position.sol";
 import {tickToSqrtRatio} from "../math/ticks.sol";
-import {maxLiquidity, liquidityDeltaToAmountDelta} from "../math/liquidity.sol";
-import {PayableMulticallable} from "./PayableMulticallable.sol";
+import {liquidityDeltaToAmountDelta} from "../math/liquidity.sol";
 import {SqrtRatio} from "../types/sqrtRatio.sol";
 import {SafeCastLib} from "solady/utils/SafeCastLib.sol";
-import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
-import {BaseNonfungibleToken} from "./BaseNonfungibleToken.sol";
-import {NATIVE_TOKEN_ADDRESS} from "../math/constants.sol";
 import {PoolId} from "../types/poolId.sol";
 import {PoolBalanceUpdate} from "../types/poolBalanceUpdate.sol";
 
@@ -27,31 +21,19 @@ import {PoolBalanceUpdate} from "../types/poolBalanceUpdate.sol";
 /// @author Moody Salem <moody@ekubo.org>
 /// @notice Abstract base contract for tracking liquidity positions in Ekubo Protocol as NFTs
 /// @dev Provides core position management functionality with abstract protocol fee collection methods
-abstract contract BasePositions is IPositions, UsesCore, PayableMulticallable, BaseLocker, BaseNonfungibleToken {
+abstract contract BasePositions is BasePositionDepositor, IPositionsV2 {
     using CoreLib for *;
     using FlashAccountantLib for *;
 
     /// @notice Constructs the BasePositions contract
     /// @param core The core contract instance
     /// @param owner The owner of the contract (for access control)
-    constructor(ICore core, address owner) BaseNonfungibleToken(owner) BaseLocker(core) UsesCore(core) {}
+    constructor(ICore core, address owner) BasePositionDepositor(core, owner) {}
 
-    uint256 private constant CALL_TYPE_DEPOSIT = 0;
     uint256 private constant CALL_TYPE_WITHDRAW = 1;
     uint256 private constant CALL_TYPE_WITHDRAW_PROTOCOL_FEES = 2;
 
-    /// @inheritdoc BaseNonfungibleToken
-    /// @dev Restricts generated token ids to 192 bits so the complete id is used as the Core position salt.
-    function saltToId(address minter, bytes32 salt)
-        public
-        view
-        override(BaseNonfungibleToken, IBaseNonfungibleToken)
-        returns (uint256 id)
-    {
-        id = uint192(super.saltToId(minter, salt));
-    }
-
-    /// @inheritdoc IPositions
+    /// @inheritdoc IPositionsV2
     function getPositionFeesAndLiquidity(uint256 id, PoolKey memory poolKey, int32 tickLower, int32 tickUpper)
         external
         view
@@ -79,35 +61,7 @@ abstract contract BasePositions is IPositions, UsesCore, PayableMulticallable, B
         (fees0, fees1) = position.fees(feesPerLiquidityInside);
     }
 
-    /// @inheritdoc IPositions
-    function deposit(
-        uint256 id,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        uint128 minLiquidity
-    ) public payable authorizedForNft(id) returns (uint128 liquidity, uint128 amount0, uint128 amount1) {
-        (liquidity, amount0, amount1) = abi.decode(
-            lock(
-                abi.encode(
-                    CALL_TYPE_DEPOSIT,
-                    msg.sender,
-                    id,
-                    poolKey,
-                    tickLower,
-                    tickUpper,
-                    maxAmount0,
-                    maxAmount1,
-                    minLiquidity
-                )
-            ),
-            (uint128, uint128, uint128)
-        );
-    }
-
-    /// @inheritdoc IPositions
+    /// @inheritdoc IPositionsV2
     function collectFees(uint256 id, PoolKey memory poolKey, int32 tickLower, int32 tickUpper)
         public
         payable
@@ -117,7 +71,7 @@ abstract contract BasePositions is IPositions, UsesCore, PayableMulticallable, B
         (amount0, amount1) = collectFees(id, poolKey, tickLower, tickUpper, msg.sender);
     }
 
-    /// @inheritdoc IPositions
+    /// @inheritdoc IPositionsV2
     function collectFees(uint256 id, PoolKey memory poolKey, int32 tickLower, int32 tickUpper, address recipient)
         public
         payable
@@ -127,7 +81,7 @@ abstract contract BasePositions is IPositions, UsesCore, PayableMulticallable, B
         (amount0, amount1) = withdraw(id, poolKey, tickLower, tickUpper, 0, recipient, true);
     }
 
-    /// @inheritdoc IPositions
+    /// @inheritdoc IPositionsV2
     function withdraw(
         uint256 id,
         PoolKey memory poolKey,
@@ -143,7 +97,7 @@ abstract contract BasePositions is IPositions, UsesCore, PayableMulticallable, B
         );
     }
 
-    /// @inheritdoc IPositions
+    /// @inheritdoc IPositionsV2
     function withdraw(uint256 id, PoolKey memory poolKey, int32 tickLower, int32 tickUpper, uint128 liquidity)
         public
         payable
@@ -152,48 +106,7 @@ abstract contract BasePositions is IPositions, UsesCore, PayableMulticallable, B
         (amount0, amount1) = withdraw(id, poolKey, tickLower, tickUpper, liquidity, address(msg.sender), true);
     }
 
-    /// @inheritdoc IPositions
-    function maybeInitializePool(PoolKey memory poolKey, int32 tick)
-        external
-        payable
-        returns (bool initialized, SqrtRatio sqrtRatio)
-    {
-        // the before update position hook shouldn't be taken into account here
-        sqrtRatio = CORE.poolState(poolKey.toPoolId()).sqrtRatio();
-        if (sqrtRatio.isZero()) {
-            initialized = true;
-            sqrtRatio = CORE.initializePool(poolKey, tick);
-        }
-    }
-
-    /// @inheritdoc IPositions
-    function mintAndDeposit(
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        uint128 minLiquidity
-    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
-        id = mint();
-        (liquidity, amount0, amount1) = deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minLiquidity);
-    }
-
-    /// @inheritdoc IPositions
-    function mintAndDepositWithSalt(
-        bytes32 salt,
-        PoolKey memory poolKey,
-        int32 tickLower,
-        int32 tickUpper,
-        uint128 maxAmount0,
-        uint128 maxAmount1,
-        uint128 minLiquidity
-    ) external payable returns (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) {
-        id = mint(salt);
-        (liquidity, amount0, amount1) = deposit(id, poolKey, tickLower, tickUpper, maxAmount0, maxAmount1, minLiquidity);
-    }
-
-    /// @inheritdoc IPositions
+    /// @inheritdoc IPositionsV2
     function withdrawProtocolFees(address token0, address token1, uint128 amount0, uint128 amount1, address recipient)
         external
         payable
@@ -202,7 +115,7 @@ abstract contract BasePositions is IPositions, UsesCore, PayableMulticallable, B
         lock(abi.encode(CALL_TYPE_WITHDRAW_PROTOCOL_FEES, token0, token1, amount0, amount1, recipient));
     }
 
-    /// @inheritdoc IPositions
+    /// @inheritdoc IPositionsV2
     function getProtocolFees(address token0, address token1) external view returns (uint128 amount0, uint128 amount1) {
         (amount0, amount1) = CORE.savedBalances(address(this), token0, token1, bytes32(0));
     }
@@ -241,55 +154,7 @@ abstract contract BasePositions is IPositions, UsesCore, PayableMulticallable, B
         uint256 callType = abi.decode(data, (uint256));
 
         if (callType == CALL_TYPE_DEPOSIT) {
-            (
-                ,
-                address caller,
-                uint256 id,
-                PoolKey memory poolKey,
-                int32 tickLower,
-                int32 tickUpper,
-                uint128 maxAmount0,
-                uint128 maxAmount1,
-                uint128 minLiquidity
-            ) = abi.decode(data, (uint256, address, uint256, PoolKey, int32, int32, uint128, uint128, uint128));
-
-            SqrtRatio sqrtRatio = CORE.poolState(poolKey.toPoolId()).sqrtRatio();
-
-            uint128 liquidity =
-                maxLiquidity(sqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), maxAmount0, maxAmount1);
-
-            if (liquidity < minLiquidity) {
-                revert DepositFailedDueToSlippage(liquidity, minLiquidity);
-            }
-
-            if (liquidity > uint128(type(int128).max)) {
-                revert DepositOverflow();
-            }
-
-            PoolBalanceUpdate balanceUpdate = CORE.updatePosition(
-                poolKey,
-                createPositionId({_salt: bytes24(uint192(id)), _tickLower: tickLower, _tickUpper: tickUpper}),
-                int128(liquidity)
-            );
-
-            uint128 amount0 = uint128(balanceUpdate.delta0());
-            uint128 amount1 = uint128(balanceUpdate.delta1());
-
-            if (amount0 > maxAmount0 || amount1 > maxAmount1) revert DepositFailedDueToPriceMovement();
-
-            // Use multi-token payment for ERC20-only pools, fall back to individual payments for native token pools
-            if (poolKey.token0 != NATIVE_TOKEN_ADDRESS) {
-                ACCOUNTANT.payTwoFrom(caller, poolKey.token0, poolKey.token1, amount0, amount1);
-            } else {
-                if (amount0 != 0) {
-                    SafeTransferLib.safeTransferETH(address(ACCOUNTANT), amount0);
-                }
-                if (amount1 != 0) {
-                    ACCOUNTANT.payFrom(caller, poolKey.token1, amount1);
-                }
-            }
-
-            result = abi.encode(liquidity, amount0, amount1);
+            result = _handleDeposit(data);
         } else if (callType == CALL_TYPE_WITHDRAW) {
             (
                 ,

--- a/src/interfaces/IPositionDepositor.sol
+++ b/src/interfaces/IPositionDepositor.sol
@@ -21,35 +21,30 @@ struct PositionDeposit {
     uint128 maxAmount0;
     /// @notice Maximum net amount of token1 the caller will pay across the price-setting swap and deposit.
     uint128 maxAmount1;
-    /// @notice Recipient of any token output left after netting the price-setting swap against the deposit.
-    address swapRecipient;
-    /// @notice Whether to add liquidity before routing, so the route can move a pool with no active liquidity.
-    bool routeAfterDeposit;
-    /// @notice Optional Core forwardee to execute before or after adding liquidity. Zero skips routing.
+    /// @notice Optional Core forwardee used to rebalance the deposit. Zero skips routing.
     /// @dev The forwardee must return ABI-encoded
     ///      `(address specifiedToken, address calculatedToken, int256 specifiedDelta, int256 calculatedDelta)`.
     ///      The deltas must be the endpoint debt changes its route leaves on the shared Core lock.
+    ///      The route runs before the deposit unless the pool has no active liquidity, in which case the deposit
+    ///      runs first so the route can move the pool.
     address router;
     /// @notice Router-specific data forwarded through Core under the position manager's lock.
-    bytes route;
+    bytes routerData;
 }
 
 /// @notice Shared interface for adding liquidity through a position NFT manager.
 interface IPositionDepositor is IBaseNonfungibleToken {
-    /// @notice Thrown when a deposit specifies zero liquidity.
-    error ZeroDepositLiquidity();
+    /// @notice Thrown when deposit liquidity is zero or cannot fit in the Core position update type.
+    error InvalidDepositLiquidity(uint128 liquidity);
 
-    /// @notice Thrown when deposit liquidity cannot fit in the Core position update type.
-    error DepositOverflow();
+    /// @notice Thrown when adding liquidity would make a managed position exceed the Core update type.
+    error PositionLiquidityOverflow(uint128 currentLiquidity, uint128 addedLiquidity);
 
     /// @notice Thrown when the target sqrt ratio is not a valid Core price.
     error InvalidTargetSqrtRatio(SqrtRatio targetSqrtRatio);
 
-    /// @notice Thrown when the routed swap does not leave the pool at the target price.
+    /// @notice Thrown when the deposit does not leave the pool at the target price.
     error TargetSqrtRatioNotReached(SqrtRatio targetSqrtRatio, SqrtRatio actualSqrtRatio);
-
-    /// @notice Thrown when an extension changes the price while liquidity is being added.
-    error DepositSqrtRatioChanged(SqrtRatio targetSqrtRatio, SqrtRatio actualSqrtRatio);
 
     /// @notice Thrown when the net price-setting swap and deposit amounts exceed a caller limit.
     error DepositExceedsMaxAmounts(int256 amount0, int256 amount1, uint128 maxAmount0, uint128 maxAmount1);
@@ -63,13 +58,12 @@ interface IPositionDepositor is IBaseNonfungibleToken {
     /// @notice Thrown when a routed output is too large to settle in one Core withdrawal.
     error RouteOutputOverflow(address token, int256 amount);
 
-    /// @notice Adds exactly the requested liquidity and optionally routes before or after the update.
-    /// @dev Positive returned amounts are paid by the caller. Negative returned amounts are sent to `swapRecipient`,
-    ///      or to the caller when `swapRecipient` is zero.
+    /// @notice Adds exactly the requested liquidity and optionally routes around the update.
+    /// @dev Positive returned amounts are paid by the caller. Negative returned amounts are sent to the caller.
     function deposit(uint256 id, PositionDeposit calldata parameters)
         external
         payable
-        returns (uint128 liquidity, int256 amount0, int256 amount1);
+        returns (int256 amount0, int256 amount1);
 
     /// @notice Initializes a pool if it has not been initialized yet.
     function maybeInitializePool(PoolKey calldata poolKey, int32 tick)
@@ -81,11 +75,11 @@ interface IPositionDepositor is IBaseNonfungibleToken {
     function mintAndDeposit(PositionDeposit calldata parameters)
         external
         payable
-        returns (uint256 id, uint128 liquidity, int256 amount0, int256 amount1);
+        returns (uint256 id, int256 amount0, int256 amount1);
 
     /// @notice Mints a deterministic NFT, adds exactly the requested liquidity, and optionally routes around the update.
     function mintAndDepositWithSalt(bytes32 salt, PositionDeposit calldata parameters)
         external
         payable
-        returns (uint256 id, uint128 liquidity, int256 amount0, int256 amount1);
+        returns (uint256 id, int256 amount0, int256 amount1);
 }

--- a/src/interfaces/IPositionDepositor.sol
+++ b/src/interfaces/IPositionDepositor.sol
@@ -5,7 +5,7 @@ import {PoolKey} from "../types/poolKey.sol";
 import {SqrtRatio} from "../types/sqrtRatio.sol";
 import {IBaseNonfungibleToken} from "./IBaseNonfungibleToken.sol";
 
-/// @notice Parameters for adding an exact amount of liquidity at an exact pool price.
+/// @notice Parameters for adding the maximum liquidity possible at an exact pool price.
 struct PositionDeposit {
     /// @notice Pool receiving the liquidity.
     PoolKey poolKey;
@@ -13,20 +13,22 @@ struct PositionDeposit {
     int32 tickLower;
     /// @notice Upper tick of the position range.
     int32 tickUpper;
-    /// @notice Exact amount of liquidity to add.
-    uint128 liquidity;
-    /// @notice Exact final pool sqrt ratio after the liquidity update and optional route.
-    SqrtRatio targetSqrtRatio;
     /// @notice Maximum net amount of token0 the caller will pay across the price-setting swap and deposit.
     uint128 maxAmount0;
     /// @notice Maximum net amount of token1 the caller will pay across the price-setting swap and deposit.
     uint128 maxAmount1;
-    /// @notice Optional Core forwardee used to rebalance the deposit. Zero skips routing.
+    /// @notice Minimum liquidity that must be added.
+    uint128 minLiquidity;
+    /// @notice Exact pool sqrt ratio at which liquidity must be added.
+    SqrtRatio targetSqrtRatio;
+    /// @notice Core forwardee used to rebalance the deposit. A nonzero address always runs; zero skips routing.
     /// @dev The forwardee must return ABI-encoded
     ///      `(address specifiedToken, address calculatedToken, int256 specifiedDelta, int256 calculatedDelta)`.
     ///      The deltas must be the endpoint debt changes its route leaves on the shared Core lock.
-    ///      The route runs before the deposit unless the pool has no active liquidity, in which case the deposit
-    ///      runs first so the route can move the pool.
+    ///      A price-limited route that consumes less than its specified maximum must return the amounts
+    ///      actually swapped, including zero deltas when moving through empty liquidity.
+    ///      The route always runs before liquidity is calculated and added. A swap can move through empty
+    ///      liquidity to its limit without changing either token balance.
     address router;
     /// @notice Router-specific data forwarded through Core under the position manager's lock.
     bytes routerData;
@@ -34,8 +36,11 @@ struct PositionDeposit {
 
 /// @notice Shared interface for adding liquidity through a position NFT manager.
 interface IPositionDepositor is IBaseNonfungibleToken {
-    /// @notice Thrown when deposit liquidity is zero or cannot fit in the Core position update type.
-    error InvalidDepositLiquidity(uint128 liquidity);
+    /// @notice Thrown when the maximum liquidity available is below the caller's minimum.
+    error DepositLiquidityBelowMinimum(uint128 liquidity, uint128 minLiquidity);
+
+    /// @notice Thrown when the available liquidity cannot fit in one Core position update.
+    error DepositLiquidityOverflow(uint128 liquidity);
 
     /// @notice Thrown when adding liquidity would make a managed position exceed the Core update type.
     error PositionLiquidityOverflow(uint128 currentLiquidity, uint128 addedLiquidity);
@@ -58,12 +63,12 @@ interface IPositionDepositor is IBaseNonfungibleToken {
     /// @notice Thrown when a routed output is too large to settle in one Core withdrawal.
     error RouteOutputOverflow(address token, int256 amount);
 
-    /// @notice Adds exactly the requested liquidity and optionally routes around the update.
+    /// @notice Routes when the router is nonzero, then adds the maximum liquidity allowed by the token limits.
     /// @dev Positive returned amounts are paid by the caller. Negative returned amounts are sent to the caller.
     function deposit(uint256 id, PositionDeposit calldata parameters)
         external
         payable
-        returns (int256 amount0, int256 amount1);
+        returns (uint128 liquidity, int256 amount0, int256 amount1);
 
     /// @notice Initializes a pool if it has not been initialized yet.
     function maybeInitializePool(PoolKey calldata poolKey, int32 tick)
@@ -71,15 +76,15 @@ interface IPositionDepositor is IBaseNonfungibleToken {
         payable
         returns (bool initialized, SqrtRatio sqrtRatio);
 
-    /// @notice Mints a new NFT, adds exactly the requested liquidity, and optionally routes around the update.
+    /// @notice Mints a new NFT, routes when the router is nonzero, and adds the maximum available liquidity.
     function mintAndDeposit(PositionDeposit calldata parameters)
         external
         payable
-        returns (uint256 id, int256 amount0, int256 amount1);
+        returns (uint256 id, uint128 liquidity, int256 amount0, int256 amount1);
 
-    /// @notice Mints a deterministic NFT, adds exactly the requested liquidity, and optionally routes around the update.
+    /// @notice Mints a deterministic NFT, routes when the router is nonzero, and adds the maximum available liquidity.
     function mintAndDepositWithSalt(bytes32 salt, PositionDeposit calldata parameters)
         external
         payable
-        returns (uint256 id, int256 amount0, int256 amount1);
+        returns (uint256 id, uint128 liquidity, int256 amount0, int256 amount1);
 }

--- a/src/interfaces/IPositionDepositor.sol
+++ b/src/interfaces/IPositionDepositor.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: ekubo-license-v1.eth
+pragma solidity ^0.8.0;
+
+import {PoolKey} from "../types/poolKey.sol";
+import {SqrtRatio} from "../types/sqrtRatio.sol";
+import {IBaseNonfungibleToken} from "./IBaseNonfungibleToken.sol";
+
+/// @notice Parameters for adding an exact amount of liquidity at an exact pool price.
+struct PositionDeposit {
+    /// @notice Pool receiving the liquidity.
+    PoolKey poolKey;
+    /// @notice Lower tick of the position range.
+    int32 tickLower;
+    /// @notice Upper tick of the position range.
+    int32 tickUpper;
+    /// @notice Exact amount of liquidity to add.
+    uint128 liquidity;
+    /// @notice Exact final pool sqrt ratio after the liquidity update and optional route.
+    SqrtRatio targetSqrtRatio;
+    /// @notice Maximum net amount of token0 the caller will pay across the price-setting swap and deposit.
+    uint128 maxAmount0;
+    /// @notice Maximum net amount of token1 the caller will pay across the price-setting swap and deposit.
+    uint128 maxAmount1;
+    /// @notice Recipient of any token output left after netting the price-setting swap against the deposit.
+    address swapRecipient;
+    /// @notice Whether to add liquidity before routing, so the route can move a pool with no active liquidity.
+    bool routeAfterDeposit;
+    /// @notice Optional Core forwardee to execute before or after adding liquidity. Zero skips routing.
+    /// @dev The forwardee must return ABI-encoded
+    ///      `(address specifiedToken, address calculatedToken, int256 specifiedDelta, int256 calculatedDelta)`.
+    ///      The deltas must be the endpoint debt changes its route leaves on the shared Core lock.
+    address router;
+    /// @notice Router-specific data forwarded through Core under the position manager's lock.
+    bytes route;
+}
+
+/// @notice Shared interface for adding liquidity through a position NFT manager.
+interface IPositionDepositor is IBaseNonfungibleToken {
+    /// @notice Thrown when a deposit specifies zero liquidity.
+    error ZeroDepositLiquidity();
+
+    /// @notice Thrown when deposit liquidity cannot fit in the Core position update type.
+    error DepositOverflow();
+
+    /// @notice Thrown when the target sqrt ratio is not a valid Core price.
+    error InvalidTargetSqrtRatio(SqrtRatio targetSqrtRatio);
+
+    /// @notice Thrown when the routed swap does not leave the pool at the target price.
+    error TargetSqrtRatioNotReached(SqrtRatio targetSqrtRatio, SqrtRatio actualSqrtRatio);
+
+    /// @notice Thrown when an extension changes the price while liquidity is being added.
+    error DepositSqrtRatioChanged(SqrtRatio targetSqrtRatio, SqrtRatio actualSqrtRatio);
+
+    /// @notice Thrown when the net price-setting swap and deposit amounts exceed a caller limit.
+    error DepositExceedsMaxAmounts(int256 amount0, int256 amount1, uint128 maxAmount0, uint128 maxAmount1);
+
+    /// @notice Thrown when route data is provided without a router.
+    error RouterRequired();
+
+    /// @notice Thrown when a router returns endpoint tokens other than the deposit pool pair.
+    error InvalidRouteTokens(address specifiedToken, address calculatedToken, address token0, address token1);
+
+    /// @notice Thrown when a routed output is too large to settle in one Core withdrawal.
+    error RouteOutputOverflow(address token, int256 amount);
+
+    /// @notice Adds exactly the requested liquidity and optionally routes before or after the update.
+    /// @dev Positive returned amounts are paid by the caller. Negative returned amounts are sent to `swapRecipient`,
+    ///      or to the caller when `swapRecipient` is zero.
+    function deposit(uint256 id, PositionDeposit calldata parameters)
+        external
+        payable
+        returns (uint128 liquidity, int256 amount0, int256 amount1);
+
+    /// @notice Initializes a pool if it has not been initialized yet.
+    function maybeInitializePool(PoolKey calldata poolKey, int32 tick)
+        external
+        payable
+        returns (bool initialized, SqrtRatio sqrtRatio);
+
+    /// @notice Mints a new NFT, adds exactly the requested liquidity, and optionally routes around the update.
+    function mintAndDeposit(PositionDeposit calldata parameters)
+        external
+        payable
+        returns (uint256 id, uint128 liquidity, int256 amount0, int256 amount1);
+
+    /// @notice Mints a deterministic NFT, adds exactly the requested liquidity, and optionally routes around the update.
+    function mintAndDepositWithSalt(bytes32 salt, PositionDeposit calldata parameters)
+        external
+        payable
+        returns (uint256 id, uint128 liquidity, int256 amount0, int256 amount1);
+}

--- a/src/interfaces/IPositionsV2.sol
+++ b/src/interfaces/IPositionsV2.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: ekubo-license-v1.eth
+pragma solidity ^0.8.0;
+
+import {PoolKey} from "../types/poolKey.sol";
+import {IPositionDepositor} from "./IPositionDepositor.sol";
+
+/// @notice Exact-liquidity positions interface with routed deposits.
+interface IPositionsV2 is IPositionDepositor {
+    error WithdrawOverflow();
+
+    function getPositionFeesAndLiquidity(uint256 id, PoolKey calldata poolKey, int32 tickLower, int32 tickUpper)
+        external
+        view
+        returns (uint128 liquidity, uint128 principal0, uint128 principal1, uint128 fees0, uint128 fees1);
+
+    function collectFees(uint256 id, PoolKey calldata poolKey, int32 tickLower, int32 tickUpper)
+        external
+        payable
+        returns (uint128 amount0, uint128 amount1);
+
+    function collectFees(uint256 id, PoolKey calldata poolKey, int32 tickLower, int32 tickUpper, address recipient)
+        external
+        payable
+        returns (uint128 amount0, uint128 amount1);
+
+    function withdraw(
+        uint256 id,
+        PoolKey calldata poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 liquidity,
+        address recipient,
+        bool withFees
+    ) external payable returns (uint128 amount0, uint128 amount1);
+
+    function withdraw(uint256 id, PoolKey calldata poolKey, int32 tickLower, int32 tickUpper, uint128 liquidity)
+        external
+        payable
+        returns (uint128 amount0, uint128 amount1);
+
+    function withdrawProtocolFees(address token0, address token1, uint128 amount0, uint128 amount1, address recipient)
+        external
+        payable;
+
+    function getProtocolFees(address token0, address token1) external view returns (uint128 amount0, uint128 amount1);
+}

--- a/src/interfaces/IPositionsV2.sol
+++ b/src/interfaces/IPositionsV2.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import {PoolKey} from "../types/poolKey.sol";
 import {IPositionDepositor} from "./IPositionDepositor.sol";
 
-/// @notice Exact-liquidity positions interface with routed deposits.
+/// @notice Positions interface with maximum-liquidity routed deposits.
 interface IPositionsV2 is IPositionDepositor {
     error WithdrawOverflow();
 

--- a/test/ConfigureSTONX.t.sol
+++ b/test/ConfigureSTONX.t.sol
@@ -37,7 +37,7 @@ contract ConfigureSTONXHarness is ConfigureSTONX {
         address governance
     ) external returns (PoolKey memory poolKey, uint256 positionId, uint256 veId, uint128 scheduledAmount) {
         poolKey = _stonxPoolKey(address(stonx), usdg, address(ve33));
-        positionId = _seedLiquidity(stonx, positions, poolKey, usdg, address(this), governance, bytes32(0));
+        positionId = _seedLiquidity(stonx, positions, core, poolKey, usdg, address(this), governance, bytes32(0));
         veId = _stakeAndVote(stonx, veToken, core, poolKey, bytes32(0));
         positions.transferOwnership(governance);
         scheduledAmount = _scheduleInitialEmissions(stonx, periphery, address(this));

--- a/test/ForwardedSwapRouter.sol
+++ b/test/ForwardedSwapRouter.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: ekubo-license-v1.eth
+pragma solidity =0.8.33;
+
+import {BaseForwardee} from "../src/base/BaseForwardee.sol";
+import {ICore} from "../src/interfaces/ICore.sol";
+import {CoreLib} from "../src/libraries/CoreLib.sol";
+import {FlashAccountantLib} from "../src/libraries/FlashAccountantLib.sol";
+import {Locker} from "../src/types/locker.sol";
+import {PoolBalanceUpdate} from "../src/types/poolBalanceUpdate.sol";
+import {PoolKey} from "../src/types/poolKey.sol";
+import {PoolState} from "../src/types/poolState.sol";
+import {SwapParameters} from "../src/types/swapParameters.sol";
+
+struct ForwardedSwapRoute {
+    PoolKey poolKey;
+    SwapParameters params;
+    bool useExtension;
+    bool reverseResult;
+    bool returnInvalidTokens;
+    bool misreportDeltas;
+}
+
+/// @notice Test router that leaves swap debts on the original Core locker.
+contract ForwardedSwapRouter is BaseForwardee {
+    using CoreLib for *;
+    using FlashAccountantLib for *;
+
+    ICore private immutable CORE;
+
+    constructor(ICore core) BaseForwardee(core) {
+        CORE = core;
+    }
+
+    function handleForwardData(Locker, bytes memory data) internal override returns (bytes memory result) {
+        ForwardedSwapRoute memory route = abi.decode(data, (ForwardedSwapRoute));
+        if (route.returnInvalidTokens) {
+            return abi.encode(address(1), address(2), int256(0), int256(0));
+        }
+
+        PoolBalanceUpdate balanceUpdate;
+        if (route.useExtension) {
+            (balanceUpdate,) = abi.decode(
+                CORE.forward(route.poolKey.config.extension(), abi.encode(route.poolKey, route.params)),
+                (PoolBalanceUpdate, PoolState)
+            );
+        } else {
+            (balanceUpdate,) = CORE.swap(0, route.poolKey, route.params);
+        }
+
+        address specifiedToken = route.params.isToken1() ? route.poolKey.token1 : route.poolKey.token0;
+        address calculatedToken = route.params.isToken1() ? route.poolKey.token0 : route.poolKey.token1;
+        int256 specifiedDelta =
+            route.params.isToken1() ? int256(balanceUpdate.delta1()) : int256(balanceUpdate.delta0());
+        int256 calculatedDelta =
+            route.params.isToken1() ? int256(balanceUpdate.delta0()) : int256(balanceUpdate.delta1());
+
+        if (route.misreportDeltas) return abi.encode(specifiedToken, calculatedToken, int256(0), int256(0));
+        if (route.reverseResult) {
+            return abi.encode(calculatedToken, specifiedToken, calculatedDelta, specifiedDelta);
+        }
+        result = abi.encode(specifiedToken, calculatedToken, specifiedDelta, calculatedDelta);
+    }
+}

--- a/test/FullTest.sol
+++ b/test/FullTest.sol
@@ -268,8 +268,9 @@ abstract contract FullTest is Test {
         }
         TestToken(poolKey.token1).approve(address(positions), amount1);
 
-        (id, liquidity,,) =
-            positions.mintAndDeposit{value: value}(positionDeposit(poolKey, tickLower, tickUpper, amount0, amount1));
+        PositionDeposit memory parameters = positionDeposit(poolKey, tickLower, tickUpper, amount0, amount1);
+        liquidity = parameters.liquidity;
+        (id,,) = positions.mintAndDeposit{value: value}(parameters);
     }
 
     function positionDeposit(
@@ -290,10 +291,8 @@ abstract contract FullTest is Test {
             targetSqrtRatio: sqrtRatio,
             maxAmount0: maxAmount0,
             maxAmount1: maxAmount1,
-            swapRecipient: address(0),
-            routeAfterDeposit: false,
             router: address(0),
-            route: bytes("")
+            routerData: bytes("")
         });
     }
 

--- a/test/FullTest.sol
+++ b/test/FullTest.sol
@@ -269,8 +269,7 @@ abstract contract FullTest is Test {
         TestToken(poolKey.token1).approve(address(positions), amount1);
 
         PositionDeposit memory parameters = positionDeposit(poolKey, tickLower, tickUpper, amount0, amount1);
-        liquidity = parameters.liquidity;
-        (id,,) = positions.mintAndDeposit{value: value}(parameters);
+        (id, liquidity,,) = positions.mintAndDeposit{value: value}(parameters);
     }
 
     function positionDeposit(
@@ -281,16 +280,16 @@ abstract contract FullTest is Test {
         uint128 maxAmount1
     ) internal view returns (PositionDeposit memory parameters) {
         SqrtRatio sqrtRatio = core.poolState(poolKey.toPoolId()).sqrtRatio();
+        uint128 liquidity =
+            maxLiquidity(sqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), maxAmount0, maxAmount1);
         parameters = PositionDeposit({
             poolKey: poolKey,
             tickLower: tickLower,
             tickUpper: tickUpper,
-            liquidity: maxLiquidity(
-                sqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), maxAmount0, maxAmount1
-            ),
-            targetSqrtRatio: sqrtRatio,
             maxAmount0: maxAmount0,
             maxAmount1: maxAmount1,
+            minLiquidity: liquidity,
+            targetSqrtRatio: sqrtRatio,
             router: address(0),
             routerData: bytes("")
         });

--- a/test/FullTest.sol
+++ b/test/FullTest.sol
@@ -3,7 +3,10 @@ pragma solidity =0.8.33;
 
 import {Test} from "forge-std/Test.sol";
 import {ICore, IExtension} from "../src/interfaces/ICore.sol";
+import {PositionDeposit} from "../src/interfaces/IPositionDepositor.sol";
 import {NATIVE_TOKEN_ADDRESS} from "../src/math/constants.sol";
+import {maxLiquidity} from "../src/math/liquidity.sol";
+import {tickToSqrtRatio} from "../src/math/ticks.sol";
 import {Core} from "../src/Core.sol";
 import {Positions} from "../src/Positions.sol";
 import {PoolKey} from "../src/types/poolKey.sol";
@@ -18,6 +21,7 @@ import {SwapParameters} from "../src/types/swapParameters.sol";
 import {BaseLocker} from "../src/base/BaseLocker.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 import {FlashAccountantLib} from "../src/libraries/FlashAccountantLib.sol";
+import {CoreLib} from "../src/libraries/CoreLib.sol";
 import {Locker} from "../src/types/locker.sol";
 import {PoolBalanceUpdate} from "../src/types/poolBalanceUpdate.sol";
 
@@ -153,6 +157,8 @@ contract MockExtension is IExtension, BaseLocker {
 }
 
 abstract contract FullTest is Test {
+    using CoreLib for *;
+
     address immutable owner = makeAddr("owner");
     Core core;
     Positions positions;
@@ -244,6 +250,16 @@ abstract contract FullTest is Test {
         internal
         returns (uint256 id, uint128 liquidity)
     {
+        return this.createPositionExternal(poolKey, tickLower, tickUpper, amount0, amount1);
+    }
+
+    function createPositionExternal(
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 amount0,
+        uint128 amount1
+    ) external returns (uint256 id, uint128 liquidity) {
         uint256 value;
         if (poolKey.token0 == NATIVE_TOKEN_ADDRESS) {
             value = amount0;
@@ -252,7 +268,33 @@ abstract contract FullTest is Test {
         }
         TestToken(poolKey.token1).approve(address(positions), amount1);
 
-        (id, liquidity,,) = positions.mintAndDeposit{value: value}(poolKey, tickLower, tickUpper, amount0, amount1, 0);
+        (id, liquidity,,) =
+            positions.mintAndDeposit{value: value}(positionDeposit(poolKey, tickLower, tickUpper, amount0, amount1));
+    }
+
+    function positionDeposit(
+        PoolKey memory poolKey,
+        int32 tickLower,
+        int32 tickUpper,
+        uint128 maxAmount0,
+        uint128 maxAmount1
+    ) internal view returns (PositionDeposit memory parameters) {
+        SqrtRatio sqrtRatio = core.poolState(poolKey.toPoolId()).sqrtRatio();
+        parameters = PositionDeposit({
+            poolKey: poolKey,
+            tickLower: tickLower,
+            tickUpper: tickUpper,
+            liquidity: maxLiquidity(
+                sqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), maxAmount0, maxAmount1
+            ),
+            targetSqrtRatio: sqrtRatio,
+            maxAmount0: maxAmount0,
+            maxAmount1: maxAmount1,
+            swapRecipient: address(0),
+            routeAfterDeposit: false,
+            router: address(0),
+            route: bytes("")
+        });
     }
 
     function advanceTime(uint256 by) internal returns (uint256 next) {

--- a/test/Orders.t.sol
+++ b/test/Orders.t.sol
@@ -488,14 +488,16 @@ contract OrdersTest is BaseOrdersTest {
 
         twamm.lockAndExecuteVirtualOrders(poolKey);
         (uint128 liquidity0,,) = positions.deposit(
-            pID, poolKey, MIN_TICK, MAX_TICK, 9065869775701580912051, 16591196256327018126941976177968210, 0
+            pID,
+            positionDeposit(poolKey, MIN_TICK, MAX_TICK, 9065869775701580912051, 16591196256327018126941976177968210)
         );
 
         advanceTime(102_399);
 
         twamm.lockAndExecuteVirtualOrders(poolKey);
-        (uint128 liquidity1,,) =
-            positions.deposit(pID, poolKey, MIN_TICK, MAX_TICK, 229636410600502050710229286961, 502804080817310396, 0);
+        (uint128 liquidity1,,) = positions.deposit(
+            pID, positionDeposit(poolKey, MIN_TICK, MAX_TICK, 229636410600502050710229286961, 502804080817310396)
+        );
         (sqrtRatio, tick, liquidity) = core.poolState(poolId).parse();
 
         assertEq(sqrtRatio.toFixed(), 13485562298671080879303606629460147559991345152);
@@ -535,7 +537,8 @@ contract OrdersTest is BaseOrdersTest {
 
         twamm.lockAndExecuteVirtualOrders(poolKey);
         (uint128 liquidity2,,) = positions.deposit(
-            pID, poolKey, MIN_TICK, MAX_TICK, 1412971749302168760052394, 35831434466998775335139276644539, 0
+            pID,
+            positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1412971749302168760052394, 35831434466998775335139276644539)
         );
 
         liquidity = core.poolState(poolId).liquidity();

--- a/test/Orders.t.sol
+++ b/test/Orders.t.sol
@@ -13,6 +13,7 @@ import {TWAMMLib} from "../src/libraries/TWAMMLib.sol";
 import {TWAMMStorageLayout} from "../src/libraries/TWAMMStorageLayout.sol";
 import {Orders} from "../src/Orders.sol";
 import {IOrders} from "../src/interfaces/IOrders.sol";
+import {PositionDeposit} from "../src/interfaces/IPositionDepositor.sol";
 import {BaseTWAMMTest} from "./extensions/TWAMM.t.sol";
 import {ITWAMM, OrderKey} from "../src/interfaces/extensions/ITWAMM.sol";
 import {TwammPoolState, createTwammPoolState} from "../src/types/twammPoolState.sol";
@@ -487,17 +488,18 @@ contract OrdersTest is BaseOrdersTest {
         uint256 pID = positions.mint();
 
         twamm.lockAndExecuteVirtualOrders(poolKey);
-        (uint128 liquidity0,,) = positions.deposit(
-            pID,
-            positionDeposit(poolKey, MIN_TICK, MAX_TICK, 9065869775701580912051, 16591196256327018126941976177968210)
-        );
+        PositionDeposit memory deposit0 =
+            positionDeposit(poolKey, MIN_TICK, MAX_TICK, 9065869775701580912051, 16591196256327018126941976177968210);
+        uint128 liquidity0 = deposit0.liquidity;
+        positions.deposit(pID, deposit0);
 
         advanceTime(102_399);
 
         twamm.lockAndExecuteVirtualOrders(poolKey);
-        (uint128 liquidity1,,) = positions.deposit(
-            pID, positionDeposit(poolKey, MIN_TICK, MAX_TICK, 229636410600502050710229286961, 502804080817310396)
-        );
+        PositionDeposit memory deposit1 =
+            positionDeposit(poolKey, MIN_TICK, MAX_TICK, 229636410600502050710229286961, 502804080817310396);
+        uint128 liquidity1 = deposit1.liquidity;
+        positions.deposit(pID, deposit1);
         (sqrtRatio, tick, liquidity) = core.poolState(poolId).parse();
 
         assertEq(sqrtRatio.toFixed(), 13485562298671080879303606629460147559991345152);
@@ -536,10 +538,10 @@ contract OrdersTest is BaseOrdersTest {
         assertEq(liquidity, liquidity0 + liquidity1);
 
         twamm.lockAndExecuteVirtualOrders(poolKey);
-        (uint128 liquidity2,,) = positions.deposit(
-            pID,
-            positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1412971749302168760052394, 35831434466998775335139276644539)
-        );
+        PositionDeposit memory deposit2 =
+            positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1412971749302168760052394, 35831434466998775335139276644539);
+        uint128 liquidity2 = deposit2.liquidity;
+        positions.deposit(pID, deposit2);
 
         liquidity = core.poolState(poolId).liquidity();
         assertEq(liquidity, liquidity0 + liquidity1 + liquidity2);

--- a/test/Orders.t.sol
+++ b/test/Orders.t.sol
@@ -490,16 +490,14 @@ contract OrdersTest is BaseOrdersTest {
         twamm.lockAndExecuteVirtualOrders(poolKey);
         PositionDeposit memory deposit0 =
             positionDeposit(poolKey, MIN_TICK, MAX_TICK, 9065869775701580912051, 16591196256327018126941976177968210);
-        uint128 liquidity0 = deposit0.liquidity;
-        positions.deposit(pID, deposit0);
+        (uint128 liquidity0,,) = positions.deposit(pID, deposit0);
 
         advanceTime(102_399);
 
         twamm.lockAndExecuteVirtualOrders(poolKey);
         PositionDeposit memory deposit1 =
             positionDeposit(poolKey, MIN_TICK, MAX_TICK, 229636410600502050710229286961, 502804080817310396);
-        uint128 liquidity1 = deposit1.liquidity;
-        positions.deposit(pID, deposit1);
+        (uint128 liquidity1,,) = positions.deposit(pID, deposit1);
         (sqrtRatio, tick, liquidity) = core.poolState(poolId).parse();
 
         assertEq(sqrtRatio.toFixed(), 13485562298671080879303606629460147559991345152);
@@ -540,8 +538,7 @@ contract OrdersTest is BaseOrdersTest {
         twamm.lockAndExecuteVirtualOrders(poolKey);
         PositionDeposit memory deposit2 =
             positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1412971749302168760052394, 35831434466998775335139276644539);
-        uint128 liquidity2 = deposit2.liquidity;
-        positions.deposit(pID, deposit2);
+        (uint128 liquidity2,,) = positions.deposit(pID, deposit2);
 
         liquidity = core.poolState(poolId).liquidity();
         assertEq(liquidity, liquidity0 + liquidity1 + liquidity2);

--- a/test/Positions.t.sol
+++ b/test/Positions.t.sol
@@ -4,20 +4,22 @@ pragma solidity =0.8.33;
 import {CallPoints} from "../src/types/callPoints.sol";
 import {PoolKey} from "../src/types/poolKey.sol";
 import {FullTest, MockExtension} from "./FullTest.sol";
+import {ForwardedSwapRoute, ForwardedSwapRouter} from "./ForwardedSwapRouter.sol";
 import {RouteNode, TokenAmount} from "../src/base/BaseRouter.sol";
+import {IFlashAccountant} from "../src/interfaces/IFlashAccountant.sol";
+import {IPositionDepositor, PositionDeposit} from "../src/interfaces/IPositionDepositor.sol";
 import {SqrtRatio} from "../src/types/sqrtRatio.sol";
-import {createSwapParameters} from "../src/types/swapParameters.sol";
+import {SwapParameters, createSwapParameters} from "../src/types/swapParameters.sol";
 import {PoolBalanceUpdate} from "../src/types/poolBalanceUpdate.sol";
 import {MIN_TICK, MAX_TICK} from "../src/math/constants.sol";
 import {MIN_SQRT_RATIO, MAX_SQRT_RATIO} from "../src/types/sqrtRatio.sol";
 import {Positions} from "../src/Positions.sol";
 import {FreePositions} from "../src/FreePositions.sol";
 import {tickToSqrtRatio} from "../src/math/ticks.sol";
+import {liquidityDeltaToAmountDelta} from "../src/math/liquidity.sol";
 import {computeFee} from "../src/math/fee.sol";
 import {CoreLib} from "../src/libraries/CoreLib.sol";
-import {CoreStorageLayout} from "../src/libraries/CoreStorageLayout.sol";
-import {StorageSlot} from "../src/types/storageSlot.sol";
-import {PoolState, createPoolState} from "../src/types/poolState.sol";
+import {PoolState} from "../src/types/poolState.sol";
 import {PoolConfig, createStableswapPoolConfig} from "../src/types/poolConfig.sol";
 import {PositionId, createPositionId} from "../src/types/positionId.sol";
 
@@ -44,13 +46,347 @@ contract PositionsTest is FullTest {
         assertNotEq(id, p2.saltToId(minter, salt));
     }
 
+    function test_mintAndDeposit_rebalancesUnevenAmountsThroughForwardedRouter() public {
+        this.runRoutedDeposit(false);
+    }
+
+    function test_mintAndDeposit_mapsReversedRouteEndpoints() public {
+        this.runRoutedDeposit(true);
+    }
+
+    function test_mintAndDeposit_sendsNetSwapOutputToRecipient() public {
+        PoolKey memory poolKey = createPool(0, 0, 100);
+        createPosition(poolKey, -100, 100, 10_000, 10_000);
+
+        int128 swapAmount = 1_000;
+        (PoolBalanceUpdate swapBalanceUpdate, PoolState stateAfter) = router.quote({
+            poolKey: poolKey, isToken1: false, amount: swapAmount, sqrtRatioLimit: MIN_SQRT_RATIO, skipAhead: 0
+        });
+        SqrtRatio targetSqrtRatio = stateAfter.sqrtRatio();
+        uint128 depositLiquidity = 4_000_000;
+        (int128 depositAmount0, int128 depositAmount1) = liquidityDeltaToAmountDelta(
+            targetSqrtRatio, int128(depositLiquidity), tickToSqrtRatio(-100), tickToSqrtRatio(100)
+        );
+        int256 expectedAmount0 = int256(swapBalanceUpdate.delta0()) + int256(depositAmount0);
+        int256 expectedAmount1 = int256(swapBalanceUpdate.delta1()) + int256(depositAmount1);
+        assertGt(expectedAmount0, 0, "token0 net input");
+        assertLt(expectedAmount1, 0, "token1 net output");
+
+        ForwardedSwapRouter forwardedRouter = new ForwardedSwapRouter(core);
+        address swapRecipient = makeAddr("swap recipient");
+        PositionDeposit memory parameters = PositionDeposit({
+            poolKey: poolKey,
+            tickLower: -100,
+            tickUpper: 100,
+            liquidity: depositLiquidity,
+            targetSqrtRatio: targetSqrtRatio,
+            maxAmount0: uint128(uint256(expectedAmount0)),
+            maxAmount1: 0,
+            swapRecipient: swapRecipient,
+            routeAfterDeposit: false,
+            router: address(forwardedRouter),
+            route: abi.encode(
+                ForwardedSwapRoute({
+                    poolKey: poolKey,
+                    params: createSwapParameters(targetSqrtRatio, swapAmount, false, 0),
+                    useExtension: false,
+                    reverseResult: false,
+                    returnInvalidTokens: false,
+                    misreportDeltas: false
+                })
+            )
+        });
+
+        token0.approve(address(positions), parameters.maxAmount0);
+        uint256 token0Before = token0.balanceOf(address(this));
+        uint256 recipientToken1Before = token1.balanceOf(swapRecipient);
+        (, uint128 actualLiquidity, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
+
+        assertEq(actualLiquidity, depositLiquidity, "exact liquidity");
+        assertEq(amount0, expectedAmount0, "net token0");
+        assertEq(amount1, expectedAmount1, "net token1");
+        assertEq(token0Before - token0.balanceOf(address(this)), uint256(expectedAmount0), "token0 spent");
+        assertEq(
+            token1.balanceOf(swapRecipient) - recipientToken1Before,
+            uint256(-expectedAmount1),
+            "recipient token1 output"
+        );
+    }
+
+    function test_mintAndDeposit_canRouteAfterAddingLiquidityToEmptyPool() public {
+        PoolKey memory poolKey = createPool(50, 0, 100);
+        assertEq(core.poolState(poolKey.toPoolId()).liquidity(), 0, "pool starts empty");
+
+        uint128 depositLiquidity = 100_000_000;
+        SqrtRatio initialSqrtRatio = core.poolState(poolKey.toPoolId()).sqrtRatio();
+        (int128 depositAmount0, int128 depositAmount1) = liquidityDeltaToAmountDelta(
+            initialSqrtRatio, int128(depositLiquidity), tickToSqrtRatio(-100), tickToSqrtRatio(100)
+        );
+
+        uint256 snapshotId = vm.snapshotState();
+        PositionDeposit memory quoteDeposit = PositionDeposit({
+            poolKey: poolKey,
+            tickLower: -100,
+            tickUpper: 100,
+            liquidity: depositLiquidity,
+            targetSqrtRatio: initialSqrtRatio,
+            maxAmount0: uint128(depositAmount0),
+            maxAmount1: uint128(depositAmount1),
+            swapRecipient: address(0),
+            routeAfterDeposit: false,
+            router: address(0),
+            route: bytes("")
+        });
+        token0.approve(address(positions), quoteDeposit.maxAmount0);
+        token1.approve(address(positions), quoteDeposit.maxAmount1);
+        (,, int256 quotedDepositAmount0, int256 quotedDepositAmount1) = positions.mintAndDeposit(quoteDeposit);
+
+        int128 swapAmount = 1_000;
+        (PoolBalanceUpdate swapBalanceUpdate, PoolState stateAfter) = router.quote({
+            poolKey: poolKey, isToken1: false, amount: swapAmount, sqrtRatioLimit: MIN_SQRT_RATIO, skipAhead: 0
+        });
+        SqrtRatio targetSqrtRatio = stateAfter.sqrtRatio();
+        assertTrue(vm.revertToState(snapshotId), "revert quote state");
+
+        int256 expectedAmount0 = quotedDepositAmount0 + int256(swapBalanceUpdate.delta0());
+        int256 expectedAmount1 = quotedDepositAmount1 + int256(swapBalanceUpdate.delta1());
+        assertGt(expectedAmount0, 0, "token0 net input");
+        assertGt(expectedAmount1, 0, "token1 net input");
+
+        ForwardedSwapRouter forwardedRouter = new ForwardedSwapRouter(core);
+        PositionDeposit memory parameters = PositionDeposit({
+            poolKey: poolKey,
+            tickLower: -100,
+            tickUpper: 100,
+            liquidity: depositLiquidity,
+            targetSqrtRatio: targetSqrtRatio,
+            maxAmount0: uint128(uint256(expectedAmount0)),
+            maxAmount1: uint128(uint256(expectedAmount1)),
+            swapRecipient: address(0),
+            routeAfterDeposit: true,
+            router: address(forwardedRouter),
+            route: abi.encode(
+                ForwardedSwapRoute({
+                    poolKey: poolKey,
+                    params: createSwapParameters(targetSqrtRatio, swapAmount, false, 0),
+                    useExtension: false,
+                    reverseResult: false,
+                    returnInvalidTokens: false,
+                    misreportDeltas: false
+                })
+            )
+        });
+        token0.approve(address(positions), parameters.maxAmount0);
+        token1.approve(address(positions), parameters.maxAmount1);
+
+        (, uint128 actualLiquidity, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
+
+        assertEq(actualLiquidity, depositLiquidity, "exact liquidity");
+        assertEq(amount0, expectedAmount0, "net token0");
+        assertEq(amount1, expectedAmount1, "net token1");
+        assertEq(core.poolState(poolKey.toPoolId()).liquidity(), depositLiquidity, "active liquidity");
+        assertEq(
+            SqrtRatio.unwrap(core.poolState(poolKey.toPoolId()).sqrtRatio()),
+            SqrtRatio.unwrap(targetSqrtRatio),
+            "target price"
+        );
+    }
+
+    function runRoutedDeposit(bool reverseResult) external {
+        PoolKey memory poolKey = createPool(0, 0, 100);
+        createPosition(poolKey, -100, 100, 10_000, 10_000);
+
+        int128 swapAmount = 1_000;
+        (PoolBalanceUpdate swapBalanceUpdate, PoolState stateAfter) = router.quote({
+            poolKey: poolKey, isToken1: false, amount: swapAmount, sqrtRatioLimit: MIN_SQRT_RATIO, skipAhead: 0
+        });
+        SqrtRatio targetSqrtRatio = stateAfter.sqrtRatio();
+        uint128 depositLiquidity = 40_000_000;
+        (int128 depositAmount0, int128 depositAmount1) = liquidityDeltaToAmountDelta(
+            targetSqrtRatio, int128(depositLiquidity), tickToSqrtRatio(-100), tickToSqrtRatio(100)
+        );
+        int256 expectedAmount0 = int256(swapBalanceUpdate.delta0()) + int256(depositAmount0);
+        int256 expectedAmount1 = int256(swapBalanceUpdate.delta1()) + int256(depositAmount1);
+        assertGt(expectedAmount0, 0, "token0 net input");
+        assertGt(expectedAmount1, 0, "token1 net input");
+        assertNotEq(expectedAmount0, expectedAmount1, "uneven net inputs");
+
+        uint128 maxAmount0 = uint128(uint256(expectedAmount0));
+        uint128 maxAmount1 = uint128(uint256(expectedAmount1));
+        ForwardedSwapRouter forwardedRouter = new ForwardedSwapRouter(core);
+        PositionDeposit memory parameters = PositionDeposit({
+            poolKey: poolKey,
+            tickLower: -100,
+            tickUpper: 100,
+            liquidity: depositLiquidity,
+            targetSqrtRatio: targetSqrtRatio,
+            maxAmount0: maxAmount0 - 1,
+            maxAmount1: maxAmount1,
+            swapRecipient: address(0),
+            routeAfterDeposit: false,
+            router: address(forwardedRouter),
+            route: abi.encode(
+                ForwardedSwapRoute({
+                    poolKey: poolKey,
+                    params: createSwapParameters(targetSqrtRatio, swapAmount, false, 0),
+                    useExtension: false,
+                    reverseResult: reverseResult,
+                    returnInvalidTokens: false,
+                    misreportDeltas: false
+                })
+            )
+        });
+
+        token0.approve(address(positions), maxAmount0);
+        token1.approve(address(positions), maxAmount1);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPositionDepositor.DepositExceedsMaxAmounts.selector,
+                expectedAmount0,
+                expectedAmount1,
+                maxAmount0 - 1,
+                maxAmount1
+            )
+        );
+        positions.mintAndDeposit(parameters);
+
+        parameters.maxAmount0 = maxAmount0;
+        uint256 balance0Before = token0.balanceOf(address(this));
+        uint256 balance1Before = token1.balanceOf(address(this));
+        (uint256 id, uint128 actualLiquidity, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
+
+        assertEq(actualLiquidity, depositLiquidity, "exact liquidity");
+        assertEq(amount0, expectedAmount0, "net token0");
+        assertEq(amount1, expectedAmount1, "net token1");
+        assertEq(balance0Before - token0.balanceOf(address(this)), uint256(expectedAmount0), "token0 spent");
+        assertEq(balance1Before - token1.balanceOf(address(this)), uint256(expectedAmount1), "token1 spent");
+        assertEq(
+            SqrtRatio.unwrap(core.poolState(poolKey.toPoolId()).sqrtRatio()),
+            SqrtRatio.unwrap(targetSqrtRatio),
+            "target price"
+        );
+
+        PositionId positionId = createPositionId(bytes24(uint192(id)), -100, 100);
+        assertEq(
+            core.poolPositions(poolKey.toPoolId(), address(positions), positionId).liquidity,
+            depositLiquidity,
+            "position liquidity"
+        );
+    }
+
+    function test_mintAndDeposit_revertsForZeroLiquidity() public {
+        PoolKey memory poolKey = createPool(0, 0, 100);
+        PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
+        parameters.liquidity = 0;
+
+        vm.expectRevert(IPositionDepositor.ZeroDepositLiquidity.selector);
+        positions.mintAndDeposit(parameters);
+    }
+
+    function test_mintAndDeposit_revertsWhenTargetPriceIsStale() public {
+        PoolKey memory poolKey = createPool(0, 0, 100);
+        PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
+        SqrtRatio actualSqrtRatio = parameters.targetSqrtRatio;
+        parameters.targetSqrtRatio = tickToSqrtRatio(1);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPositionDepositor.TargetSqrtRatioNotReached.selector, parameters.targetSqrtRatio, actualSqrtRatio
+            )
+        );
+        positions.mintAndDeposit(parameters);
+    }
+
+    function test_mintAndDeposit_revertsForInvalidTargetPrice() public {
+        PoolKey memory poolKey = createPool(0, 0, 100);
+        PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
+        parameters.targetSqrtRatio = SqrtRatio.wrap(0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IPositionDepositor.InvalidTargetSqrtRatio.selector, parameters.targetSqrtRatio)
+        );
+        positions.mintAndDeposit(parameters);
+    }
+
+    function test_mintAndDeposit_revertsForRouteWithoutRouter() public {
+        PoolKey memory poolKey = createPool(0, 0, 100);
+        PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
+        parameters.route = hex"01";
+
+        vm.expectRevert(IPositionDepositor.RouterRequired.selector);
+        positions.mintAndDeposit(parameters);
+    }
+
+    function test_mintAndDeposit_revertsForInvalidRouteTokens() public {
+        PoolKey memory poolKey = createPool(0, 0, 100);
+        ForwardedSwapRouter forwardedRouter = new ForwardedSwapRouter(core);
+        PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
+        parameters.router = address(forwardedRouter);
+        parameters.route = abi.encode(
+            ForwardedSwapRoute({
+                poolKey: poolKey,
+                params: SwapParameters.wrap(bytes32(0)),
+                useExtension: false,
+                reverseResult: false,
+                returnInvalidTokens: true,
+                misreportDeltas: false
+            })
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPositionDepositor.InvalidRouteTokens.selector, address(1), address(2), poolKey.token0, poolKey.token1
+            )
+        );
+        positions.mintAndDeposit(parameters);
+    }
+
+    function test_mintAndDeposit_revertsWhenRouterMisreportsDeltas() public {
+        PoolKey memory poolKey = createPool(0, 0, 100);
+        createPosition(poolKey, -100, 100, 10_000, 10_000);
+
+        int128 swapAmount = 100;
+        (, PoolState stateAfter) = router.quote({
+            poolKey: poolKey, isToken1: false, amount: swapAmount, sqrtRatioLimit: MIN_SQRT_RATIO, skipAhead: 0
+        });
+        ForwardedSwapRouter forwardedRouter = new ForwardedSwapRouter(core);
+        PositionDeposit memory parameters = PositionDeposit({
+            poolKey: poolKey,
+            tickLower: -100,
+            tickUpper: 100,
+            liquidity: 1_000_000,
+            targetSqrtRatio: stateAfter.sqrtRatio(),
+            maxAmount0: type(uint128).max,
+            maxAmount1: type(uint128).max,
+            swapRecipient: address(0),
+            routeAfterDeposit: false,
+            router: address(forwardedRouter),
+            route: abi.encode(
+                ForwardedSwapRoute({
+                    poolKey: poolKey,
+                    params: createSwapParameters(stateAfter.sqrtRatio(), swapAmount, false, 0),
+                    useExtension: false,
+                    reverseResult: false,
+                    returnInvalidTokens: false,
+                    misreportDeltas: true
+                })
+            )
+        });
+        token0.approve(address(positions), type(uint256).max);
+        token1.approve(address(positions), type(uint256).max);
+
+        vm.expectRevert(abi.encodeWithSelector(IFlashAccountant.DebtsNotZeroed.selector, 0));
+        positions.mintAndDeposit(parameters);
+    }
+
     function test_mintAndDeposit(CallPoints memory callPoints) public {
         PoolKey memory poolKey = createPool(0, 1 << 63, 100, callPoints);
 
         token0.approve(address(positions), 100);
         token1.approve(address(positions), 100);
 
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(poolKey, -100, 100, 100, 100, 0);
+        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(positionDeposit(poolKey, -100, 100, 100, 100));
         assertGt(id, 0);
         assertGt(liquidity, 0);
         PositionId positionId = createPositionId(bytes24(uint192(id)), -100, 100);
@@ -79,8 +415,8 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        (, uint128 liquidityA,,) = positions.mintAndDeposit(poolKey, -100, 100, 100, 100, 0);
-        (, uint128 liquidityB,,) = positions.mintAndDeposit(poolKey, -300, -100, 100, 100, 0);
+        (, uint128 liquidityA,,) = positions.mintAndDeposit(positionDeposit(poolKey, -100, 100, 100, 100));
+        (, uint128 liquidityB,,) = positions.mintAndDeposit(positionDeposit(poolKey, -300, -100, 100, 100));
 
         (int128 liquidityDelta, uint128 liquidityNet) = core.poolTicks(poolKey.toPoolId(), -300);
         assertEq(liquidityDelta, int128(liquidityB));
@@ -302,7 +638,8 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), type(uint256).max);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, 0);
+        (uint256 id, uint128 liquidity,,) =
+            positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36));
         vm.snapshotGasLastCall("mintAndDeposit full range max");
         assertGt(liquidity, 0);
 
@@ -331,7 +668,8 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), type(uint256).max);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, 0);
+        (uint256 id, uint128 liquidity,,) =
+            positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36));
         vm.snapshotGasLastCall("mintAndDeposit full range min");
         assertGt(liquidity, 0);
 
@@ -360,7 +698,7 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        (uint256 id,,,) = positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, 0);
+        (uint256 id,,,) = positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36));
         (,,, uint128 f0, uint128 f1) = positions.getPositionFeesAndLiquidity(id, poolKey, MIN_TICK, MAX_TICK);
         assertEq(f0, 0);
         assertEq(f1, 0);
@@ -386,7 +724,7 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        (uint256 id,,,) = positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36, 0);
+        (uint256 id,,,) = positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36));
         (,,, uint128 f0, uint128 f1) = positions.getPositionFeesAndLiquidity(id, poolKey, MIN_TICK, MAX_TICK);
         assertEq(f0, 0);
         assertEq(f1, 0);
@@ -453,7 +791,7 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), 100);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(poolKey, -100, 100, 100, 100, 0);
+        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(positionDeposit(poolKey, -100, 100, 100, 100));
         vm.snapshotGasLastCall("mintAndDeposit");
 
         coolAllContracts();
@@ -467,7 +805,8 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), 100);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit{value: 100}(poolKey, -100, 100, 100, 100, 0);
+        (uint256 id, uint128 liquidity,,) =
+            positions.mintAndDeposit{value: 100}(positionDeposit(poolKey, -100, 100, 100, 100));
         vm.snapshotGasLastCall("mintAndDeposit eth");
 
         coolAllContracts();
@@ -482,7 +821,8 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), 100);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit{value: 100}(poolKey, -100, 100, 100, 100, 0);
+        (uint256 id, uint128 liquidity,,) =
+            positions.mintAndDeposit{value: 100}(positionDeposit(poolKey, -100, 100, 100, 100));
         vm.snapshotGasLastCall("mintAndDeposit eth (free)");
 
         coolAllContracts();
@@ -504,7 +844,8 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), type(uint256).max);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
+        (uint256 id, uint128 liquidity,,) =
+            positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18));
         vm.snapshotGasLastCall("mintAndDeposit full range both tokens");
 
         coolAllContracts();
@@ -533,8 +874,10 @@ contract PositionsTest is FullTest {
         token1.approve(address(testPositions), type(uint256).max);
 
         // Test 1: Mint and deposit should work regardless of protocol fee parameters
-        (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) =
-            testPositions.mintAndDeposit(poolKey, -100, 100, 1000, 1000, 0);
+        (uint256 id, uint128 liquidity, int256 signedAmount0, int256 signedAmount1) =
+            testPositions.mintAndDeposit(positionDeposit(poolKey, -100, 100, 1000, 1000));
+        uint128 amount0 = uint128(uint256(signedAmount0));
+        uint128 amount1 = uint128(uint256(signedAmount1));
 
         assertGt(id, 0, "Position ID should be greater than 0");
         assertGt(liquidity, 0, "Liquidity should be greater than 0");
@@ -608,8 +951,10 @@ contract PositionsTest is FullTest {
         token1.approve(address(testPositions), type(uint256).max);
 
         // Test 1: Mint and deposit should work regardless of protocol fee parameters
-        (uint256 id, uint128 liquidity, uint128 amount0, uint128 amount1) =
-            testPositions.mintAndDeposit(poolKey, -100, 100, 1000, 1000, 0);
+        (uint256 id, uint128 liquidity, int256 signedAmount0, int256 signedAmount1) =
+            testPositions.mintAndDeposit(positionDeposit(poolKey, -100, 100, 1000, 1000));
+        uint128 amount0 = uint128(uint256(signedAmount0));
+        uint128 amount1 = uint128(uint256(signedAmount1));
 
         assertGt(id, 0, "Position ID should be greater than 0");
         assertGt(liquidity, 0, "Liquidity should be greater than 0");

--- a/test/Positions.t.sol
+++ b/test/Positions.t.sol
@@ -54,7 +54,7 @@ contract PositionsTest is FullTest {
         this.runRoutedDeposit(true);
     }
 
-    function test_mintAndDeposit_sendsNetSwapOutputToRecipient() public {
+    function test_mintAndDeposit_sendsNetSwapOutputToCaller() public {
         PoolKey memory poolKey = createPool(0, 0, 100);
         createPosition(poolKey, -100, 100, 10_000, 10_000);
 
@@ -73,7 +73,6 @@ contract PositionsTest is FullTest {
         assertLt(expectedAmount1, 0, "token1 net output");
 
         ForwardedSwapRouter forwardedRouter = new ForwardedSwapRouter(core);
-        address swapRecipient = makeAddr("swap recipient");
         PositionDeposit memory parameters = PositionDeposit({
             poolKey: poolKey,
             tickLower: -100,
@@ -82,10 +81,8 @@ contract PositionsTest is FullTest {
             targetSqrtRatio: targetSqrtRatio,
             maxAmount0: uint128(uint256(expectedAmount0)),
             maxAmount1: 0,
-            swapRecipient: swapRecipient,
-            routeAfterDeposit: false,
             router: address(forwardedRouter),
-            route: abi.encode(
+            routerData: abi.encode(
                 ForwardedSwapRoute({
                     poolKey: poolKey,
                     params: createSwapParameters(targetSqrtRatio, swapAmount, false, 0),
@@ -99,21 +96,16 @@ contract PositionsTest is FullTest {
 
         token0.approve(address(positions), parameters.maxAmount0);
         uint256 token0Before = token0.balanceOf(address(this));
-        uint256 recipientToken1Before = token1.balanceOf(swapRecipient);
-        (, uint128 actualLiquidity, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
+        uint256 token1Before = token1.balanceOf(address(this));
+        (, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
 
-        assertEq(actualLiquidity, depositLiquidity, "exact liquidity");
         assertEq(amount0, expectedAmount0, "net token0");
         assertEq(amount1, expectedAmount1, "net token1");
         assertEq(token0Before - token0.balanceOf(address(this)), uint256(expectedAmount0), "token0 spent");
-        assertEq(
-            token1.balanceOf(swapRecipient) - recipientToken1Before,
-            uint256(-expectedAmount1),
-            "recipient token1 output"
-        );
+        assertEq(token1.balanceOf(address(this)) - token1Before, uint256(-expectedAmount1), "caller token1 output");
     }
 
-    function test_mintAndDeposit_canRouteAfterAddingLiquidityToEmptyPool() public {
+    function test_mintAndDeposit_automaticallyRoutesAfterAddingLiquidityToEmptyPool() public {
         PoolKey memory poolKey = createPool(50, 0, 100);
         assertEq(core.poolState(poolKey.toPoolId()).liquidity(), 0, "pool starts empty");
 
@@ -132,14 +124,12 @@ contract PositionsTest is FullTest {
             targetSqrtRatio: initialSqrtRatio,
             maxAmount0: uint128(depositAmount0),
             maxAmount1: uint128(depositAmount1),
-            swapRecipient: address(0),
-            routeAfterDeposit: false,
             router: address(0),
-            route: bytes("")
+            routerData: bytes("")
         });
         token0.approve(address(positions), quoteDeposit.maxAmount0);
         token1.approve(address(positions), quoteDeposit.maxAmount1);
-        (,, int256 quotedDepositAmount0, int256 quotedDepositAmount1) = positions.mintAndDeposit(quoteDeposit);
+        (, int256 quotedDepositAmount0, int256 quotedDepositAmount1) = positions.mintAndDeposit(quoteDeposit);
 
         int128 swapAmount = 1_000;
         (PoolBalanceUpdate swapBalanceUpdate, PoolState stateAfter) = router.quote({
@@ -162,10 +152,8 @@ contract PositionsTest is FullTest {
             targetSqrtRatio: targetSqrtRatio,
             maxAmount0: uint128(uint256(expectedAmount0)),
             maxAmount1: uint128(uint256(expectedAmount1)),
-            swapRecipient: address(0),
-            routeAfterDeposit: true,
             router: address(forwardedRouter),
-            route: abi.encode(
+            routerData: abi.encode(
                 ForwardedSwapRoute({
                     poolKey: poolKey,
                     params: createSwapParameters(targetSqrtRatio, swapAmount, false, 0),
@@ -179,9 +167,8 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), parameters.maxAmount0);
         token1.approve(address(positions), parameters.maxAmount1);
 
-        (, uint128 actualLiquidity, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
+        (, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
 
-        assertEq(actualLiquidity, depositLiquidity, "exact liquidity");
         assertEq(amount0, expectedAmount0, "net token0");
         assertEq(amount1, expectedAmount1, "net token1");
         assertEq(core.poolState(poolKey.toPoolId()).liquidity(), depositLiquidity, "active liquidity");
@@ -222,10 +209,8 @@ contract PositionsTest is FullTest {
             targetSqrtRatio: targetSqrtRatio,
             maxAmount0: maxAmount0 - 1,
             maxAmount1: maxAmount1,
-            swapRecipient: address(0),
-            routeAfterDeposit: false,
             router: address(forwardedRouter),
-            route: abi.encode(
+            routerData: abi.encode(
                 ForwardedSwapRoute({
                     poolKey: poolKey,
                     params: createSwapParameters(targetSqrtRatio, swapAmount, false, 0),
@@ -254,9 +239,8 @@ contract PositionsTest is FullTest {
         parameters.maxAmount0 = maxAmount0;
         uint256 balance0Before = token0.balanceOf(address(this));
         uint256 balance1Before = token1.balanceOf(address(this));
-        (uint256 id, uint128 actualLiquidity, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
+        (uint256 id, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
 
-        assertEq(actualLiquidity, depositLiquidity, "exact liquidity");
         assertEq(amount0, expectedAmount0, "net token0");
         assertEq(amount1, expectedAmount1, "net token1");
         assertEq(balance0Before - token0.balanceOf(address(this)), uint256(expectedAmount0), "token0 spent");
@@ -280,7 +264,9 @@ contract PositionsTest is FullTest {
         PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
         parameters.liquidity = 0;
 
-        vm.expectRevert(IPositionDepositor.ZeroDepositLiquidity.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(IPositionDepositor.InvalidDepositLiquidity.selector, parameters.liquidity)
+        );
         positions.mintAndDeposit(parameters);
     }
 
@@ -312,7 +298,7 @@ contract PositionsTest is FullTest {
     function test_mintAndDeposit_revertsForRouteWithoutRouter() public {
         PoolKey memory poolKey = createPool(0, 0, 100);
         PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
-        parameters.route = hex"01";
+        parameters.routerData = hex"01";
 
         vm.expectRevert(IPositionDepositor.RouterRequired.selector);
         positions.mintAndDeposit(parameters);
@@ -323,7 +309,7 @@ contract PositionsTest is FullTest {
         ForwardedSwapRouter forwardedRouter = new ForwardedSwapRouter(core);
         PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
         parameters.router = address(forwardedRouter);
-        parameters.route = abi.encode(
+        parameters.routerData = abi.encode(
             ForwardedSwapRoute({
                 poolKey: poolKey,
                 params: SwapParameters.wrap(bytes32(0)),
@@ -359,10 +345,8 @@ contract PositionsTest is FullTest {
             targetSqrtRatio: stateAfter.sqrtRatio(),
             maxAmount0: type(uint128).max,
             maxAmount1: type(uint128).max,
-            swapRecipient: address(0),
-            routeAfterDeposit: false,
             router: address(forwardedRouter),
-            route: abi.encode(
+            routerData: abi.encode(
                 ForwardedSwapRoute({
                     poolKey: poolKey,
                     params: createSwapParameters(stateAfter.sqrtRatio(), swapAmount, false, 0),
@@ -386,7 +370,9 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), 100);
         token1.approve(address(positions), 100);
 
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(positionDeposit(poolKey, -100, 100, 100, 100));
+        PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
+        uint128 liquidity = parameters.liquidity;
+        (uint256 id,,) = positions.mintAndDeposit(parameters);
         assertGt(id, 0);
         assertGt(liquidity, 0);
         PositionId positionId = createPositionId(bytes24(uint192(id)), -100, 100);
@@ -415,8 +401,12 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        (, uint128 liquidityA,,) = positions.mintAndDeposit(positionDeposit(poolKey, -100, 100, 100, 100));
-        (, uint128 liquidityB,,) = positions.mintAndDeposit(positionDeposit(poolKey, -300, -100, 100, 100));
+        PositionDeposit memory parametersA = positionDeposit(poolKey, -100, 100, 100, 100);
+        PositionDeposit memory parametersB = positionDeposit(poolKey, -300, -100, 100, 100);
+        uint128 liquidityA = parametersA.liquidity;
+        uint128 liquidityB = parametersB.liquidity;
+        positions.mintAndDeposit(parametersA);
+        positions.mintAndDeposit(parametersB);
 
         (int128 liquidityDelta, uint128 liquidityNet) = core.poolTicks(poolKey.toPoolId(), -300);
         assertEq(liquidityDelta, int128(liquidityB));
@@ -638,8 +628,9 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), type(uint256).max);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) =
-            positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36));
+        PositionDeposit memory parameters = positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36);
+        uint128 liquidity = parameters.liquidity;
+        (uint256 id,,) = positions.mintAndDeposit(parameters);
         vm.snapshotGasLastCall("mintAndDeposit full range max");
         assertGt(liquidity, 0);
 
@@ -668,8 +659,9 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), type(uint256).max);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) =
-            positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36));
+        PositionDeposit memory parameters = positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36);
+        uint128 liquidity = parameters.liquidity;
+        (uint256 id,,) = positions.mintAndDeposit(parameters);
         vm.snapshotGasLastCall("mintAndDeposit full range min");
         assertGt(liquidity, 0);
 
@@ -698,7 +690,7 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        (uint256 id,,,) = positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36));
+        (uint256 id,,) = positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36));
         (,,, uint128 f0, uint128 f1) = positions.getPositionFeesAndLiquidity(id, poolKey, MIN_TICK, MAX_TICK);
         assertEq(f0, 0);
         assertEq(f1, 0);
@@ -724,7 +716,7 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        (uint256 id,,,) = positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36));
+        (uint256 id,,) = positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36));
         (,,, uint128 f0, uint128 f1) = positions.getPositionFeesAndLiquidity(id, poolKey, MIN_TICK, MAX_TICK);
         assertEq(f0, 0);
         assertEq(f1, 0);
@@ -791,7 +783,9 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), 100);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(positionDeposit(poolKey, -100, 100, 100, 100));
+        PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
+        uint128 liquidity = parameters.liquidity;
+        (uint256 id,,) = positions.mintAndDeposit(parameters);
         vm.snapshotGasLastCall("mintAndDeposit");
 
         coolAllContracts();
@@ -805,8 +799,9 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), 100);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) =
-            positions.mintAndDeposit{value: 100}(positionDeposit(poolKey, -100, 100, 100, 100));
+        PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
+        uint128 liquidity = parameters.liquidity;
+        (uint256 id,,) = positions.mintAndDeposit{value: 100}(parameters);
         vm.snapshotGasLastCall("mintAndDeposit eth");
 
         coolAllContracts();
@@ -821,8 +816,9 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), 100);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) =
-            positions.mintAndDeposit{value: 100}(positionDeposit(poolKey, -100, 100, 100, 100));
+        PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
+        uint128 liquidity = parameters.liquidity;
+        (uint256 id,,) = positions.mintAndDeposit{value: 100}(parameters);
         vm.snapshotGasLastCall("mintAndDeposit eth (free)");
 
         coolAllContracts();
@@ -844,8 +840,9 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), type(uint256).max);
 
         coolAllContracts();
-        (uint256 id, uint128 liquidity,,) =
-            positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18));
+        PositionDeposit memory parameters = positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18);
+        uint128 liquidity = parameters.liquidity;
+        (uint256 id,,) = positions.mintAndDeposit(parameters);
         vm.snapshotGasLastCall("mintAndDeposit full range both tokens");
 
         coolAllContracts();
@@ -874,8 +871,9 @@ contract PositionsTest is FullTest {
         token1.approve(address(testPositions), type(uint256).max);
 
         // Test 1: Mint and deposit should work regardless of protocol fee parameters
-        (uint256 id, uint128 liquidity, int256 signedAmount0, int256 signedAmount1) =
-            testPositions.mintAndDeposit(positionDeposit(poolKey, -100, 100, 1000, 1000));
+        PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 1000, 1000);
+        uint128 liquidity = parameters.liquidity;
+        (uint256 id, int256 signedAmount0, int256 signedAmount1) = testPositions.mintAndDeposit(parameters);
         uint128 amount0 = uint128(uint256(signedAmount0));
         uint128 amount1 = uint128(uint256(signedAmount1));
 
@@ -951,8 +949,9 @@ contract PositionsTest is FullTest {
         token1.approve(address(testPositions), type(uint256).max);
 
         // Test 1: Mint and deposit should work regardless of protocol fee parameters
-        (uint256 id, uint128 liquidity, int256 signedAmount0, int256 signedAmount1) =
-            testPositions.mintAndDeposit(positionDeposit(poolKey, -100, 100, 1000, 1000));
+        PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 1000, 1000);
+        uint128 liquidity = parameters.liquidity;
+        (uint256 id, int256 signedAmount0, int256 signedAmount1) = testPositions.mintAndDeposit(parameters);
         uint128 amount0 = uint128(uint256(signedAmount0));
         uint128 amount1 = uint128(uint256(signedAmount1));
 

--- a/test/Positions.t.sol
+++ b/test/Positions.t.sol
@@ -16,7 +16,7 @@ import {MIN_SQRT_RATIO, MAX_SQRT_RATIO} from "../src/types/sqrtRatio.sol";
 import {Positions} from "../src/Positions.sol";
 import {FreePositions} from "../src/FreePositions.sol";
 import {tickToSqrtRatio} from "../src/math/ticks.sol";
-import {liquidityDeltaToAmountDelta} from "../src/math/liquidity.sol";
+import {liquidityDeltaToAmountDelta, maxLiquidity} from "../src/math/liquidity.sol";
 import {computeFee} from "../src/math/fee.sol";
 import {CoreLib} from "../src/libraries/CoreLib.sol";
 import {PoolState} from "../src/types/poolState.sol";
@@ -63,9 +63,21 @@ contract PositionsTest is FullTest {
             poolKey: poolKey, isToken1: false, amount: swapAmount, sqrtRatioLimit: MIN_SQRT_RATIO, skipAhead: 0
         });
         SqrtRatio targetSqrtRatio = stateAfter.sqrtRatio();
-        uint128 depositLiquidity = 4_000_000;
+        uint128 seedLiquidity = 4_000_000;
+        (int128 seedAmount0, int128 seedAmount1) = liquidityDeltaToAmountDelta(
+            targetSqrtRatio, int128(seedLiquidity), tickToSqrtRatio(-100), tickToSqrtRatio(100)
+        );
+        uint128 maxAmount0 = uint128(uint256(int256(swapBalanceUpdate.delta0()) + int256(seedAmount0)));
+        uint128 availableAmount1 = uint128(uint256(-int256(swapBalanceUpdate.delta1())));
+        uint128 expectedLiquidity = maxLiquidity(
+            targetSqrtRatio,
+            tickToSqrtRatio(-100),
+            tickToSqrtRatio(100),
+            maxAmount0 - uint128(swapBalanceUpdate.delta0()),
+            availableAmount1
+        );
         (int128 depositAmount0, int128 depositAmount1) = liquidityDeltaToAmountDelta(
-            targetSqrtRatio, int128(depositLiquidity), tickToSqrtRatio(-100), tickToSqrtRatio(100)
+            targetSqrtRatio, int128(expectedLiquidity), tickToSqrtRatio(-100), tickToSqrtRatio(100)
         );
         int256 expectedAmount0 = int256(swapBalanceUpdate.delta0()) + int256(depositAmount0);
         int256 expectedAmount1 = int256(swapBalanceUpdate.delta1()) + int256(depositAmount1);
@@ -77,10 +89,10 @@ contract PositionsTest is FullTest {
             poolKey: poolKey,
             tickLower: -100,
             tickUpper: 100,
-            liquidity: depositLiquidity,
-            targetSqrtRatio: targetSqrtRatio,
-            maxAmount0: uint128(uint256(expectedAmount0)),
+            maxAmount0: maxAmount0,
             maxAmount1: 0,
+            minLiquidity: expectedLiquidity,
+            targetSqrtRatio: targetSqrtRatio,
             router: address(forwardedRouter),
             routerData: abi.encode(
                 ForwardedSwapRoute({
@@ -97,61 +109,49 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), parameters.maxAmount0);
         uint256 token0Before = token0.balanceOf(address(this));
         uint256 token1Before = token1.balanceOf(address(this));
-        (, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
+        (, uint128 liquidity, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
 
+        assertEq(liquidity, expectedLiquidity, "added liquidity");
         assertEq(amount0, expectedAmount0, "net token0");
         assertEq(amount1, expectedAmount1, "net token1");
         assertEq(token0Before - token0.balanceOf(address(this)), uint256(expectedAmount0), "token0 spent");
         assertEq(token1.balanceOf(address(this)) - token1Before, uint256(-expectedAmount1), "caller token1 output");
     }
 
-    function test_mintAndDeposit_automaticallyRoutesAfterAddingLiquidityToEmptyPool() public {
+    function test_mintAndDeposit_routesEmptyPoolBeforeDepositWithoutConsumingSwapAmount() public {
         PoolKey memory poolKey = createPool(50, 0, 100);
         assertEq(core.poolState(poolKey.toPoolId()).liquidity(), 0, "pool starts empty");
 
-        uint128 depositLiquidity = 100_000_000;
-        SqrtRatio initialSqrtRatio = core.poolState(poolKey.toPoolId()).sqrtRatio();
+        uint128 seedLiquidity = 100_000_000;
+        SqrtRatio targetSqrtRatio = tickToSqrtRatio(-50);
         (int128 depositAmount0, int128 depositAmount1) = liquidityDeltaToAmountDelta(
-            initialSqrtRatio, int128(depositLiquidity), tickToSqrtRatio(-100), tickToSqrtRatio(100)
+            targetSqrtRatio, int128(seedLiquidity), tickToSqrtRatio(-100), tickToSqrtRatio(100)
         );
-
-        uint256 snapshotId = vm.snapshotState();
-        PositionDeposit memory quoteDeposit = PositionDeposit({
-            poolKey: poolKey,
-            tickLower: -100,
-            tickUpper: 100,
-            liquidity: depositLiquidity,
-            targetSqrtRatio: initialSqrtRatio,
-            maxAmount0: uint128(depositAmount0),
-            maxAmount1: uint128(depositAmount1),
-            router: address(0),
-            routerData: bytes("")
-        });
-        token0.approve(address(positions), quoteDeposit.maxAmount0);
-        token1.approve(address(positions), quoteDeposit.maxAmount1);
-        (, int256 quotedDepositAmount0, int256 quotedDepositAmount1) = positions.mintAndDeposit(quoteDeposit);
+        uint128 expectedLiquidity = maxLiquidity(
+            targetSqrtRatio,
+            tickToSqrtRatio(-100),
+            tickToSqrtRatio(100),
+            uint128(depositAmount0),
+            uint128(depositAmount1)
+        );
 
         int128 swapAmount = 1_000;
         (PoolBalanceUpdate swapBalanceUpdate, PoolState stateAfter) = router.quote({
-            poolKey: poolKey, isToken1: false, amount: swapAmount, sqrtRatioLimit: MIN_SQRT_RATIO, skipAhead: 0
+            poolKey: poolKey, isToken1: false, amount: swapAmount, sqrtRatioLimit: targetSqrtRatio, skipAhead: 0
         });
-        SqrtRatio targetSqrtRatio = stateAfter.sqrtRatio();
-        assertTrue(vm.revertToState(snapshotId), "revert quote state");
-
-        int256 expectedAmount0 = quotedDepositAmount0 + int256(swapBalanceUpdate.delta0());
-        int256 expectedAmount1 = quotedDepositAmount1 + int256(swapBalanceUpdate.delta1());
-        assertGt(expectedAmount0, 0, "token0 net input");
-        assertGt(expectedAmount1, 0, "token1 net input");
+        assertEq(swapBalanceUpdate.delta0(), 0, "empty swap token0 delta");
+        assertEq(swapBalanceUpdate.delta1(), 0, "empty swap token1 delta");
+        assertEq(SqrtRatio.unwrap(stateAfter.sqrtRatio()), SqrtRatio.unwrap(targetSqrtRatio), "quoted target");
 
         ForwardedSwapRouter forwardedRouter = new ForwardedSwapRouter(core);
         PositionDeposit memory parameters = PositionDeposit({
             poolKey: poolKey,
             tickLower: -100,
             tickUpper: 100,
-            liquidity: depositLiquidity,
+            maxAmount0: uint128(depositAmount0),
+            maxAmount1: uint128(depositAmount1),
+            minLiquidity: expectedLiquidity,
             targetSqrtRatio: targetSqrtRatio,
-            maxAmount0: uint128(uint256(expectedAmount0)),
-            maxAmount1: uint128(uint256(expectedAmount1)),
             router: address(forwardedRouter),
             routerData: abi.encode(
                 ForwardedSwapRoute({
@@ -167,11 +167,12 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), parameters.maxAmount0);
         token1.approve(address(positions), parameters.maxAmount1);
 
-        (, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
+        (, uint128 liquidity, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
 
-        assertEq(amount0, expectedAmount0, "net token0");
-        assertEq(amount1, expectedAmount1, "net token1");
-        assertEq(core.poolState(poolKey.toPoolId()).liquidity(), depositLiquidity, "active liquidity");
+        assertEq(liquidity, expectedLiquidity, "added liquidity");
+        assertEq(amount0, depositAmount0, "net token0");
+        assertEq(amount1, depositAmount1, "net token1");
+        assertEq(core.poolState(poolKey.toPoolId()).liquidity(), expectedLiquidity, "active liquidity");
         assertEq(
             SqrtRatio.unwrap(core.poolState(poolKey.toPoolId()).sqrtRatio()),
             SqrtRatio.unwrap(targetSqrtRatio),
@@ -188,9 +189,19 @@ contract PositionsTest is FullTest {
             poolKey: poolKey, isToken1: false, amount: swapAmount, sqrtRatioLimit: MIN_SQRT_RATIO, skipAhead: 0
         });
         SqrtRatio targetSqrtRatio = stateAfter.sqrtRatio();
-        uint128 depositLiquidity = 40_000_000;
+        uint128 seedLiquidity = 40_000_000;
+        (int128 seedAmount0, int128 seedAmount1) = liquidityDeltaToAmountDelta(
+            targetSqrtRatio, int128(seedLiquidity), tickToSqrtRatio(-100), tickToSqrtRatio(100)
+        );
+        uint128 maxAmount0 = uint128(uint256(int256(swapBalanceUpdate.delta0()) + int256(seedAmount0)));
+        uint128 maxAmount1 = uint128(uint256(int256(swapBalanceUpdate.delta1()) + int256(seedAmount1)));
+        uint128 availableAmount0 = maxAmount0 - uint128(swapBalanceUpdate.delta0());
+        uint128 availableAmount1 = maxAmount1 + uint128(uint256(-int256(swapBalanceUpdate.delta1())));
+        uint128 expectedLiquidity = maxLiquidity(
+            targetSqrtRatio, tickToSqrtRatio(-100), tickToSqrtRatio(100), availableAmount0, availableAmount1
+        );
         (int128 depositAmount0, int128 depositAmount1) = liquidityDeltaToAmountDelta(
-            targetSqrtRatio, int128(depositLiquidity), tickToSqrtRatio(-100), tickToSqrtRatio(100)
+            targetSqrtRatio, int128(expectedLiquidity), tickToSqrtRatio(-100), tickToSqrtRatio(100)
         );
         int256 expectedAmount0 = int256(swapBalanceUpdate.delta0()) + int256(depositAmount0);
         int256 expectedAmount1 = int256(swapBalanceUpdate.delta1()) + int256(depositAmount1);
@@ -198,17 +209,15 @@ contract PositionsTest is FullTest {
         assertGt(expectedAmount1, 0, "token1 net input");
         assertNotEq(expectedAmount0, expectedAmount1, "uneven net inputs");
 
-        uint128 maxAmount0 = uint128(uint256(expectedAmount0));
-        uint128 maxAmount1 = uint128(uint256(expectedAmount1));
         ForwardedSwapRouter forwardedRouter = new ForwardedSwapRouter(core);
         PositionDeposit memory parameters = PositionDeposit({
             poolKey: poolKey,
             tickLower: -100,
             tickUpper: 100,
-            liquidity: depositLiquidity,
-            targetSqrtRatio: targetSqrtRatio,
             maxAmount0: maxAmount0 - 1,
             maxAmount1: maxAmount1,
+            minLiquidity: expectedLiquidity,
+            targetSqrtRatio: targetSqrtRatio,
             router: address(forwardedRouter),
             routerData: abi.encode(
                 ForwardedSwapRoute({
@@ -225,13 +234,12 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), maxAmount0);
         token1.approve(address(positions), maxAmount1);
 
+        uint128 reducedLiquidity = maxLiquidity(
+            targetSqrtRatio, tickToSqrtRatio(-100), tickToSqrtRatio(100), availableAmount0 - 1, availableAmount1
+        );
         vm.expectRevert(
             abi.encodeWithSelector(
-                IPositionDepositor.DepositExceedsMaxAmounts.selector,
-                expectedAmount0,
-                expectedAmount1,
-                maxAmount0 - 1,
-                maxAmount1
+                IPositionDepositor.DepositLiquidityBelowMinimum.selector, reducedLiquidity, expectedLiquidity
             )
         );
         positions.mintAndDeposit(parameters);
@@ -239,8 +247,9 @@ contract PositionsTest is FullTest {
         parameters.maxAmount0 = maxAmount0;
         uint256 balance0Before = token0.balanceOf(address(this));
         uint256 balance1Before = token1.balanceOf(address(this));
-        (uint256 id, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
+        (uint256 id, uint128 liquidity, int256 amount0, int256 amount1) = positions.mintAndDeposit(parameters);
 
+        assertEq(liquidity, expectedLiquidity, "added liquidity");
         assertEq(amount0, expectedAmount0, "net token0");
         assertEq(amount1, expectedAmount1, "net token1");
         assertEq(balance0Before - token0.balanceOf(address(this)), uint256(expectedAmount0), "token0 spent");
@@ -254,18 +263,18 @@ contract PositionsTest is FullTest {
         PositionId positionId = createPositionId(bytes24(uint192(id)), -100, 100);
         assertEq(
             core.poolPositions(poolKey.toPoolId(), address(positions), positionId).liquidity,
-            depositLiquidity,
+            expectedLiquidity,
             "position liquidity"
         );
     }
 
-    function test_mintAndDeposit_revertsForZeroLiquidity() public {
+    function test_mintAndDeposit_revertsBelowMinimumLiquidity() public {
         PoolKey memory poolKey = createPool(0, 0, 100);
-        PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
-        parameters.liquidity = 0;
+        PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 0, 0);
+        parameters.minLiquidity = 1;
 
         vm.expectRevert(
-            abi.encodeWithSelector(IPositionDepositor.InvalidDepositLiquidity.selector, parameters.liquidity)
+            abi.encodeWithSelector(IPositionDepositor.DepositLiquidityBelowMinimum.selector, uint128(0), uint128(1))
         );
         positions.mintAndDeposit(parameters);
     }
@@ -341,10 +350,10 @@ contract PositionsTest is FullTest {
             poolKey: poolKey,
             tickLower: -100,
             tickUpper: 100,
-            liquidity: 1_000_000,
+            maxAmount0: 10_000,
+            maxAmount1: 10_000,
+            minLiquidity: 1_000_000,
             targetSqrtRatio: stateAfter.sqrtRatio(),
-            maxAmount0: type(uint128).max,
-            maxAmount1: type(uint128).max,
             router: address(forwardedRouter),
             routerData: abi.encode(
                 ForwardedSwapRoute({
@@ -371,8 +380,7 @@ contract PositionsTest is FullTest {
         token1.approve(address(positions), 100);
 
         PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
-        uint128 liquidity = parameters.liquidity;
-        (uint256 id,,) = positions.mintAndDeposit(parameters);
+        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(parameters);
         assertGt(id, 0);
         assertGt(liquidity, 0);
         PositionId positionId = createPositionId(bytes24(uint192(id)), -100, 100);
@@ -403,10 +411,8 @@ contract PositionsTest is FullTest {
 
         PositionDeposit memory parametersA = positionDeposit(poolKey, -100, 100, 100, 100);
         PositionDeposit memory parametersB = positionDeposit(poolKey, -300, -100, 100, 100);
-        uint128 liquidityA = parametersA.liquidity;
-        uint128 liquidityB = parametersB.liquidity;
-        positions.mintAndDeposit(parametersA);
-        positions.mintAndDeposit(parametersB);
+        (, uint128 liquidityA,,) = positions.mintAndDeposit(parametersA);
+        (, uint128 liquidityB,,) = positions.mintAndDeposit(parametersB);
 
         (int128 liquidityDelta, uint128 liquidityNet) = core.poolTicks(poolKey.toPoolId(), -300);
         assertEq(liquidityDelta, int128(liquidityB));
@@ -629,8 +635,7 @@ contract PositionsTest is FullTest {
 
         coolAllContracts();
         PositionDeposit memory parameters = positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36);
-        uint128 liquidity = parameters.liquidity;
-        (uint256 id,,) = positions.mintAndDeposit(parameters);
+        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(parameters);
         vm.snapshotGasLastCall("mintAndDeposit full range max");
         assertGt(liquidity, 0);
 
@@ -660,8 +665,7 @@ contract PositionsTest is FullTest {
 
         coolAllContracts();
         PositionDeposit memory parameters = positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36);
-        uint128 liquidity = parameters.liquidity;
-        (uint256 id,,) = positions.mintAndDeposit(parameters);
+        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(parameters);
         vm.snapshotGasLastCall("mintAndDeposit full range min");
         assertGt(liquidity, 0);
 
@@ -690,7 +694,7 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        (uint256 id,,) = positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36));
+        (uint256 id,,,) = positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36));
         (,,, uint128 f0, uint128 f1) = positions.getPositionFeesAndLiquidity(id, poolKey, MIN_TICK, MAX_TICK);
         assertEq(f0, 0);
         assertEq(f1, 0);
@@ -716,7 +720,7 @@ contract PositionsTest is FullTest {
         token0.approve(address(positions), type(uint256).max);
         token1.approve(address(positions), type(uint256).max);
 
-        (uint256 id,,) = positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36));
+        (uint256 id,,,) = positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e36, 1e36));
         (,,, uint128 f0, uint128 f1) = positions.getPositionFeesAndLiquidity(id, poolKey, MIN_TICK, MAX_TICK);
         assertEq(f0, 0);
         assertEq(f1, 0);
@@ -784,8 +788,7 @@ contract PositionsTest is FullTest {
 
         coolAllContracts();
         PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
-        uint128 liquidity = parameters.liquidity;
-        (uint256 id,,) = positions.mintAndDeposit(parameters);
+        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(parameters);
         vm.snapshotGasLastCall("mintAndDeposit");
 
         coolAllContracts();
@@ -800,8 +803,7 @@ contract PositionsTest is FullTest {
 
         coolAllContracts();
         PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
-        uint128 liquidity = parameters.liquidity;
-        (uint256 id,,) = positions.mintAndDeposit{value: 100}(parameters);
+        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit{value: 100}(parameters);
         vm.snapshotGasLastCall("mintAndDeposit eth");
 
         coolAllContracts();
@@ -817,8 +819,7 @@ contract PositionsTest is FullTest {
 
         coolAllContracts();
         PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 100, 100);
-        uint128 liquidity = parameters.liquidity;
-        (uint256 id,,) = positions.mintAndDeposit{value: 100}(parameters);
+        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit{value: 100}(parameters);
         vm.snapshotGasLastCall("mintAndDeposit eth (free)");
 
         coolAllContracts();
@@ -841,8 +842,7 @@ contract PositionsTest is FullTest {
 
         coolAllContracts();
         PositionDeposit memory parameters = positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18);
-        uint128 liquidity = parameters.liquidity;
-        (uint256 id,,) = positions.mintAndDeposit(parameters);
+        (uint256 id, uint128 liquidity,,) = positions.mintAndDeposit(parameters);
         vm.snapshotGasLastCall("mintAndDeposit full range both tokens");
 
         coolAllContracts();
@@ -872,8 +872,8 @@ contract PositionsTest is FullTest {
 
         // Test 1: Mint and deposit should work regardless of protocol fee parameters
         PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 1000, 1000);
-        uint128 liquidity = parameters.liquidity;
-        (uint256 id, int256 signedAmount0, int256 signedAmount1) = testPositions.mintAndDeposit(parameters);
+        (uint256 id, uint128 liquidity, int256 signedAmount0, int256 signedAmount1) =
+            testPositions.mintAndDeposit(parameters);
         uint128 amount0 = uint128(uint256(signedAmount0));
         uint128 amount1 = uint128(uint256(signedAmount1));
 
@@ -950,8 +950,8 @@ contract PositionsTest is FullTest {
 
         // Test 1: Mint and deposit should work regardless of protocol fee parameters
         PositionDeposit memory parameters = positionDeposit(poolKey, -100, 100, 1000, 1000);
-        uint128 liquidity = parameters.liquidity;
-        (uint256 id, int256 signedAmount0, int256 signedAmount1) = testPositions.mintAndDeposit(parameters);
+        (uint256 id, uint128 liquidity, int256 signedAmount0, int256 signedAmount1) =
+            testPositions.mintAndDeposit(parameters);
         uint128 amount0 = uint128(uint256(signedAmount0));
         uint128 amount1 = uint128(uint256(signedAmount1));
 

--- a/test/PositionsRevenueBuybacks.t.sol
+++ b/test/PositionsRevenueBuybacks.t.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.33;
 
 import {BaseOrdersTest} from "./Orders.t.sol";
 import {PositionsRevenueBuybacks} from "../src/PositionsRevenueBuybacks.sol";
+import {IPositions} from "../src/interfaces/IPositions.sol";
 import {CoreStorageLayout} from "../src/libraries/CoreStorageLayout.sol";
 import {PoolKey} from "../src/types/poolKey.sol";
 import {createFullRangePoolConfig} from "../src/types/poolConfig.sol";
@@ -27,7 +28,8 @@ contract PositionsRevenueBuybacksTest is BaseOrdersTest {
             (token0, token1) = (token1, token0);
         }
 
-        buybacks = new PositionsRevenueBuybacks(address(this), positions, orders, address(buybacksToken));
+        buybacks =
+            new PositionsRevenueBuybacks(address(this), IPositions(address(positions)), orders, address(buybacksToken));
 
         vm.prank(positions.owner());
         positions.transferOwnership(address(buybacks));
@@ -122,7 +124,7 @@ contract PositionsRevenueBuybacksTest is BaseOrdersTest {
         positions.maybeInitializePool(poolKey, 0);
         token0.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
+        positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18));
 
         cheatDonateProtocolFees(address(token0), address(token1), 1e18, 1e17);
 
@@ -147,7 +149,7 @@ contract PositionsRevenueBuybacksTest is BaseOrdersTest {
         positions.maybeInitializePool(poolKey, 0);
         token1.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
+        positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18));
 
         cheatDonateProtocolFees(address(token0), address(token1), 1e18, 1e17);
 
@@ -181,8 +183,8 @@ contract PositionsRevenueBuybacksTest is BaseOrdersTest {
         token1.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 2e18);
 
-        positions.mintAndDeposit(poolKey0, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
-        positions.mintAndDeposit(poolKey1, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
+        positions.mintAndDeposit(positionDeposit(poolKey0, MIN_TICK, MAX_TICK, 1e18, 1e18));
+        positions.mintAndDeposit(positionDeposit(poolKey1, MIN_TICK, MAX_TICK, 1e18, 1e18));
 
         (uint128 fees0, uint128 fees1) = positions.getProtocolFees(address(token0), address(token1));
         assertEq(fees0, 0);

--- a/test/SolvencyInvariantTest.t.sol
+++ b/test/SolvencyInvariantTest.t.sol
@@ -155,16 +155,12 @@ contract Handler is StdUtils, StdAssertions {
             targetSqrtRatio: sqrtRatio,
             maxAmount0: amount0,
             maxAmount1: amount1,
-            swapRecipient: address(0),
-            routeAfterDeposit: false,
             router: address(0),
-            route: bytes("")
+            routerData: bytes("")
         });
 
-        try positions.deposit(positionId, parameters) returns (uint128 liquidity, int256 result0, int256 result1) {
-            if (liquidity > 0) {
-                activePositions.push(ActivePosition(poolKey, tickLower, tickUpper, liquidity));
-            }
+        try positions.deposit(positionId, parameters) returns (int256 result0, int256 result1) {
+            activePositions.push(ActivePosition(poolKey, tickLower, tickUpper, depositLiquidity));
 
             PoolId poolId = poolKey.toPoolId();
             poolBalances[poolId].amount0 += result0;
@@ -177,11 +173,11 @@ contract Handler is StdUtils, StdAssertions {
 
             // 0x4e487b71 is arithmetic overflow/underflow
             if (
-                sig != IPositionDepositor.DepositOverflow.selector && sig != SafeCastLib.Overflow.selector
+                sig != IPositionDepositor.InvalidDepositLiquidity.selector && sig != SafeCastLib.Overflow.selector
                     && sig != 0x4e487b71 && sig != FixedPointMathLib.FullMulDivFailed.selector
                     && sig != LiquidityDeltaOverflow.selector && sig != ICore.MaxLiquidityPerTickExceeded.selector
                     && sig != IPositionDepositor.DepositExceedsMaxAmounts.selector
-                    && sig != IPositionDepositor.DepositSqrtRatioChanged.selector
+                    && sig != IPositionDepositor.TargetSqrtRatioNotReached.selector
             ) {
                 revert UnexpectedError(err);
             }

--- a/test/SolvencyInvariantTest.t.sol
+++ b/test/SolvencyInvariantTest.t.sol
@@ -21,8 +21,7 @@ import {Positions} from "../src/Positions.sol";
 import {IPositionDepositor, PositionDeposit} from "../src/interfaces/IPositionDepositor.sol";
 import {TestToken} from "./TestToken.sol";
 import {ICore} from "../src/interfaces/ICore.sol";
-import {LiquidityDeltaOverflow, maxLiquidity} from "../src/math/liquidity.sol";
-import {tickToSqrtRatio} from "../src/math/ticks.sol";
+import {LiquidityDeltaOverflow} from "../src/math/liquidity.sol";
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
 
 function maxBounds(PoolConfig config) pure returns (int32 tickLower, int32 tickUpper) {
@@ -144,23 +143,20 @@ contract Handler is StdUtils, StdAssertions {
         }
 
         SqrtRatio sqrtRatio = core.poolState(poolKey.toPoolId()).sqrtRatio();
-        uint128 depositLiquidity =
-            maxLiquidity(sqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), amount0, amount1);
-        if (depositLiquidity == 0) return;
         PositionDeposit memory parameters = PositionDeposit({
             poolKey: poolKey,
             tickLower: tickLower,
             tickUpper: tickUpper,
-            liquidity: depositLiquidity,
-            targetSqrtRatio: sqrtRatio,
             maxAmount0: amount0,
             maxAmount1: amount1,
+            minLiquidity: 1,
+            targetSqrtRatio: sqrtRatio,
             router: address(0),
             routerData: bytes("")
         });
 
-        try positions.deposit(positionId, parameters) returns (int256 result0, int256 result1) {
-            activePositions.push(ActivePosition(poolKey, tickLower, tickUpper, depositLiquidity));
+        try positions.deposit(positionId, parameters) returns (uint128 liquidity, int256 result0, int256 result1) {
+            activePositions.push(ActivePosition(poolKey, tickLower, tickUpper, liquidity));
 
             PoolId poolId = poolKey.toPoolId();
             poolBalances[poolId].amount0 += result0;
@@ -173,9 +169,11 @@ contract Handler is StdUtils, StdAssertions {
 
             // 0x4e487b71 is arithmetic overflow/underflow
             if (
-                sig != IPositionDepositor.InvalidDepositLiquidity.selector && sig != SafeCastLib.Overflow.selector
-                    && sig != 0x4e487b71 && sig != FixedPointMathLib.FullMulDivFailed.selector
-                    && sig != LiquidityDeltaOverflow.selector && sig != ICore.MaxLiquidityPerTickExceeded.selector
+                sig != IPositionDepositor.DepositLiquidityBelowMinimum.selector
+                    && sig != IPositionDepositor.DepositLiquidityOverflow.selector
+                    && sig != SafeCastLib.Overflow.selector && sig != 0x4e487b71
+                    && sig != FixedPointMathLib.FullMulDivFailed.selector && sig != LiquidityDeltaOverflow.selector
+                    && sig != ICore.MaxLiquidityPerTickExceeded.selector
                     && sig != IPositionDepositor.DepositExceedsMaxAmounts.selector
                     && sig != IPositionDepositor.TargetSqrtRatioNotReached.selector
             ) {

--- a/test/SolvencyInvariantTest.t.sol
+++ b/test/SolvencyInvariantTest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity =0.8.33;
 
 import {PoolKey} from "../src/types/poolKey.sol";
-import {PoolBalanceUpdate, createPoolBalanceUpdate} from "../src/types/poolBalanceUpdate.sol";
+import {PoolBalanceUpdate} from "../src/types/poolBalanceUpdate.sol";
 import {PoolConfig, createStableswapPoolConfig, createConcentratedPoolConfig} from "../src/types/poolConfig.sol";
 import {PoolId} from "../src/types/poolId.sol";
 import {SqrtRatio, MIN_SQRT_RATIO, MAX_SQRT_RATIO, toSqrtRatio} from "../src/types/sqrtRatio.sol";
@@ -18,10 +18,11 @@ import {StdUtils} from "forge-std/StdUtils.sol";
 import {StdAssertions} from "forge-std/StdAssertions.sol";
 import {CoreLib} from "../src/libraries/CoreLib.sol";
 import {Positions} from "../src/Positions.sol";
-import {IPositions} from "../src/interfaces/IPositions.sol";
+import {IPositionDepositor, PositionDeposit} from "../src/interfaces/IPositionDepositor.sol";
 import {TestToken} from "./TestToken.sol";
 import {ICore} from "../src/interfaces/ICore.sol";
-import {LiquidityDeltaOverflow} from "../src/math/liquidity.sol";
+import {LiquidityDeltaOverflow, maxLiquidity} from "../src/math/liquidity.sol";
+import {tickToSqrtRatio} from "../src/math/ticks.sol";
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
 
 function maxBounds(PoolConfig config) pure returns (int32 tickLower, int32 tickUpper) {
@@ -142,16 +143,32 @@ contract Handler is StdUtils, StdAssertions {
                 * int32(poolKey.config.concentratedTickSpacing());
         }
 
-        try positions.deposit(positionId, poolKey, tickLower, tickUpper, amount0, amount1, 0) returns (
-            uint128 liquidity, uint128 result0, uint128 result1
-        ) {
+        SqrtRatio sqrtRatio = core.poolState(poolKey.toPoolId()).sqrtRatio();
+        uint128 depositLiquidity =
+            maxLiquidity(sqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), amount0, amount1);
+        if (depositLiquidity == 0) return;
+        PositionDeposit memory parameters = PositionDeposit({
+            poolKey: poolKey,
+            tickLower: tickLower,
+            tickUpper: tickUpper,
+            liquidity: depositLiquidity,
+            targetSqrtRatio: sqrtRatio,
+            maxAmount0: amount0,
+            maxAmount1: amount1,
+            swapRecipient: address(0),
+            routeAfterDeposit: false,
+            router: address(0),
+            route: bytes("")
+        });
+
+        try positions.deposit(positionId, parameters) returns (uint128 liquidity, int256 result0, int256 result1) {
             if (liquidity > 0) {
                 activePositions.push(ActivePosition(poolKey, tickLower, tickUpper, liquidity));
             }
 
             PoolId poolId = poolKey.toPoolId();
-            poolBalances[poolId].amount0 += int256(uint256(result0));
-            poolBalances[poolId].amount1 += int256(uint256(result1));
+            poolBalances[poolId].amount0 += result0;
+            poolBalances[poolId].amount1 += result1;
         } catch (bytes memory err) {
             bytes4 sig;
             assembly ("memory-safe") {
@@ -160,9 +177,11 @@ contract Handler is StdUtils, StdAssertions {
 
             // 0x4e487b71 is arithmetic overflow/underflow
             if (
-                sig != IPositions.DepositOverflow.selector && sig != SafeCastLib.Overflow.selector && sig != 0x4e487b71
-                    && sig != FixedPointMathLib.FullMulDivFailed.selector && sig != LiquidityDeltaOverflow.selector
-                    && sig != ICore.MaxLiquidityPerTickExceeded.selector
+                sig != IPositionDepositor.DepositOverflow.selector && sig != SafeCastLib.Overflow.selector
+                    && sig != 0x4e487b71 && sig != FixedPointMathLib.FullMulDivFailed.selector
+                    && sig != LiquidityDeltaOverflow.selector && sig != ICore.MaxLiquidityPerTickExceeded.selector
+                    && sig != IPositionDepositor.DepositExceedsMaxAmounts.selector
+                    && sig != IPositionDepositor.DepositSqrtRatioChanged.selector
             ) {
                 revert UnexpectedError(err);
             }

--- a/test/SwapTest.t.sol
+++ b/test/SwapTest.t.sol
@@ -70,14 +70,15 @@ contract SwapTest is FullTest {
             sqrtRatioUpper: MAX_SQRT_RATIO
         });
 
-        (uint256 id, uint128 positionLiquidity,,) = positions.mintAndDeposit({
-            poolKey: poolKey,
-            tickLower: MIN_TICK,
-            tickUpper: MAX_TICK,
-            maxAmount0: uint128(amount0),
-            maxAmount1: uint128(amount1),
-            minLiquidity: liquidity
-        });
+        uint256 id;
+        uint128 positionLiquidity;
+        if (liquidity == 0) {
+            id = positions.mint();
+        } else {
+            (id, positionLiquidity,,) = positions.mintAndDeposit(
+                positionDeposit(poolKey, MIN_TICK, MAX_TICK, uint128(amount0), uint128(amount1))
+            );
+        }
 
         assertEq(positionLiquidity, liquidity, "liquidity expected");
 

--- a/test/SwapTest.t.sol
+++ b/test/SwapTest.t.sol
@@ -78,8 +78,7 @@ contract SwapTest is FullTest {
         } else {
             PositionDeposit memory parameters =
                 positionDeposit(poolKey, MIN_TICK, MAX_TICK, uint128(amount0), uint128(amount1));
-            positionLiquidity = parameters.liquidity;
-            (id,,) = positions.mintAndDeposit(parameters);
+            (id, positionLiquidity,,) = positions.mintAndDeposit(parameters);
         }
 
         assertEq(positionLiquidity, liquidity, "liquidity expected");

--- a/test/SwapTest.t.sol
+++ b/test/SwapTest.t.sol
@@ -4,6 +4,7 @@ pragma solidity =0.8.33;
 import {SafeCastLib} from "solady/utils/SafeCastLib.sol";
 
 import {ICore} from "../src/interfaces/ICore.sol";
+import {PositionDeposit} from "../src/interfaces/IPositionDepositor.sol";
 import {isPriceIncreasing} from "../src/math/isPriceIncreasing.sol";
 import {MIN_SQRT_RATIO, MAX_SQRT_RATIO, toSqrtRatio, SqrtRatio, ONE} from "../src/types/sqrtRatio.sol";
 import {MIN_TICK, MAX_TICK} from "../src/math/constants.sol";
@@ -75,9 +76,10 @@ contract SwapTest is FullTest {
         if (liquidity == 0) {
             id = positions.mint();
         } else {
-            (id, positionLiquidity,,) = positions.mintAndDeposit(
-                positionDeposit(poolKey, MIN_TICK, MAX_TICK, uint128(amount0), uint128(amount1))
-            );
+            PositionDeposit memory parameters =
+                positionDeposit(poolKey, MIN_TICK, MAX_TICK, uint128(amount0), uint128(amount1));
+            positionLiquidity = parameters.liquidity;
+            (id,,) = positions.mintAndDeposit(parameters);
         }
 
         assertEq(positionLiquidity, liquidity, "liquidity expected");

--- a/test/TWAMMInvariantTest.t.sol
+++ b/test/TWAMMInvariantTest.t.sol
@@ -26,8 +26,7 @@ import {IOrders} from "../src/interfaces/IOrders.sol";
 import {TestToken} from "./TestToken.sol";
 import {ICore} from "../src/interfaces/ICore.sol";
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
-import {LiquidityDeltaOverflow, maxLiquidity} from "../src/math/liquidity.sol";
-import {tickToSqrtRatio} from "../src/math/ticks.sol";
+import {LiquidityDeltaOverflow} from "../src/math/liquidity.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 import {createOrderConfig} from "../src/types/orderConfig.sol";
@@ -132,23 +131,20 @@ contract Handler is StdUtils, StdAssertions {
         PoolKey memory poolKey = allPoolKeys[bound(poolKeyIndex, 0, allPoolKeys.length - 1)];
 
         SqrtRatio sqrtRatio = core.poolState(poolKey.toPoolId()).sqrtRatio();
-        uint128 depositLiquidity =
-            maxLiquidity(sqrtRatio, tickToSqrtRatio(MIN_TICK), tickToSqrtRatio(MAX_TICK), amount0, amount1);
-        if (depositLiquidity == 0) return;
         PositionDeposit memory parameters = PositionDeposit({
             poolKey: poolKey,
             tickLower: MIN_TICK,
             tickUpper: MAX_TICK,
-            liquidity: depositLiquidity,
-            targetSqrtRatio: sqrtRatio,
             maxAmount0: amount0,
             maxAmount1: amount1,
+            minLiquidity: 1,
+            targetSqrtRatio: sqrtRatio,
             router: address(0),
             routerData: bytes("")
         });
 
-        try positions.deposit(positionId, parameters) returns (int256, int256) {
-            activePositions.push(ActivePosition(poolKey, MIN_TICK, MAX_TICK, depositLiquidity));
+        try positions.deposit(positionId, parameters) returns (uint128 liquidity, int256, int256) {
+            activePositions.push(ActivePosition(poolKey, MIN_TICK, MAX_TICK, liquidity));
         } catch (bytes memory err) {
             bytes4 sig;
             assembly ("memory-safe") {
@@ -157,10 +153,12 @@ contract Handler is StdUtils, StdAssertions {
 
             // 0x4e487b71 is arithmetic overflow/underflow
             if (
-                sig != IPositionDepositor.InvalidDepositLiquidity.selector && sig != SafeCastLib.Overflow.selector
-                    && sig != 0x4e487b71 && sig != FixedPointMathLib.FullMulDivFailed.selector
-                    && sig != LiquidityDeltaOverflow.selector && sig != Amount1DeltaOverflow.selector
-                    && sig != Amount0DeltaOverflow.selector && sig != SafeTransferLib.TransferFromFailed.selector
+                sig != IPositionDepositor.DepositLiquidityBelowMinimum.selector
+                    && sig != IPositionDepositor.DepositLiquidityOverflow.selector
+                    && sig != SafeCastLib.Overflow.selector && sig != 0x4e487b71
+                    && sig != FixedPointMathLib.FullMulDivFailed.selector && sig != LiquidityDeltaOverflow.selector
+                    && sig != Amount1DeltaOverflow.selector && sig != Amount0DeltaOverflow.selector
+                    && sig != SafeTransferLib.TransferFromFailed.selector
                     && sig != IPositionDepositor.DepositExceedsMaxAmounts.selector
                     && sig != IPositionDepositor.TargetSqrtRatioNotReached.selector
             ) {

--- a/test/TWAMMInvariantTest.t.sol
+++ b/test/TWAMMInvariantTest.t.sol
@@ -20,13 +20,14 @@ import {StdAssertions} from "forge-std/StdAssertions.sol";
 import {CoreLib} from "../src/libraries/CoreLib.sol";
 import {Positions} from "../src/Positions.sol";
 import {PoolBalanceUpdate} from "../src/types/poolBalanceUpdate.sol";
-import {IPositions} from "../src/interfaces/IPositions.sol";
+import {IPositionDepositor, PositionDeposit} from "../src/interfaces/IPositionDepositor.sol";
 import {Orders} from "../src/Orders.sol";
 import {IOrders} from "../src/interfaces/IOrders.sol";
 import {TestToken} from "./TestToken.sol";
 import {ICore} from "../src/interfaces/ICore.sol";
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
-import {LiquidityDeltaOverflow} from "../src/math/liquidity.sol";
+import {LiquidityDeltaOverflow, maxLiquidity} from "../src/math/liquidity.sol";
+import {tickToSqrtRatio} from "../src/math/ticks.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 import {createOrderConfig} from "../src/types/orderConfig.sol";
@@ -130,9 +131,25 @@ contract Handler is StdUtils, StdAssertions {
     function deposit(uint256 poolKeyIndex, uint128 amount0, uint128 amount1) public ifPoolExists {
         PoolKey memory poolKey = allPoolKeys[bound(poolKeyIndex, 0, allPoolKeys.length - 1)];
 
-        try positions.deposit(positionId, poolKey, MIN_TICK, MAX_TICK, amount0, amount1, 0) returns (
-            uint128 liquidity, uint128, uint128
-        ) {
+        SqrtRatio sqrtRatio = core.poolState(poolKey.toPoolId()).sqrtRatio();
+        uint128 depositLiquidity =
+            maxLiquidity(sqrtRatio, tickToSqrtRatio(MIN_TICK), tickToSqrtRatio(MAX_TICK), amount0, amount1);
+        if (depositLiquidity == 0) return;
+        PositionDeposit memory parameters = PositionDeposit({
+            poolKey: poolKey,
+            tickLower: MIN_TICK,
+            tickUpper: MAX_TICK,
+            liquidity: depositLiquidity,
+            targetSqrtRatio: sqrtRatio,
+            maxAmount0: amount0,
+            maxAmount1: amount1,
+            swapRecipient: address(0),
+            routeAfterDeposit: false,
+            router: address(0),
+            route: bytes("")
+        });
+
+        try positions.deposit(positionId, parameters) returns (uint128 liquidity, int256, int256) {
             if (liquidity > 0) {
                 activePositions.push(ActivePosition(poolKey, MIN_TICK, MAX_TICK, liquidity));
             }
@@ -144,11 +161,12 @@ contract Handler is StdUtils, StdAssertions {
 
             // 0x4e487b71 is arithmetic overflow/underflow
             if (
-                sig != IPositions.DepositOverflow.selector && sig != IPositions.DepositFailedDueToPriceMovement.selector
-                    && sig != SafeCastLib.Overflow.selector && sig != 0x4e487b71
-                    && sig != FixedPointMathLib.FullMulDivFailed.selector && sig != LiquidityDeltaOverflow.selector
-                    && sig != Amount1DeltaOverflow.selector && sig != Amount0DeltaOverflow.selector
-                    && sig != SafeTransferLib.TransferFromFailed.selector
+                sig != IPositionDepositor.DepositOverflow.selector && sig != SafeCastLib.Overflow.selector
+                    && sig != 0x4e487b71 && sig != FixedPointMathLib.FullMulDivFailed.selector
+                    && sig != LiquidityDeltaOverflow.selector && sig != Amount1DeltaOverflow.selector
+                    && sig != Amount0DeltaOverflow.selector && sig != SafeTransferLib.TransferFromFailed.selector
+                    && sig != IPositionDepositor.DepositExceedsMaxAmounts.selector
+                    && sig != IPositionDepositor.DepositSqrtRatioChanged.selector
             ) {
                 revert UnexpectedError(err);
             }

--- a/test/TWAMMInvariantTest.t.sol
+++ b/test/TWAMMInvariantTest.t.sol
@@ -143,16 +143,12 @@ contract Handler is StdUtils, StdAssertions {
             targetSqrtRatio: sqrtRatio,
             maxAmount0: amount0,
             maxAmount1: amount1,
-            swapRecipient: address(0),
-            routeAfterDeposit: false,
             router: address(0),
-            route: bytes("")
+            routerData: bytes("")
         });
 
-        try positions.deposit(positionId, parameters) returns (uint128 liquidity, int256, int256) {
-            if (liquidity > 0) {
-                activePositions.push(ActivePosition(poolKey, MIN_TICK, MAX_TICK, liquidity));
-            }
+        try positions.deposit(positionId, parameters) returns (int256, int256) {
+            activePositions.push(ActivePosition(poolKey, MIN_TICK, MAX_TICK, depositLiquidity));
         } catch (bytes memory err) {
             bytes4 sig;
             assembly ("memory-safe") {
@@ -161,12 +157,12 @@ contract Handler is StdUtils, StdAssertions {
 
             // 0x4e487b71 is arithmetic overflow/underflow
             if (
-                sig != IPositionDepositor.DepositOverflow.selector && sig != SafeCastLib.Overflow.selector
+                sig != IPositionDepositor.InvalidDepositLiquidity.selector && sig != SafeCastLib.Overflow.selector
                     && sig != 0x4e487b71 && sig != FixedPointMathLib.FullMulDivFailed.selector
                     && sig != LiquidityDeltaOverflow.selector && sig != Amount1DeltaOverflow.selector
                     && sig != Amount0DeltaOverflow.selector && sig != SafeTransferLib.TransferFromFailed.selector
                     && sig != IPositionDepositor.DepositExceedsMaxAmounts.selector
-                    && sig != IPositionDepositor.DepositSqrtRatioChanged.selector
+                    && sig != IPositionDepositor.TargetSqrtRatioNotReached.selector
             ) {
                 revert UnexpectedError(err);
             }

--- a/test/base/RevenueBuybacks.t.sol
+++ b/test/base/RevenueBuybacks.t.sol
@@ -154,7 +154,7 @@ contract RevenueBuybacksTest is BaseOrdersTest {
         positions.maybeInitializePool(poolKey, 0);
         token0.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
+        positions.mintAndDeposit(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18));
 
         (uint64 endTime, uint112 saleRate) = rb.roll(address(token0));
         assertEq(endTime, 3840);
@@ -190,7 +190,7 @@ contract RevenueBuybacksTest is BaseOrdersTest {
 
         positions.maybeInitializePool(poolKey, 0);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit{value: 1e18}(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
+        positions.mintAndDeposit{value: 1e18}(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18));
 
         (uint64 endTime, uint112 saleRate) = rb.roll(address(0));
         assertEq(endTime, 3840);
@@ -244,7 +244,7 @@ contract RevenueBuybacksTest is BaseOrdersTest {
         positions.maybeInitializePool(poolKey, 0);
         token0.approve(address(positions), 1e18);
         buybacksToken.approve(address(positions), 1e18);
-        positions.mintAndDeposit{value: isEth ? 1e18 : 0}(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, 0);
+        positions.mintAndDeposit{value: isEth ? 1e18 : 0}(positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18));
 
         (uint64 endTime,) = rb.roll(token);
         assertGt(endTime, startTime, "end time gt");

--- a/test/extensions/Oracle.t.sol
+++ b/test/extensions/Oracle.t.sol
@@ -86,9 +86,7 @@ abstract contract BaseOracleTest is FullTest {
             TestToken(token).approve(address(positions), type(uint256).max);
 
             vm.deal(address(positions), uint128(d0));
-            positions.deposit(
-                positionId, pk, MIN_TICK, MAX_TICK, uint128(d0), uint128(d1), liquidityNext - liquidityBefore - 1
-            );
+            positions.deposit(positionId, positionDeposit(pk, MIN_TICK, MAX_TICK, uint128(d0), uint128(d1)));
         } else if (liquidityBefore > liquidityNext) {
             uint128 diff = liquidityBefore - liquidityNext;
             if (diff > uint256(int256(type(int128).min))) {

--- a/test/extensions/Ve33.t.sol
+++ b/test/extensions/Ve33.t.sol
@@ -2,6 +2,7 @@
 pragma solidity =0.8.33;
 
 import {FullTest} from "../FullTest.sol";
+import {ForwardedSwapRoute, ForwardedSwapRouter} from "../ForwardedSwapRouter.sol";
 import {TestToken} from "../TestToken.sol";
 import {BaseLocker} from "../../src/base/BaseLocker.sol";
 import {Router} from "../../src/Router.sol";
@@ -16,6 +17,7 @@ import {
     ve33CallPoints
 } from "../../src/extensions/Ve33.sol";
 import {ICore} from "../../src/interfaces/ICore.sol";
+import {IPositionDepositor, PositionDeposit} from "../../src/interfaces/IPositionDepositor.sol";
 import {
     IVe33,
     VE33_CLAIM_POOL_FEES,
@@ -235,20 +237,28 @@ contract Ve33Test is FullTest {
     {
         uint256 id = _positionNftId(positionId);
         if (liquidityDelta > 0) {
+            SqrtRatio sqrtRatio = core.poolState(poolKey.toPoolId()).sqrtRatio();
             (int128 delta0, int128 delta1) = liquidityDeltaToAmountDelta(
-                core.poolState(poolKey.toPoolId()).sqrtRatio(),
+                sqrtRatio,
                 liquidityDelta,
                 tickToSqrtRatio(positionId.tickLower()),
                 tickToSqrtRatio(positionId.tickUpper())
             );
-            (, uint128 amount0, uint128 amount1) = vePositions.deposit(
+            (, int256 amount0, int256 amount1) = vePositions.deposit(
                 id,
-                poolKey,
-                positionId.tickLower(),
-                positionId.tickUpper(),
-                uint128(delta0),
-                uint128(delta1),
-                uint128(liquidityDelta)
+                PositionDeposit({
+                    poolKey: poolKey,
+                    tickLower: positionId.tickLower(),
+                    tickUpper: positionId.tickUpper(),
+                    liquidity: uint128(liquidityDelta),
+                    targetSqrtRatio: sqrtRatio,
+                    maxAmount0: uint128(delta0),
+                    maxAmount1: uint128(delta1),
+                    swapRecipient: address(0),
+                    routeAfterDeposit: false,
+                    router: address(0),
+                    route: bytes("")
+                })
             );
             balanceUpdate = createPoolBalanceUpdate(int128(amount0), int128(amount1));
         } else {
@@ -1595,8 +1605,68 @@ contract Ve33Test is FullTest {
         (uint128 liquidity,,) = vePositions.getPositionLiquidity(id, poolKey, MIN_TICK, MAX_TICK);
         assertEq(liquidity, uint128(type(int128).max));
 
-        vm.expectRevert(Ve33Positions.DepositOverflow.selector);
-        vePositions.deposit(id, poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18, 1);
+        PositionDeposit memory parameters = positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18);
+        parameters.liquidity = 1;
+        vm.expectRevert(IPositionDepositor.DepositOverflow.selector);
+        vePositions.deposit(id, parameters);
+    }
+
+    function test_vePositionsDepositRoutesThroughVe33ToTargetPrice() public {
+        (PoolKey memory poolKey, PositionId positionId) = _createConcentratedPool();
+        uint128 initialLiquidity = 20_000_000;
+        _updatePosition(poolKey, positionId, int128(initialLiquidity));
+
+        int128 swapAmount = 100;
+        (PoolBalanceUpdate swapBalanceUpdate, PoolState stateAfter) = router.quote({
+            poolKey: poolKey, isToken1: false, amount: swapAmount, sqrtRatioLimit: MIN_SQRT_RATIO, skipAhead: 0
+        });
+        SqrtRatio targetSqrtRatio = stateAfter.sqrtRatio();
+        uint128 depositLiquidity = 10_000_000;
+        (int128 depositAmount0, int128 depositAmount1) = liquidityDeltaToAmountDelta(
+            targetSqrtRatio, int128(depositLiquidity), tickToSqrtRatio(-64), tickToSqrtRatio(64)
+        );
+        int256 expectedAmount0 = int256(swapBalanceUpdate.delta0()) + int256(depositAmount0);
+        int256 expectedAmount1 = int256(swapBalanceUpdate.delta1()) + int256(depositAmount1);
+        assertGt(expectedAmount0, 0, "token0 net input");
+        assertGt(expectedAmount1, 0, "token1 net input");
+
+        ForwardedSwapRouter forwardedRouter = new ForwardedSwapRouter(core);
+        uint256 id = _positionNftId(positionId);
+        (uint128 actualLiquidity, int256 amount0, int256 amount1) = vePositions.deposit(
+            id,
+            PositionDeposit({
+                poolKey: poolKey,
+                tickLower: -64,
+                tickUpper: 64,
+                liquidity: depositLiquidity,
+                targetSqrtRatio: targetSqrtRatio,
+                maxAmount0: uint128(uint256(expectedAmount0)),
+                maxAmount1: uint128(uint256(expectedAmount1)),
+                swapRecipient: address(0),
+                routeAfterDeposit: false,
+                router: address(forwardedRouter),
+                route: abi.encode(
+                    ForwardedSwapRoute({
+                        poolKey: poolKey,
+                        params: createSwapParameters(targetSqrtRatio, swapAmount, false, 0),
+                        useExtension: true,
+                        reverseResult: false,
+                        returnInvalidTokens: false,
+                        misreportDeltas: false
+                    })
+                )
+            })
+        );
+
+        assertEq(actualLiquidity, depositLiquidity, "exact liquidity");
+        assertEq(amount0, expectedAmount0, "net token0");
+        assertEq(amount1, expectedAmount1, "net token1");
+        assertEq(_positionLiquidity(poolKey, positionId), initialLiquidity + depositLiquidity, "position liquidity");
+        assertEq(
+            SqrtRatio.unwrap(core.poolState(poolKey.toPoolId()).sqrtRatio()),
+            SqrtRatio.unwrap(targetSqrtRatio),
+            "target price"
+        );
     }
 
     function test_scheduleEmissionsAccruesMultipleEventsAtSameTime() public {

--- a/test/extensions/Ve33.t.sol
+++ b/test/extensions/Ve33.t.sol
@@ -244,7 +244,7 @@ contract Ve33Test is FullTest {
                 tickToSqrtRatio(positionId.tickLower()),
                 tickToSqrtRatio(positionId.tickUpper())
             );
-            (, int256 amount0, int256 amount1) = vePositions.deposit(
+            (int256 amount0, int256 amount1) = vePositions.deposit(
                 id,
                 PositionDeposit({
                     poolKey: poolKey,
@@ -254,10 +254,8 @@ contract Ve33Test is FullTest {
                     targetSqrtRatio: sqrtRatio,
                     maxAmount0: uint128(delta0),
                     maxAmount1: uint128(delta1),
-                    swapRecipient: address(0),
-                    routeAfterDeposit: false,
                     router: address(0),
-                    route: bytes("")
+                    routerData: bytes("")
                 })
             );
             balanceUpdate = createPoolBalanceUpdate(int128(amount0), int128(amount1));
@@ -1607,7 +1605,11 @@ contract Ve33Test is FullTest {
 
         PositionDeposit memory parameters = positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18);
         parameters.liquidity = 1;
-        vm.expectRevert(IPositionDepositor.DepositOverflow.selector);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPositionDepositor.PositionLiquidityOverflow.selector, uint128(type(int128).max), uint128(1)
+            )
+        );
         vePositions.deposit(id, parameters);
     }
 
@@ -1632,7 +1634,7 @@ contract Ve33Test is FullTest {
 
         ForwardedSwapRouter forwardedRouter = new ForwardedSwapRouter(core);
         uint256 id = _positionNftId(positionId);
-        (uint128 actualLiquidity, int256 amount0, int256 amount1) = vePositions.deposit(
+        (int256 amount0, int256 amount1) = vePositions.deposit(
             id,
             PositionDeposit({
                 poolKey: poolKey,
@@ -1642,10 +1644,8 @@ contract Ve33Test is FullTest {
                 targetSqrtRatio: targetSqrtRatio,
                 maxAmount0: uint128(uint256(expectedAmount0)),
                 maxAmount1: uint128(uint256(expectedAmount1)),
-                swapRecipient: address(0),
-                routeAfterDeposit: false,
                 router: address(forwardedRouter),
-                route: abi.encode(
+                routerData: abi.encode(
                     ForwardedSwapRoute({
                         poolKey: poolKey,
                         params: createSwapParameters(targetSqrtRatio, swapAmount, false, 0),
@@ -1658,7 +1658,6 @@ contract Ve33Test is FullTest {
             })
         );
 
-        assertEq(actualLiquidity, depositLiquidity, "exact liquidity");
         assertEq(amount0, expectedAmount0, "net token0");
         assertEq(amount1, expectedAmount1, "net token1");
         assertEq(_positionLiquidity(poolKey, positionId), initialLiquidity + depositLiquidity, "position liquidity");

--- a/test/extensions/Ve33.t.sol
+++ b/test/extensions/Ve33.t.sol
@@ -33,7 +33,7 @@ import {FeesPerLiquidity} from "../../src/types/feesPerLiquidity.sol";
 import {computeFee} from "../../src/math/fee.sol";
 import {nextValidTime} from "../../src/math/time.sol";
 import {tickToSqrtRatio} from "../../src/math/ticks.sol";
-import {liquidityDeltaToAmountDelta} from "../../src/math/liquidity.sol";
+import {liquidityDeltaToAmountDelta, maxLiquidity} from "../../src/math/liquidity.sol";
 import {timeToBitmapWordAndIndex} from "../../src/math/timeBitmap.sol";
 import {MIN_TICK, MAX_TICK, NATIVE_TOKEN_ADDRESS} from "../../src/math/constants.sol";
 import {PoolBalanceUpdate, createPoolBalanceUpdate} from "../../src/types/poolBalanceUpdate.sol";
@@ -244,16 +244,16 @@ contract Ve33Test is FullTest {
                 tickToSqrtRatio(positionId.tickLower()),
                 tickToSqrtRatio(positionId.tickUpper())
             );
-            (int256 amount0, int256 amount1) = vePositions.deposit(
+            (, int256 amount0, int256 amount1) = vePositions.deposit(
                 id,
                 PositionDeposit({
                     poolKey: poolKey,
                     tickLower: positionId.tickLower(),
                     tickUpper: positionId.tickUpper(),
-                    liquidity: uint128(liquidityDelta),
-                    targetSqrtRatio: sqrtRatio,
                     maxAmount0: uint128(delta0),
                     maxAmount1: uint128(delta1),
+                    minLiquidity: uint128(liquidityDelta),
+                    targetSqrtRatio: sqrtRatio,
                     router: address(0),
                     routerData: bytes("")
                 })
@@ -1603,8 +1603,11 @@ contract Ve33Test is FullTest {
         (uint128 liquidity,,) = vePositions.getPositionLiquidity(id, poolKey, MIN_TICK, MAX_TICK);
         assertEq(liquidity, uint128(type(int128).max));
 
-        PositionDeposit memory parameters = positionDeposit(poolKey, MIN_TICK, MAX_TICK, 1e18, 1e18);
-        parameters.liquidity = 1;
+        SqrtRatio sqrtRatio = core.poolState(poolKey.toPoolId()).sqrtRatio();
+        (int128 amount0, int128 amount1) = liquidityDeltaToAmountDelta(sqrtRatio, 1, MIN_SQRT_RATIO, MAX_SQRT_RATIO);
+        PositionDeposit memory parameters =
+            positionDeposit(poolKey, MIN_TICK, MAX_TICK, uint128(amount0), uint128(amount1));
+        parameters.minLiquidity = 1;
         vm.expectRevert(
             abi.encodeWithSelector(
                 IPositionDepositor.PositionLiquidityOverflow.selector, uint128(type(int128).max), uint128(1)
@@ -1617,15 +1620,28 @@ contract Ve33Test is FullTest {
         (PoolKey memory poolKey, PositionId positionId) = _createConcentratedPool();
         uint128 initialLiquidity = 20_000_000;
         _updatePosition(poolKey, positionId, int128(initialLiquidity));
+        uint128 initialPositionLiquidity = _positionLiquidity(poolKey, positionId);
 
         int128 swapAmount = 100;
         (PoolBalanceUpdate swapBalanceUpdate, PoolState stateAfter) = router.quote({
             poolKey: poolKey, isToken1: false, amount: swapAmount, sqrtRatioLimit: MIN_SQRT_RATIO, skipAhead: 0
         });
         SqrtRatio targetSqrtRatio = stateAfter.sqrtRatio();
-        uint128 depositLiquidity = 10_000_000;
+        uint128 seedLiquidity = 10_000_000;
+        (int128 seedAmount0, int128 seedAmount1) = liquidityDeltaToAmountDelta(
+            targetSqrtRatio, int128(seedLiquidity), tickToSqrtRatio(-64), tickToSqrtRatio(64)
+        );
+        uint128 maxAmount0 = uint128(uint256(int256(swapBalanceUpdate.delta0()) + int256(seedAmount0)));
+        uint128 maxAmount1 = uint128(uint256(int256(swapBalanceUpdate.delta1()) + int256(seedAmount1)));
+        uint128 expectedLiquidity = maxLiquidity(
+            targetSqrtRatio,
+            tickToSqrtRatio(-64),
+            tickToSqrtRatio(64),
+            maxAmount0 - uint128(swapBalanceUpdate.delta0()),
+            maxAmount1 + uint128(uint256(-int256(swapBalanceUpdate.delta1())))
+        );
         (int128 depositAmount0, int128 depositAmount1) = liquidityDeltaToAmountDelta(
-            targetSqrtRatio, int128(depositLiquidity), tickToSqrtRatio(-64), tickToSqrtRatio(64)
+            targetSqrtRatio, int128(expectedLiquidity), tickToSqrtRatio(-64), tickToSqrtRatio(64)
         );
         int256 expectedAmount0 = int256(swapBalanceUpdate.delta0()) + int256(depositAmount0);
         int256 expectedAmount1 = int256(swapBalanceUpdate.delta1()) + int256(depositAmount1);
@@ -1634,16 +1650,16 @@ contract Ve33Test is FullTest {
 
         ForwardedSwapRouter forwardedRouter = new ForwardedSwapRouter(core);
         uint256 id = _positionNftId(positionId);
-        (int256 amount0, int256 amount1) = vePositions.deposit(
+        (uint128 liquidity, int256 amount0, int256 amount1) = vePositions.deposit(
             id,
             PositionDeposit({
                 poolKey: poolKey,
                 tickLower: -64,
                 tickUpper: 64,
-                liquidity: depositLiquidity,
+                maxAmount0: maxAmount0,
+                maxAmount1: maxAmount1,
+                minLiquidity: expectedLiquidity,
                 targetSqrtRatio: targetSqrtRatio,
-                maxAmount0: uint128(uint256(expectedAmount0)),
-                maxAmount1: uint128(uint256(expectedAmount1)),
                 router: address(forwardedRouter),
                 routerData: abi.encode(
                     ForwardedSwapRoute({
@@ -1658,9 +1674,12 @@ contract Ve33Test is FullTest {
             })
         );
 
+        assertEq(liquidity, expectedLiquidity, "added liquidity");
         assertEq(amount0, expectedAmount0, "net token0");
         assertEq(amount1, expectedAmount1, "net token1");
-        assertEq(_positionLiquidity(poolKey, positionId), initialLiquidity + depositLiquidity, "position liquidity");
+        assertEq(
+            _positionLiquidity(poolKey, positionId), initialPositionLiquidity + expectedLiquidity, "position liquidity"
+        );
         assertEq(
             SqrtRatio.unwrap(core.poolState(poolKey.toPoolId()).sqrtRatio()),
             SqrtRatio.unwrap(targetSqrtRatio),

--- a/test/extensions/Ve33EmissionsInvariant.t.sol
+++ b/test/extensions/Ve33EmissionsInvariant.t.sol
@@ -313,15 +313,15 @@ contract Ve33EmissionsInvariantHandler is StdUtils, StdAssertions {
         uint128 maxAmount = uint128(POSITION_AMOUNT);
         uint128 liquidity =
             maxLiquidity(sqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), maxAmount, maxAmount);
-        (uint256 nftId,,) = ve33Positions.mintAndDeposit(
+        (uint256 nftId,,,) = ve33Positions.mintAndDeposit(
             PositionDeposit({
                 poolKey: trackedPool.poolKey,
                 tickLower: tickLower,
                 tickUpper: tickUpper,
-                liquidity: liquidity,
-                targetSqrtRatio: sqrtRatio,
                 maxAmount0: maxAmount,
                 maxAmount1: maxAmount,
+                minLiquidity: liquidity,
+                targetSqrtRatio: sqrtRatio,
                 router: address(0),
                 routerData: bytes("")
             })

--- a/test/extensions/Ve33EmissionsInvariant.t.sol
+++ b/test/extensions/Ve33EmissionsInvariant.t.sol
@@ -311,21 +311,19 @@ contract Ve33EmissionsInvariantHandler is StdUtils, StdAssertions {
         TrackedPool memory trackedPool = pools[poolIndex];
         SqrtRatio sqrtRatio = core.poolState(trackedPool.poolId).sqrtRatio();
         uint128 maxAmount = uint128(POSITION_AMOUNT);
-        (uint256 nftId, uint128 liquidity,,) = ve33Positions.mintAndDeposit(
+        uint128 liquidity =
+            maxLiquidity(sqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), maxAmount, maxAmount);
+        (uint256 nftId,,) = ve33Positions.mintAndDeposit(
             PositionDeposit({
                 poolKey: trackedPool.poolKey,
                 tickLower: tickLower,
                 tickUpper: tickUpper,
-                liquidity: maxLiquidity(
-                    sqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), maxAmount, maxAmount
-                ),
+                liquidity: liquidity,
                 targetSqrtRatio: sqrtRatio,
                 maxAmount0: maxAmount,
                 maxAmount1: maxAmount,
-                swapRecipient: address(0),
-                routeAfterDeposit: false,
                 router: address(0),
-                route: bytes("")
+                routerData: bytes("")
             })
         );
         positions.push(

--- a/test/extensions/Ve33EmissionsInvariant.t.sol
+++ b/test/extensions/Ve33EmissionsInvariant.t.sol
@@ -23,11 +23,13 @@ import {
     ve33CallPoints
 } from "../../src/extensions/Ve33.sol";
 import {ICore} from "../../src/interfaces/ICore.sol";
+import {PositionDeposit} from "../../src/interfaces/IPositionDepositor.sol";
 import {CoreLib} from "../../src/libraries/CoreLib.sol";
 import {Ve33StorageLayout} from "../../src/libraries/Ve33StorageLayout.sol";
 import {Ve33Lib} from "../../src/libraries/Ve33Lib.sol";
 import {AmountBeforeFeeOverflow} from "../../src/math/fee.sol";
 import {Amount0DeltaOverflow, Amount1DeltaOverflow} from "../../src/math/delta.sol";
+import {maxLiquidity} from "../../src/math/liquidity.sol";
 import {nextValidTime} from "../../src/math/time.sol";
 import {tickToSqrtRatio} from "../../src/math/ticks.sol";
 import {PoolBalanceUpdate} from "../../src/types/poolBalanceUpdate.sol";
@@ -307,8 +309,24 @@ contract Ve33EmissionsInvariantHandler is StdUtils, StdAssertions {
 
     function _mintPosition(uint256 poolIndex, int32 tickLower, int32 tickUpper) private {
         TrackedPool memory trackedPool = pools[poolIndex];
+        SqrtRatio sqrtRatio = core.poolState(trackedPool.poolId).sqrtRatio();
+        uint128 maxAmount = uint128(POSITION_AMOUNT);
         (uint256 nftId, uint128 liquidity,,) = ve33Positions.mintAndDeposit(
-            trackedPool.poolKey, tickLower, tickUpper, uint128(POSITION_AMOUNT), uint128(POSITION_AMOUNT), 1
+            PositionDeposit({
+                poolKey: trackedPool.poolKey,
+                tickLower: tickLower,
+                tickUpper: tickUpper,
+                liquidity: maxLiquidity(
+                    sqrtRatio, tickToSqrtRatio(tickLower), tickToSqrtRatio(tickUpper), maxAmount, maxAmount
+                ),
+                targetSqrtRatio: sqrtRatio,
+                maxAmount0: maxAmount,
+                maxAmount1: maxAmount,
+                swapRecipient: address(0),
+                routeAfterDeposit: false,
+                router: address(0),
+                route: bytes("")
+            })
         );
         positions.push(
             TrackedPosition({


### PR DESCRIPTION
## Summary

Add atomic target-price routing to the max-token/min-liquidity position deposit flow shared by `Positions`, `FreePositions`, and `Ve33Positions`.

- `PositionDeposit` carries the pool/range, `maxAmount0`, `maxAmount1`, `minLiquidity`, an exact `targetSqrtRatio`, and optional `router`/`routerData`.
- A nonzero router always executes first through `Core.forward`; zero skips routing, and nonempty data without a router reverts.
- The position manager uses the route's actual signed endpoint deltas to calculate the remaining token budgets, then adds the maximum feasible liquidity once.
- The exact target is checked before and after the position update.
- Deposit methods return the liquidity actually added plus signed net token amounts. Positive amounts are paid by the caller and negative amounts are returned to the caller.

Routing remains outside the NFT position contracts, so aggregators can add liquidity sources without requiring a position-manager upgrade. Packed forwarded-route support, including target-price partial fills, is implemented in EkuboProtocol/yul-router#10.

## Why route before one maximum deposit

For a fixed range and final price, the principal token amounts are determined by the position's final total liquidity. Alternating deposits and swaps toward that price does not improve the maximum principal liquidity available from the same net token budgets; it only adds calls, rounding, and potentially fees.

The simpler flow is:

1. Route toward the exact target using a maximum exact-input amount.
2. Use the route's actual deltas to determine what remains of each token budget.
3. Add the maximum liquidity once at the target.

This also works when the pool is initialized but has no active liquidity. Core can move an empty pool directly to the swap limit with zero balance deltas, after which the full deposit is calculated at the target price. No route-ordering boolean or temporary seed liquidity is needed.

## Interface and DX

- `router == address(0)` is the only routing switch; there is no redundant `routeAfterDeposit` flag.
- `routerData` is rejected when no router is supplied, catching a likely integration mistake.
- `minLiquidity` protects the result while max token amounts bound the combined route and deposit.
- `targetSqrtRatio` protects both the routed execution price and the price at which liquidity is added.
- The forwardee returns `(specifiedToken, calculatedToken, specifiedDelta, calculatedDelta)`, using actual deltas for price-limited partial fills.
- Returned endpoint tokens may be in either pool-token order but must exactly match the deposit pair.
- `maybeInitializePool` remains available so initialization and routed deposit can be composed in one multicall.

## Safety properties

- Net spend caps apply after combining route and LP debts; route-level thresholds independently protect swap execution.
- The manager verifies the target immediately after routing and again after adding liquidity.
- Core forwarding temporarily makes the router the active locker address, so it cannot mutate positions owned by the position manager.
- The outer Core lock requires all debts to be settled. Omitted or falsified route debts revert the complete operation.
- Liquidity that cannot fit in one Core update, oversized routed outputs, invalid route endpoints, and below-minimum results revert with explicit errors.
- The legacy `IPositions.sol` source remains unchanged for deployed consumers; the new ABI is exposed through `IPositionsV2` / `IPositionDepositor`.

## Compatibility and contract size

Keeping both old and new deposit implementations exceeded EIP-170, so this intentionally replaces the old deposit ABI on the newly deployed position managers.

- `Positions`: 24,195-byte runtime, 381-byte margin
- `FreePositions`: 23,035-byte runtime
- `Ve33Positions`: 23,598-byte runtime

An exact creation-bytecode comparison found no changes to other production deployments, including Core, Orders, and PositionsRevenueBuybacks.

## Verification

- `forge build --offline`
- `forge script --offline script/DeployAll.s.sol`
- `forge test --offline` — 993 passing across 97 suites
- `forge snapshot --offline` — 993 passing
- Solvency and TWAMM invariants — 500 calls each, zero handler reverts
- Routed coverage includes uneven budgets, actual partial-route deltas, reversed endpoints, net caller outputs, stale targets, zero-liquidity price movement, nested Ve33 forwarding, max-spend failures, invalid endpoints, and falsified router accounting
