### PR TITLE
Add scheduled token launches with locked liquidity migration

### DIFF
--- a/scheduled-launch-extension.md
+++ b/scheduled-launch-extension.md
@@ -1,131 +1,189 @@
-# Scheduled token launches
+# Scheduled launches with locked liquidity migration
 
-`ScheduledLaunch` deploys a fixed-supply token and initializes its pool atomically.
-It releases token inventory linearly between configured start and end times. Before
-external swaps, it sells available inventory toward a fixed target price and adds
-remaining balances to a launch-owned liquidity position. Once the launch ends, one
-final advancement marks it complete and subsequent swap callbacks become no-ops.
+`ScheduledLaunch` creates a fixed-supply token, releases its inventory linearly over
+an auction interval, and charges a declining creator fee on external launch swaps.
+At the end, principal moves to `LockedLaunchLiquidity`, which balances it against any
+existing liquidity and deposits into a **no-extension full-range pool**. That pool's
+fixed fee equals the launch schedule's final fee.
 
-## Creating a launch
+Principal is permanently locked. The creator can claim launch trading fees and fees
+earned by this launch's terminal position, never another LP's fees or the principal.
 
-Call `Core.forward(address(extension))` inside an existing Core lock, appending
-`abi.encode(ScheduledLaunch.LaunchConfig)` to its calldata. The authenticated
-forwarding handler returns `abi.encode(PoolKey)`. `FlashAccountantLib.forward` handles
-this calling convention. See the `LaunchCreator` test helper for a complete example
-of forwarding and funding; a production wallet/router integration should also enforce
-its own caller authorization and native-value/refund policy.
+## Configuration and atomic creation
 
-The configuration includes:
+Inside a Core lock, forward `abi.encode(uint8(0), LaunchConfig)` to `ScheduledLaunch`.
+The response is `abi.encode(PoolKey)`. The forwarding locker must settle optional
+quote funding before returning. `FlashAccountantLib.forward` handles the calling
+convention; the test-only `LaunchActor` shows funding and settlement examples.
 
-| Field | Meaning |
+| Configuration | Meaning |
 | --- | --- |
-| `owner` | Nonzero beneficiary, authorized to withdraw after completion |
-| `quoteToken` | Paired asset; address zero means native ETH |
-| `name`, `symbol`, `decimals` | Metadata for the deployed `MintableERC20` |
-| `totalSupply` | Entire fixed token supply, initially reserved for this launch |
-| `quoteAmount` | Optional quote seed, owed by the forwarding locker to Core |
-| `startTime`, `endTime` | Future or current start and strictly later end |
-| `targetTick`, `upperTick` | Fixed economic target and upper sell-range boundary |
-| `tickSpacing`, `fee` | Concentrated-pool parameters |
+| `owner` | Immutable nonzero creator and fee beneficiary |
+| `quoteToken` | Quote asset; address zero means native ETH |
+| `name`, `symbol`, `decimals` | Metadata for the existing `MintableERC20` implementation |
+| `totalSupply` | Entire token supply, reserved for this launch |
+| `quoteAmount` | Optional quote funding supplied by the forwarding locker |
+| `startTime`, `endTime` | Current/future start and strictly later end |
+| `targetTick`, `upperTick` | Fixed launch target and upper sell-range boundary |
+| `tickSpacing` | Launch concentrated-pool spacing |
+| `initialFee`, `finalFee` | Declining creator fee endpoints, in Q0.64 |
+| `migrationTickLower`, `migrationTickUpper` | Immutable acceptable terminal-price bounds |
 
-Ticks express **raw quote units per raw launch-token unit**, regardless of token
-address ordering. The extension negates ticks and reverses bounds when the deployed
-token is token1. Account for token decimals when converting a human price to a tick.
-Both bounds must align with tick spacing; the target must be below the upper bound.
-Initialization occurs exactly at the target. Supply must be positive and supply/seed
-must each fit a positive int128. Token metadata uses the existing implementation's
-packed-string limits (31 bytes per name/symbol).
+All configured ticks express **raw quote units per raw launch-token unit**. The
+implementation reverses bounds and negates ticks when the launch token is token1.
+Convert for token decimals before choosing ticks. Launch bounds must align with tick
+spacing. Migration bounds need not align with launch spacing. Choose bounds that
+reflect acceptable migration prices: unrestricted bounds do not protect against
+migration at a manipulated price.
 
-Creation deploys `MintableERC20` with the extension as temporary token owner, mints
-all inventory, and renounces token ownership. The separately recorded launch owner
-has **no further minting authority**. All token inventory is paid into Core and saved
-under the extension, token pair, and pool-ID salt. Optional quote funding creates debt
-that the forwarding locker must settle before its lock returns. Any failure rolls
-back token deployment, minting, state, funding, and pool initialization.
+Supply must be positive and supply/seed must fit a positive int128. Fees are below
+100% by construction and must satisfy `initialFee >= finalFee`. Metadata inherits
+`MintableERC20`'s 31-byte name/symbol limits. Creation deploys a fresh token through
+the extension's immutable liquidity contract, mints inventory to the extension, and
+renounces minting authority. The extension pays that inventory into Core and saves it
+under its own address, the token pair, and the launch pool-ID salt. Creation, funding,
+and initialization revert atomically if anything fails.
 
-Only `beforeInitializePool` and `beforeSwap` call points are enabled. The initialization
-callback always reverts. Core skips it when the extension itself initializes, so
-validated forwarding is the only pool-creation path. Core also skips the extension's
-swap callback during its own swaps.
+The launch pool starts at its target and has a **zero Core pool fee**. Its two enabled
+call points are `beforeInitializePool` and `beforeSwap`; both always revert. Core
+skips these callbacks when the extension itself initializes or swaps. There is no
+alternative initialization path and no direct swap path that bypasses creator fees.
 
-## Release, sales, and liquidity
+## Release and creator fees
 
-Cumulative released supply is zero before/at start, the entire supply at/after end,
+Cumulative released tokens are zero at/before start, the whole supply at/after end,
 and otherwise:
 
 ```text
 released = totalSupply * (now - startTime) / (endTime - startTime)
 available = released - deployed
+fee = initialFee - (initialFee - finalFee) * (now - startTime) / (endTime - startTime)
 ```
 
-`deployed` counts launch tokens consumed by both exact-input sales and positive
-liquidity additions. It does not count quote assets or tokens circulating inside LP
-positions. Remaining saved token inventory equals `totalSupply - deployed`.
-Releases depend on elapsed time, never swap count. Swaps before start revert;
-permissionless advancement before start leaves the launch unchanged.
+The fee is clamped to its configured endpoints. During the auction, `deployed` counts
+released tokens consumed by launch sales and positive liquidity additions. It is not
+an accounting measure for post-auction migration. Releases depend on time, never
+swap count.
 
-On advancement:
+Forward `abi.encode(uint8(1), PoolKey, SwapParameters)` to trade; the result is
+`abi.encode(PoolBalanceUpdate, PoolState)`. Before executing the external trade, the
+extension advances inventory: sell available tokens toward the target only while
+price is above it, then add feasible balances in the launch sell-side range. At or
+below target, skip selling and add token-side liquidity. Unreleased tokens cannot be
+used to pair quote proceeds. Excess quote remains reserved.
 
-1. Sell available inventory only if the economic price is above target. The swap's
-   price limit is the target, and its input limit is released, undeployed inventory.
-2. Add liquidity in the fixed range from target to upper boundary using available
-   released tokens and saved quote proceeds. At/below target this is single-sided
-   launch-token liquidity. Above target, an active position needs both assets.
-3. Carry forward balances that do not fit. Never use unreleased tokens to pair quote.
-4. If time has reached the end, mark complete even when dust, missing counterparts,
-   or exhausted tick capacity prevent full deployment.
+The creator fee applies to the **calculated side** of the actual fill:
 
-Quote proceeds remain attributed to the launch. At the target, the chosen position
-cannot accept quote assets, so excess proceeds stay reserved. **This implementation
-does not place a separate buy position below target.** Quote seed follows the same
-rule; seeding quote does not guarantee two-sided depth at the target.
+- Exact input: deduct the fee from output.
+- Exact output: gross up the required input to include the fee.
 
-Price can move below target through other liquidity or empty-range traversal. In
-that state, skip sales and continue adding token-side liquidity. No price floor or
-elimination of sniper profit is promised. Internal sales against launch-owned LPs
-move assets between positions and reserves; external funding comes from net buyer
-purchases, not from the internal swap itself.
+This preserves the specified amount and handles partial fills. The forwarding
+router must settle the returned deltas and enforce the user's slippage constraints
+against those fee-inclusive deltas. Raw Core swap events exclude the extension fee.
 
-Liquidity additions respect remaining capacity at both boundary ticks, including
-liquidity owned by other LPs. A sale is skipped when saved quote already exceeds
-int128.max, retaining headroom for a signed swap output in Core's uint128 saved
-balance. Sales also cap input at the current price so output fits a signed delta;
-liquidity additions and withdrawals are similarly capped. These capacity
-conditions leave residual balances, not an endless completion requirement.
+Internal release sales never pass through this fee-charging path. Their Core pool
+fee is zero. Creator fees are saved separately using `creatorFeeSalt(launchPoolId)`;
+they never become migration principal. `claimFees(PoolKey, recipient)` lets the owner
+claim this ledger without withdrawing inventory or liquidity. Any donated Core fees
+on the launch-owned position are collected before its final removal and attributed
+to the creator as position fees.
 
-## Completion and owner rights
+## End of auction and principal custody
 
-Anyone may call `advance(PoolKey)`; no trade or owner availability is needed to finish.
-Reaching target early does not finish the schedule. After end time, the next advance
-or external swap performs final management. Completion is irreversible. Normal
-subsequent swaps do not load reserves, trade for the launch, or change its positions.
+At/after end, launch swaps revert. Anyone may call `advance(PoolKey)` to end the
+auction; this does not depend on an owner transaction or another trade. It transfers
+saved principal and removes launch-owned liquidity into the immutable
+`LockedLaunchLiquidity` contract through Core forwarding. Other LPs' launch positions
+are not removed. Core token-delta and saved-balance limits can require multiple
+advances for unusually large positions.
 
-The owner can call `withdraw(PoolKey, recipient)` only after completion, collecting
-fees before removing liquidity, then withdrawing saved reserves. Principal withdrawal
-is capped to Core's signed token-delta limits; call again if a large position retains
-liquidity. Normal-sized positions are removed in one call. The recipient
-must be nonzero. **Liquidity is owner-withdrawable, not permanently locked.** This
-explicit owner action is separate from automatic management. Before completion,
-there is no owner withdrawal, cancellation, schedule mutation, or inventory rescue.
-Owner identity is immutable; there are no owner transfers or platform admin powers.
+`Launch.complete` means all launch-owned principal has left the auction pool.
+It does **not** imply every reserve has already been deposited into the destination.
+After completion, `advance` makes no further launch-pool changes. All pending
+principal remains locked and anyone may retry terminal migration separately.
 
-Get configuration/accounting with `getLaunch(PoolId)`, release progress with
-`released(PoolId)`, and reserves with `CoreLib.savedBalances` using the extension
-address and pool-ID salt. `LaunchCreated` includes configuration, token, owner, and
-pool ID; `LaunchAdvanced` includes deployed supply and completion; `LaunchWithdrawn`
-records the recipient. Core emits the underlying pool/position/swap events.
+The liquidity contract exposes no principal withdrawal, approval, arbitrary call,
+upgrade, or ownership-transfer entry point. Its only token-deployment method is
+extension-only and creates new fixed-supply tokens; it cannot mint existing tokens.
+Creator identity, fee schedule, destination pool fee, and migration bounds are fixed
+at launch creation.
+
+## Full-range migration
+
+The destination key uses the same token pair,
+`createFullRangePoolConfig(finalFee, address(0))`: the unamplified, full-range
+stableswap configuration, with XYK price movement and no initialized-tick traversal.
+Each launch receives its own full-range position owned by the liquidity contract.
+
+**Existing liquidity:** use its current liquidity and square-root price to solve the
+fee-adjusted XYK balancing trade. For token0 input `x`, liquidity `L`, and square-root
+price `s`, the idealized price movement is:
+
+```text
+net = x - inputFee(x)
+s' = L*s / (L + net*s)
+token1Out = L * (s - s')
+```
+
+The solver uses Core's actual rounding for these equations and the finite full-range
+endpoints. It bisects the input amount until both remaining assets support equal
+deposit liquidity, checks adjacent integer candidates, and compares against no swap.
+There are at most 127 input-search iterations; cost does not depend on tick history.
+The solver includes the position's own internal-fee rebate when predicting remaining
+balances. Compact-price precision and integer rounding can still leave small reserves.
+It caps swap output, deposits, and arithmetic at Core's amount/liquidity limits.
+
+The current and resulting prices must remain within the launch's migration bounds.
+Migration at an out-of-bounds existing price is deferred; it does not force a bad
+swap or unlock the funds. Bounds restrict acceptable prices but are not an oracle.
+
+**Empty destination:** with both assets available, choose the full-range deposit
+price implied by those balances, including finite endpoint corrections. Initialize
+if necessary, and reset any preexisting empty-pool price before depositing. The price
+search uses fixed-point values because compact `SqrtRatio` encodings have gaps.
+The selected price must also satisfy migration bounds.
+
+**Missing counterpart:** if there is neither existing liquidity to swap against nor
+both assets to seed a pool, retain locked reserves. This includes a launch with no
+buyers and no quote seed. Once the launch is registered in the liquidity contract,
+anyone can fund it by forwarding `abi.encode(uint8(1), launchPoolId, amount0, amount1)`
+to that contract and settling the resulting Core debt. Funding is an irrevocable
+contribution to principal. Then call `migrate(launchPoolId)` to retry. Dust, capacity
+limits, or price bounds may also leave reserves pending; they are never paid out as
+creator fees.
+
+A migration swap pays the destination's normal fixed pool fee to its LPs; there is
+no additional creator surcharge. Before a rebalance, existing earned position fees
+are preserved in a separate creator ledger. Fees the launch's own terminal position
+earns from that internal rebalance are recycled into locked principal, preventing
+migration retries from turning principal into creator income.
+
+## Terminal fees and observability
+
+`LockedLaunchLiquidity.claimFees(launchPoolId, recipient)` is owner-only. It collects
+only that launch's position fees, plus any external-trade fees saved before a
+rebalance. Position liquidity and principal reserves are untouched. Other LPs retain
+their own fee claims. The terminal pool's fixed fee persists after migration; no
+extension stays in its swap path.
+
+Use `getLaunch`, `released`, `feeAt`, and `terminalPool` on the extension. Use
+`getTerminal` and `positionId` on the liquidity contract. Query Core saved balances
+with the holder contract, token pair, and launch pool-ID salt for principal; use
+that holder's `creatorFeeSalt` for creator fees. Query the terminal position's Core
+liquidity to distinguish a pending migration from an established position.
+`LaunchCreated`, `LaunchAdvanced`, `PrincipalReceived`, `LiquidityLocked`, and fee
+claim events accompany Core's normal pool, swap, and position events.
 
 ## Deployment and validation
 
-`script/DeployScheduledLaunch.s.sol` mines the required extension address prefix and
-uses the existing deterministic deployer. Configure `CORE_ADDRESS` (defaults to the
-canonical Core), optional starting `SALT`, and optional expected
-`SCHEDULED_LAUNCH_ADDRESS`. Run with `forge script --offline`; broadcasting is a
-separate deployment decision. No existing deployed contract source is changed.
+`script/DeployScheduledLaunch.s.sol` mines the extension's required address prefix
+and deploys it with its immutable liquidity contract. Configure `CORE_ADDRESS`,
+optional starting `SALT`, and optional expected `SCHEDULED_LAUNCH_ADDRESS`. Use
+`forge script --offline`; broadcasting is a separate action. No existing deployed
+contract source is modified.
 
-The test suite covers both asset orderings, fixed supply and ownership, atomic
-rollback, hook authentication, release rounding, native/ERC-20 quote funding,
-insufficient released inventory, sales to target, below-target releases, reserve
-isolation, owner withdrawal, fees, completion, trading/accounting sequences, extreme
-prices and supplies, large quote-output bounds, chunked principal withdrawals, third-party
-tick capacity, and real CREATE2 deployment with the required prefix.
+Tests cover fee decay and fee-inclusive fills, internal-fee exemption, atomic
+creation, ownership, both token orders, native quote assets, source and destination
+accounting, existing/empty terminal pools, no-counterpart retries, price bounds,
+locked principal, per-position fees, internal-fee recycling, chunked migration,
+CREATE2 deployment and size limits, and the balancing solver against brute force.

--- a/scheduled-launch-extension.md
+++ b/scheduled-launch-extension.md
@@ -1,0 +1,131 @@
+# Scheduled token launches
+
+`ScheduledLaunch` deploys a fixed-supply token and initializes its pool atomically.
+It releases token inventory linearly between configured start and end times. Before
+external swaps, it sells available inventory toward a fixed target price and adds
+remaining balances to a launch-owned liquidity position. Once the launch ends, one
+final advancement marks it complete and subsequent swap callbacks become no-ops.
+
+## Creating a launch
+
+Call `Core.forward(address(extension))` inside an existing Core lock, appending
+`abi.encode(ScheduledLaunch.LaunchConfig)` to its calldata. The authenticated
+forwarding handler returns `abi.encode(PoolKey)`. `FlashAccountantLib.forward` handles
+this calling convention. See the `LaunchCreator` test helper for a complete example
+of forwarding and funding; a production wallet/router integration should also enforce
+its own caller authorization and native-value/refund policy.
+
+The configuration includes:
+
+| Field | Meaning |
+| --- | --- |
+| `owner` | Nonzero beneficiary, authorized to withdraw after completion |
+| `quoteToken` | Paired asset; address zero means native ETH |
+| `name`, `symbol`, `decimals` | Metadata for the deployed `MintableERC20` |
+| `totalSupply` | Entire fixed token supply, initially reserved for this launch |
+| `quoteAmount` | Optional quote seed, owed by the forwarding locker to Core |
+| `startTime`, `endTime` | Future or current start and strictly later end |
+| `targetTick`, `upperTick` | Fixed economic target and upper sell-range boundary |
+| `tickSpacing`, `fee` | Concentrated-pool parameters |
+
+Ticks express **raw quote units per raw launch-token unit**, regardless of token
+address ordering. The extension negates ticks and reverses bounds when the deployed
+token is token1. Account for token decimals when converting a human price to a tick.
+Both bounds must align with tick spacing; the target must be below the upper bound.
+Initialization occurs exactly at the target. Supply must be positive and supply/seed
+must each fit a positive int128. Token metadata uses the existing implementation's
+packed-string limits (31 bytes per name/symbol).
+
+Creation deploys `MintableERC20` with the extension as temporary token owner, mints
+all inventory, and renounces token ownership. The separately recorded launch owner
+has **no further minting authority**. All token inventory is paid into Core and saved
+under the extension, token pair, and pool-ID salt. Optional quote funding creates debt
+that the forwarding locker must settle before its lock returns. Any failure rolls
+back token deployment, minting, state, funding, and pool initialization.
+
+Only `beforeInitializePool` and `beforeSwap` call points are enabled. The initialization
+callback always reverts. Core skips it when the extension itself initializes, so
+validated forwarding is the only pool-creation path. Core also skips the extension's
+swap callback during its own swaps.
+
+## Release, sales, and liquidity
+
+Cumulative released supply is zero before/at start, the entire supply at/after end,
+and otherwise:
+
+```text
+released = totalSupply * (now - startTime) / (endTime - startTime)
+available = released - deployed
+```
+
+`deployed` counts launch tokens consumed by both exact-input sales and positive
+liquidity additions. It does not count quote assets or tokens circulating inside LP
+positions. Remaining saved token inventory equals `totalSupply - deployed`.
+Releases depend on elapsed time, never swap count. Swaps before start revert;
+permissionless advancement before start leaves the launch unchanged.
+
+On advancement:
+
+1. Sell available inventory only if the economic price is above target. The swap's
+   price limit is the target, and its input limit is released, undeployed inventory.
+2. Add liquidity in the fixed range from target to upper boundary using available
+   released tokens and saved quote proceeds. At/below target this is single-sided
+   launch-token liquidity. Above target, an active position needs both assets.
+3. Carry forward balances that do not fit. Never use unreleased tokens to pair quote.
+4. If time has reached the end, mark complete even when dust, missing counterparts,
+   or exhausted tick capacity prevent full deployment.
+
+Quote proceeds remain attributed to the launch. At the target, the chosen position
+cannot accept quote assets, so excess proceeds stay reserved. **This implementation
+does not place a separate buy position below target.** Quote seed follows the same
+rule; seeding quote does not guarantee two-sided depth at the target.
+
+Price can move below target through other liquidity or empty-range traversal. In
+that state, skip sales and continue adding token-side liquidity. No price floor or
+elimination of sniper profit is promised. Internal sales against launch-owned LPs
+move assets between positions and reserves; external funding comes from net buyer
+purchases, not from the internal swap itself.
+
+Liquidity additions respect remaining capacity at both boundary ticks, including
+liquidity owned by other LPs. A sale is skipped when saved quote already exceeds
+int128.max, retaining headroom for a signed swap output in Core's uint128 saved
+balance. Sales also cap input at the current price so output fits a signed delta;
+liquidity additions and withdrawals are similarly capped. These capacity
+conditions leave residual balances, not an endless completion requirement.
+
+## Completion and owner rights
+
+Anyone may call `advance(PoolKey)`; no trade or owner availability is needed to finish.
+Reaching target early does not finish the schedule. After end time, the next advance
+or external swap performs final management. Completion is irreversible. Normal
+subsequent swaps do not load reserves, trade for the launch, or change its positions.
+
+The owner can call `withdraw(PoolKey, recipient)` only after completion, collecting
+fees before removing liquidity, then withdrawing saved reserves. Principal withdrawal
+is capped to Core's signed token-delta limits; call again if a large position retains
+liquidity. Normal-sized positions are removed in one call. The recipient
+must be nonzero. **Liquidity is owner-withdrawable, not permanently locked.** This
+explicit owner action is separate from automatic management. Before completion,
+there is no owner withdrawal, cancellation, schedule mutation, or inventory rescue.
+Owner identity is immutable; there are no owner transfers or platform admin powers.
+
+Get configuration/accounting with `getLaunch(PoolId)`, release progress with
+`released(PoolId)`, and reserves with `CoreLib.savedBalances` using the extension
+address and pool-ID salt. `LaunchCreated` includes configuration, token, owner, and
+pool ID; `LaunchAdvanced` includes deployed supply and completion; `LaunchWithdrawn`
+records the recipient. Core emits the underlying pool/position/swap events.
+
+## Deployment and validation
+
+`script/DeployScheduledLaunch.s.sol` mines the required extension address prefix and
+uses the existing deterministic deployer. Configure `CORE_ADDRESS` (defaults to the
+canonical Core), optional starting `SALT`, and optional expected
+`SCHEDULED_LAUNCH_ADDRESS`. Run with `forge script --offline`; broadcasting is a
+separate deployment decision. No existing deployed contract source is changed.
+
+The test suite covers both asset orderings, fixed supply and ownership, atomic
+rollback, hook authentication, release rounding, native/ERC-20 quote funding,
+insufficient released inventory, sales to target, below-target releases, reserve
+isolation, owner withdrawal, fees, completion, trading/accounting sequences, extreme
+prices and supplies, large quote-output bounds, chunked principal withdrawals, third-party
+tick capacity, and real CREATE2 deployment with the required prefix.

--- a/script/DeployScheduledLaunch.s.sol
+++ b/script/DeployScheduledLaunch.s.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: ekubo-license-v1.eth
+pragma solidity =0.8.33;
+
+import {Script} from "forge-std/Script.sol";
+import {ICore} from "../src/interfaces/ICore.sol";
+import {ScheduledLaunch, scheduledLaunchCallPoints} from "../src/extensions/ScheduledLaunch.sol";
+import {deployExtension} from "./DeployAll.s.sol";
+
+/// @notice Deploys the launch extension with its required hook address prefix.
+contract DeployScheduledLaunch is Script {
+    function run() public returns (ScheduledLaunch extension) {
+        ICore core = ICore(payable(vm.envOr("CORE_ADDRESS", address(0x00000000000014aA86C5d3c41765bb24e11bd701))));
+        bytes32 startingSalt = vm.envOr("SALT", bytes32(0));
+        address expected = vm.envOr("SCHEDULED_LAUNCH_ADDRESS", address(0));
+        vm.startBroadcast();
+        (address deployed,) = deployExtension(
+            abi.encodePacked(type(ScheduledLaunch).creationCode, abi.encode(core)),
+            startingSalt,
+            scheduledLaunchCallPoints(),
+            expected,
+            "ScheduledLaunch"
+        );
+        vm.stopBroadcast();
+        extension = ScheduledLaunch(deployed);
+    }
+}

--- a/src/LockedLaunchLiquidity.sol
+++ b/src/LockedLaunchLiquidity.sol
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: ekubo-license-v1.eth
+pragma solidity =0.8.33;
+
+import {MintableERC20} from "./MintableERC20.sol";
+import {ICore} from "./interfaces/ICore.sol";
+import {BaseForwardee} from "./base/BaseForwardee.sol";
+import {BaseLocker} from "./base/BaseLocker.sol";
+import {UsesCore} from "./base/UsesCore.sol";
+import {CoreLib} from "./libraries/CoreLib.sol";
+import {FlashAccountantLib} from "./libraries/FlashAccountantLib.sol";
+import {PoolKey} from "./types/poolKey.sol";
+import {PoolId} from "./types/poolId.sol";
+import {PoolState} from "./types/poolState.sol";
+import {PoolBalanceUpdate} from "./types/poolBalanceUpdate.sol";
+import {PositionId, createPositionId} from "./types/positionId.sol";
+import {createSwapParameters} from "./types/swapParameters.sol";
+import {Locker} from "./types/locker.sol";
+import {SqrtRatio} from "./types/sqrtRatio.sol";
+import {MIN_TICK, MAX_TICK} from "./math/constants.sol";
+import {sqrtRatioToTick} from "./math/ticks.sol";
+import {LaunchLiquidityMath} from "./math/launchLiquidity.sol";
+import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
+
+/// @notice Permanently owns migrated launch principal. Only position fees can leave.
+/// @dev No withdrawal, approval, arbitrary execution, upgrade, or ownership-transfer path.
+contract LockedLaunchLiquidity is BaseForwardee, BaseLocker, UsesCore {
+    using CoreLib for ICore;
+    using FlashAccountantLib for *;
+
+    address public immutable EXTENSION;
+
+    struct Registration {
+        PoolId launchId;
+        address owner;
+        PoolKey poolKey;
+        SqrtRatio lower;
+        SqrtRatio upper;
+        uint128 amount0;
+        uint128 amount1;
+    }
+
+    struct Terminal {
+        address owner;
+        PoolKey poolKey;
+        SqrtRatio lower;
+        SqrtRatio upper;
+    }
+
+    mapping(PoolId => Terminal) private _terminals;
+
+    error ExtensionOnly();
+    error UnknownLaunch();
+    error OwnerOnly();
+    error InvalidRecipient();
+    error InvalidAction();
+
+    event PrincipalReceived(PoolId indexed launchId, uint128 amount0, uint128 amount1);
+    event LiquidityLocked(PoolId indexed launchId, PoolId indexed terminalPoolId, uint128 liquidity);
+    event FeesClaimed(PoolId indexed launchId, address indexed recipient, uint128 amount0, uint128 amount1);
+
+    constructor(ICore core, address extension) BaseForwardee(core) BaseLocker(core) UsesCore(core) {
+        EXTENSION = extension;
+    }
+
+    /// @notice Deploys fixed launch inventory for the extension's atomic creation path.
+    function createToken(string memory name, string memory symbol, uint8 decimals, uint128 supply)
+        external
+        returns (address)
+    {
+        if (msg.sender != EXTENSION) revert ExtensionOnly();
+        MintableERC20 token = new MintableERC20(address(this), name, symbol, decimals);
+        token.mint(EXTENSION, supply);
+        token.renounceOwnership();
+        return address(token);
+    }
+
+    function getTerminal(PoolId launchId) external view returns (Terminal memory) {
+        return _terminals[launchId];
+    }
+
+    function creatorFeeSalt(PoolId launchId) public pure returns (bytes32) {
+        return keccak256(abi.encode("LockedLaunchLiquidity creator fees", launchId));
+    }
+
+    function positionId(PoolId launchId) public pure returns (PositionId) {
+        return createPositionId(bytes24(PoolId.unwrap(launchId)), MIN_TICK, MAX_TICK);
+    }
+
+    /// @notice Retry balancing/depositing locked reserves; never removes existing principal.
+    function migrate(PoolId launchId) external {
+        _requireLaunch(launchId);
+        lock(abi.encode(launchId, address(0)));
+    }
+
+    /// @notice Collect only this launch's position fees, never fees belonging to other LPs.
+    function claimFees(PoolId launchId, address recipient) external {
+        if (_terminals[launchId].owner != msg.sender) revert OwnerOnly();
+        if (recipient == address(0)) revert InvalidRecipient();
+        lock(abi.encode(launchId, recipient));
+    }
+
+    /// @dev action 0: extension-only Registration. action 1: permissionless funding
+    /// encoded as (uint8(1), launchId, amount0, amount1), paid by the forwarding locker.
+    function handleForwardData(Locker original, bytes memory data) internal override returns (bytes memory) {
+        uint8 action = abi.decode(data, (uint8));
+        if (action == 0) {
+            if (original.addr() != EXTENSION) revert ExtensionOnly();
+            (, Registration memory registration) = abi.decode(data, (uint8, Registration));
+            _receivePrincipal(registration);
+        } else if (action == 1) {
+            (, PoolId launchId, uint128 amount0, uint128 amount1) = abi.decode(data, (uint8, PoolId, uint128, uint128));
+            _requireLaunch(launchId);
+            _save(launchId, int256(uint256(amount0)), int256(uint256(amount1)));
+            emit PrincipalReceived(launchId, amount0, amount1);
+        } else {
+            revert InvalidAction();
+        }
+        return "";
+    }
+
+    function _receivePrincipal(Registration memory registration) private {
+        if (_terminals[registration.launchId].owner == address(0)) {
+            _terminals[registration.launchId] =
+                Terminal(registration.owner, registration.poolKey, registration.lower, registration.upper);
+        }
+        _save(registration.launchId, int256(uint256(registration.amount0)), int256(uint256(registration.amount1)));
+        emit PrincipalReceived(registration.launchId, registration.amount0, registration.amount1);
+    }
+
+    function handleLockData(uint256, bytes memory data) internal override returns (bytes memory) {
+        (PoolId launchId, address recipient) = abi.decode(data, (PoolId, address));
+        if (recipient == address(0)) _migrate(launchId);
+        else _claim(launchId, recipient);
+        return "";
+    }
+
+    function _requireLaunch(PoolId launchId) private view {
+        if (_terminals[launchId].owner == address(0)) revert UnknownLaunch();
+    }
+
+    function _balances(PoolId launchId) private view returns (uint128, uint128) {
+        PoolKey memory key = _terminals[launchId].poolKey;
+        return CORE.savedBalances(address(this), key.token0, key.token1, PoolId.unwrap(launchId));
+    }
+
+    function _save(PoolId launchId, int256 delta0, int256 delta1) private {
+        PoolKey memory key = _terminals[launchId].poolKey;
+        CORE.updateSavedBalances(key.token0, key.token1, PoolId.unwrap(launchId), delta0, delta1);
+    }
+
+    function _migrate(PoolId launchId) private {
+        Terminal storage terminal = _terminals[launchId];
+        (uint128 amount0, uint128 amount1) = _balances(launchId);
+        PoolState state = CORE.poolState(terminal.poolKey.toPoolId());
+        if (state.liquidity() == 0) {
+            if (!_prepareEmpty(terminal, amount0, amount1)) return;
+        } else {
+            if (state.liquidity() == type(uint128).max) return;
+            if (state.sqrtRatio() < terminal.lower || state.sqrtRatio() > terminal.upper) return;
+            _balance(launchId, state, amount0, amount1);
+        }
+        _deposit(launchId);
+    }
+
+    function _prepareEmpty(Terminal storage terminal, uint128 amount0, uint128 amount1) private returns (bool) {
+        // Without either an external counterparty or both assets there is no funded XYK pool.
+        if (amount0 == 0 || amount1 == 0) return false;
+        SqrtRatio price = LaunchLiquidityMath.depositPrice(amount0, amount1);
+        if (price < terminal.lower || price > terminal.upper) return false;
+        PoolKey memory key = terminal.poolKey;
+        PoolState state = CORE.poolState(key.toPoolId());
+        if (!state.isInitialized()) {
+            CORE.initializePool(key, sqrtRatioToTick(price));
+            state = CORE.poolState(key.toPoolId());
+        }
+        // An empty pool's price is not meaningful and can have been moved by anyone.
+        CORE.swap(0, key, createSwapParameters(price, 1, state.sqrtRatio() < price, 0));
+        return true;
+    }
+
+    function _balance(PoolId launchId, PoolState state, uint128 amount0, uint128 amount1) private {
+        Terminal storage terminal = _terminals[launchId];
+        LaunchLiquidityMath.Market memory market = LaunchLiquidityMath.Market(
+            state.sqrtRatio(),
+            terminal.lower,
+            terminal.upper,
+            state.liquidity(),
+            terminal.poolKey.config.fee(),
+            amount0,
+            amount1,
+            CORE.poolPositions(terminal.poolKey.toPoolId(), address(this), positionId(launchId)).liquidity
+        );
+        (bool token1, uint128 amount) = LaunchLiquidityMath.optimalSwap(market);
+        if (amount == 0) return;
+        // Preserve fees earned before this internal operation for the creator.
+        _collectBeforeRebalance(launchId);
+        SqrtRatio limit = token1 ? terminal.upper : terminal.lower;
+        (PoolBalanceUpdate update,) =
+            CORE.swap(0, terminal.poolKey, createSwapParameters(limit, int128(amount), token1, 0));
+        _save(launchId, -int256(update.delta0()), -int256(update.delta1()));
+        // Fees this position earns from its own migration swap remain locked principal.
+        (uint128 fee0, uint128 fee1) = CORE.collectFees(terminal.poolKey, positionId(launchId));
+        _save(launchId, int256(uint256(fee0)), int256(uint256(fee1)));
+    }
+
+    function _collectBeforeRebalance(PoolId launchId) private {
+        PoolKey memory key = _terminals[launchId].poolKey;
+        (uint128 fee0, uint128 fee1) = CORE.collectFees(key, positionId(launchId));
+        CORE.updateSavedBalances(
+            key.token0, key.token1, creatorFeeSalt(launchId), int256(uint256(fee0)), int256(uint256(fee1))
+        );
+    }
+
+    function _deposit(PoolId launchId) private {
+        Terminal storage terminal = _terminals[launchId];
+        (uint128 amount0, uint128 amount1) = _balances(launchId);
+        PoolState state = CORE.poolState(terminal.poolKey.toPoolId());
+        uint128 liquidity = LaunchLiquidityMath.liquidityFor(
+            state.sqrtRatio(),
+            uint128(FixedPointMathLib.min(amount0, uint128(type(int128).max))),
+            uint128(FixedPointMathLib.min(amount1, uint128(type(int128).max)))
+        );
+        liquidity = uint128(FixedPointMathLib.min(liquidity, type(uint128).max - state.liquidity()));
+        liquidity = uint128(FixedPointMathLib.min(liquidity, uint128(type(int128).max)));
+        if (liquidity == 0) return;
+        PoolBalanceUpdate update = CORE.updatePosition(terminal.poolKey, positionId(launchId), int128(liquidity));
+        _save(launchId, -int256(update.delta0()), -int256(update.delta1()));
+        emit LiquidityLocked(launchId, terminal.poolKey.toPoolId(), liquidity);
+    }
+
+    function _claim(PoolId launchId, address recipient) private {
+        PoolKey memory key = _terminals[launchId].poolKey;
+        (uint128 amount0, uint128 amount1) = CORE.collectFees(key, positionId(launchId));
+        CORE.withdrawTwo(key.token0, key.token1, recipient, amount0, amount1);
+        emit FeesClaimed(launchId, recipient, amount0, amount1);
+        bytes32 salt = creatorFeeSalt(launchId);
+        (amount0, amount1) = CORE.savedBalances(address(this), key.token0, key.token1, salt);
+        CORE.updateSavedBalances(key.token0, key.token1, salt, -int256(uint256(amount0)), -int256(uint256(amount1)));
+        CORE.withdrawTwo(key.token0, key.token1, recipient, amount0, amount1);
+        emit FeesClaimed(launchId, recipient, amount0, amount1);
+    }
+}

--- a/src/extensions/ScheduledLaunch.sol
+++ b/src/extensions/ScheduledLaunch.sol
@@ -5,14 +5,17 @@ import {ICore, CallPoints} from "../interfaces/ICore.sol";
 import {BaseExtension} from "../base/BaseExtension.sol";
 import {BaseForwardee} from "../base/BaseForwardee.sol";
 import {BaseLocker} from "../base/BaseLocker.sol";
-import {MintableERC20} from "../MintableERC20.sol";
+import {LockedLaunchLiquidity} from "../LockedLaunchLiquidity.sol";
+import {PoolState} from "../types/poolState.sol";
+import {computeFee, amountBeforeFee} from "../math/fee.sol";
+import {SafeCastLib} from "solady/utils/SafeCastLib.sol";
 import {CoreLib} from "../libraries/CoreLib.sol";
 import {FlashAccountantLib} from "../libraries/FlashAccountantLib.sol";
 import {PoolKey} from "../types/poolKey.sol";
 import {PoolId} from "../types/poolId.sol";
-import {createConcentratedPoolConfig} from "../types/poolConfig.sol";
+import {createConcentratedPoolConfig, createFullRangePoolConfig} from "../types/poolConfig.sol";
 import {PositionId, createPositionId} from "../types/positionId.sol";
-import {PoolBalanceUpdate} from "../types/poolBalanceUpdate.sol";
+import {PoolBalanceUpdate, createPoolBalanceUpdate} from "../types/poolBalanceUpdate.sol";
 import {SwapParameters, createSwapParameters} from "../types/swapParameters.sol";
 import {Locker} from "../types/locker.sol";
 import {SqrtRatio} from "../types/sqrtRatio.sol";
@@ -35,11 +38,13 @@ function scheduledLaunchCallPoints() pure returns (CallPoints memory) {
 }
 
 /// @notice Fixed-supply launches with linear inventory release and a fixed price target.
-/// @dev Create via Core.forward with abi.encode(LaunchConfig). The forwarding locker owes
-/// quoteAmount to Core. Automatic management ends after endTime; the owner may then withdraw.
+/// @dev Create via Core.forward with abi.encode(uint8(0), LaunchConfig). The forwarding locker owes
+/// quoteAmount to Core. Principal migrates to permanently locked full-range liquidity at endTime.
 contract ScheduledLaunch is BaseExtension, BaseForwardee, BaseLocker {
     using CoreLib for ICore;
     using FlashAccountantLib for *;
+
+    LockedLaunchLiquidity public immutable LIQUIDITY;
 
     /// @dev Ticks express raw quote units per launch token, independent of address ordering.
     struct LaunchConfig {
@@ -55,7 +60,10 @@ contract ScheduledLaunch is BaseExtension, BaseForwardee, BaseLocker {
         int32 targetTick;
         int32 upperTick;
         uint32 tickSpacing;
-        uint64 fee;
+        uint64 initialFee;
+        uint64 finalFee;
+        int32 migrationTickLower;
+        int32 migrationTickUpper;
     }
 
     struct Launch {
@@ -68,6 +76,10 @@ contract ScheduledLaunch is BaseExtension, BaseForwardee, BaseLocker {
         int32 targetTick;
         PositionId positionId;
         bool complete;
+        uint64 initialFee;
+        uint64 finalFee;
+        SqrtRatio migrationLower;
+        SqrtRatio migrationUpper;
     }
 
     mapping(PoolId => Launch) private _launches;
@@ -76,15 +88,19 @@ contract ScheduledLaunch is BaseExtension, BaseForwardee, BaseLocker {
     error UnknownLaunch();
     error InitializationThroughForwardOnly();
     error LaunchNotStarted();
-    error LaunchNotComplete();
+    error LaunchEnded();
+    error SwapsThroughForwardOnly();
+    error InvalidAction();
     error OwnerOnly();
     error InvalidRecipient();
 
     event LaunchCreated(PoolId indexed poolId, address indexed token, address indexed owner, LaunchConfig config);
     event LaunchAdvanced(PoolId indexed poolId, uint128 deployed, bool complete);
-    event LaunchWithdrawn(PoolId indexed poolId, address indexed recipient);
+    event CreatorFeesClaimed(PoolId indexed poolId, address indexed recipient, uint128 amount0, uint128 amount1);
 
-    constructor(ICore core) BaseExtension(core) BaseForwardee(core) BaseLocker(core) {}
+    constructor(ICore core) BaseExtension(core) BaseForwardee(core) BaseLocker(core) {
+        LIQUIDITY = new LockedLaunchLiquidity(core, address(this));
+    }
 
     function getCallPoints() internal pure override returns (CallPoints memory) {
         return scheduledLaunchCallPoints();
@@ -110,11 +126,31 @@ contract ScheduledLaunch is BaseExtension, BaseForwardee, BaseLocker {
         revert InitializationThroughForwardOnly();
     }
 
-    function beforeSwap(Locker, PoolKey memory key, SwapParameters) external override onlyCore {
+    function beforeSwap(Locker, PoolKey memory, SwapParameters) external pure override {
+        revert SwapsThroughForwardOnly();
+    }
+
+    /// @notice Linearly declining fee charged only on external forwarded launch swaps.
+    function feeAt(PoolId poolId) public view returns (uint64) {
+        Launch storage launch = _launches[poolId];
+        if (launch.owner == address(0)) revert UnknownLaunch();
+        if (block.timestamp <= launch.startTime) return launch.initialFee;
+        if (block.timestamp >= launch.endTime) return launch.finalFee;
+        return launch.initialFee
+            - uint64(
+            uint256(launch.initialFee - launch.finalFee) * (block.timestamp - launch.startTime)
+                / (launch.endTime - launch.startTime)
+        );
+    }
+
+    function creatorFeeSalt(PoolId poolId) public pure returns (bytes32) {
+        return keccak256(abi.encode("ScheduledLaunch creator fees", poolId));
+    }
+
+    function terminalPool(PoolKey memory key) public view returns (PoolKey memory) {
         Launch storage launch = _launches[key.toPoolId()];
         if (launch.owner == address(0)) revert UnknownLaunch();
-        if (block.timestamp < launch.startTime) revert LaunchNotStarted();
-        if (!launch.complete) advance(key);
+        return PoolKey(key.token0, key.token1, createFullRangePoolConfig(launch.finalFee, address(0)));
     }
 
     /// @notice Anyone may advance a launch, including completing it without a trade.
@@ -124,23 +160,31 @@ contract ScheduledLaunch is BaseExtension, BaseForwardee, BaseLocker {
         if (!launch.complete) lock(abi.encode(key, address(0)));
     }
 
-    /// @notice After completion, withdraw reserves, fees, and liquidity up to Core's per-call amount limits.
-    /// @dev Repeat to remove any liquidity remaining after a large withdrawal.
-    /// @dev This is an owner action, not automatic pool management. Liquidity is not permanently locked.
-    function withdraw(PoolKey memory key, address recipient) external {
-        Launch storage launch = _launches[key.toPoolId()];
-        if (msg.sender != launch.owner) revert OwnerOnly();
-        if (!launch.complete) revert LaunchNotComplete();
+    /// @notice Claims creator trading fees; principal is never owner-withdrawable.
+    function claimFees(PoolKey memory key, address recipient) external {
+        if (msg.sender != _launches[key.toPoolId()].owner) revert OwnerOnly();
         if (recipient == address(0)) revert InvalidRecipient();
         lock(abi.encode(key, recipient));
     }
 
+    /// @dev Forward abi.encode(uint8(0), LaunchConfig) to create, or
+    /// abi.encode(uint8(1), PoolKey, SwapParameters) to trade and receive (update, state).
     function handleForwardData(Locker, bytes memory data) internal override returns (bytes memory) {
-        LaunchConfig memory config = abi.decode(data, (LaunchConfig));
+        uint8 action = abi.decode(data, (uint8));
+        if (action == 0) {
+            (, LaunchConfig memory config) = abi.decode(data, (uint8, LaunchConfig));
+            return _create(config);
+        }
+        if (action == 1) {
+            (, PoolKey memory key, SwapParameters params) = abi.decode(data, (uint8, PoolKey, SwapParameters));
+            return _swap(key, params);
+        }
+        revert InvalidAction();
+    }
+
+    function _create(LaunchConfig memory config) private returns (bytes memory) {
         _validateConfig(config);
-        MintableERC20 token = new MintableERC20(address(this), config.name, config.symbol, config.decimals);
-        token.mint(address(this), config.totalSupply);
-        token.renounceOwnership();
+        address token = LIQUIDITY.createToken(config.name, config.symbol, config.decimals, config.totalSupply);
         PoolKey memory key = _initialize(config, address(token));
         CORE.pay(address(token), config.totalSupply);
         bool tokenIs0 = key.token0 == address(token);
@@ -155,13 +199,50 @@ contract ScheduledLaunch is BaseExtension, BaseForwardee, BaseLocker {
         return abi.encode(key);
     }
 
+    function _swap(PoolKey memory key, SwapParameters params) private returns (bytes memory) {
+        Launch storage launch = _launches[key.toPoolId()];
+        if (launch.owner == address(0)) revert UnknownLaunch();
+        if (block.timestamp < launch.startTime) revert LaunchNotStarted();
+        if (block.timestamp >= launch.endTime) revert LaunchEnded();
+        _advance(key);
+        (PoolBalanceUpdate update, PoolState state) = CORE.swap(0, key, params.withDefaultSqrtRatioLimit());
+        update = _chargeFee(key, params, update);
+        return abi.encode(update, state);
+    }
+
+    function _chargeFee(PoolKey memory key, SwapParameters params, PoolBalanceUpdate update)
+        private
+        returns (PoolBalanceUpdate)
+    {
+        // Fee on the calculated side: output for exact-input, input for exact-output.
+        // This preserves the specified amount and charges only the actual partial fill.
+        bool calculatedIs1 = !params.isToken1();
+        int128 calculated = calculatedIs1 ? update.delta1() : update.delta0();
+        uint128 amount = uint128(FixedPointMathLib.abs(calculated));
+        uint64 fee = feeAt(key.toPoolId());
+        uint128 feeAmount = params.isExactOut() ? amountBeforeFee(amount, fee) - amount : computeFee(amount, fee);
+        _saveFees(key, calculatedIs1 ? 0 : feeAmount, calculatedIs1 ? feeAmount : 0);
+        int128 withFee = SafeCastLib.toInt128(int256(calculated) + int256(uint256(feeAmount)));
+        return calculatedIs1
+            ? createPoolBalanceUpdate(update.delta0(), withFee)
+            : createPoolBalanceUpdate(withFee, update.delta1());
+    }
+
+    function _saveFees(PoolKey memory key, uint128 amount0, uint128 amount1) private {
+        CORE.updateSavedBalances(
+            key.token0, key.token1, creatorFeeSalt(key.toPoolId()), int256(uint256(amount0)), int256(uint256(amount1))
+        );
+    }
+
     function _validateConfig(LaunchConfig memory config) private view {
         if (config.owner == address(0) || config.totalSupply == 0) revert InvalidLaunch();
         if (config.startTime < block.timestamp || config.endTime <= config.startTime) revert InvalidLaunch();
         if (config.totalSupply > uint128(type(int128).max) || config.quoteAmount > uint128(type(int128).max)) {
             revert InvalidLaunch();
         }
+        if (config.initialFee < config.finalFee) revert InvalidLaunch();
         _validateTicks(config);
+        _validateMigrationBounds(config);
     }
 
     function _validateTicks(LaunchConfig memory config) private pure {
@@ -172,13 +253,20 @@ contract ScheduledLaunch is BaseExtension, BaseForwardee, BaseLocker {
         // PositionId.validate checks aligned bounds after accounting for token ordering.
     }
 
+    function _validateMigrationBounds(LaunchConfig memory config) private pure {
+        if (
+            config.migrationTickLower < MIN_TICK || config.migrationTickUpper > MAX_TICK
+                || config.migrationTickLower >= config.migrationTickUpper
+        ) revert InvalidLaunch();
+    }
+
     function _initialize(LaunchConfig memory config, address token) private returns (PoolKey memory key) {
         if (config.quoteToken == token) revert InvalidLaunch();
         bool tokenIs0 = token < config.quoteToken;
         key = PoolKey({
             token0: tokenIs0 ? token : config.quoteToken,
             token1: tokenIs0 ? config.quoteToken : token,
-            config: createConcentratedPoolConfig(config.fee, config.tickSpacing, address(this))
+            config: createConcentratedPoolConfig(0, config.tickSpacing, address(this))
         });
         key.config.validate();
         int32 targetTick = tokenIs0 ? config.targetTick : -config.targetTick;
@@ -197,7 +285,11 @@ contract ScheduledLaunch is BaseExtension, BaseForwardee, BaseLocker {
             deployed: 0,
             targetTick: targetTick,
             positionId: positionId,
-            complete: false
+            complete: false,
+            initialFee: config.initialFee,
+            finalFee: config.finalFee,
+            migrationLower: tickToSqrtRatio(tokenIs0 ? config.migrationTickLower : -config.migrationTickUpper),
+            migrationUpper: tickToSqrtRatio(tokenIs0 ? config.migrationTickUpper : -config.migrationTickLower)
         });
         CORE.initializePool(key, targetTick);
     }
@@ -205,7 +297,7 @@ contract ScheduledLaunch is BaseExtension, BaseForwardee, BaseLocker {
     function handleLockData(uint256, bytes memory data) internal override returns (bytes memory) {
         (PoolKey memory key, address recipient) = abi.decode(data, (PoolKey, address));
         if (recipient == address(0)) _advance(key);
-        else _withdraw(key, recipient);
+        else _claimFees(key, recipient);
         return "";
     }
 
@@ -213,11 +305,15 @@ contract ScheduledLaunch is BaseExtension, BaseForwardee, BaseLocker {
         PoolId poolId = key.toPoolId();
         Launch storage launch = _launches[poolId];
         if (block.timestamp < launch.startTime) return;
-        uint128 available = released(poolId) - launch.deployed;
+        if (block.timestamp >= launch.endTime) _finish(key, launch);
+        else _release(key, launch);
+        emit LaunchAdvanced(poolId, launch.deployed, launch.complete);
+    }
+
+    function _release(PoolKey memory key, Launch storage launch) private {
+        uint128 available = released(key.toPoolId()) - launch.deployed;
         if (available != 0) _sell(key, launch, available);
         _addLiquidity(key, launch);
-        if (block.timestamp >= launch.endTime) launch.complete = true;
-        emit LaunchAdvanced(poolId, launch.deployed, launch.complete);
     }
 
     function _sell(PoolKey memory key, Launch storage launch, uint128 available) private {
@@ -281,35 +377,66 @@ contract ScheduledLaunch is BaseExtension, BaseForwardee, BaseLocker {
         return CORE.savedBalances(address(this), key.token0, key.token1, PoolId.unwrap(key.toPoolId()));
     }
 
-    function _withdraw(PoolKey memory key, address recipient) private {
-        Launch storage launch = _launches[key.toPoolId()];
-        uint128 liquidity = CORE.poolPositions(key.toPoolId(), address(this), launch.positionId).liquidity;
-        liquidity = uint128(
+    function _claimFees(PoolKey memory key, address recipient) private {
+        bytes32 salt = creatorFeeSalt(key.toPoolId());
+        (uint128 amount0, uint128 amount1) = CORE.savedBalances(address(this), key.token0, key.token1, salt);
+        CORE.updateSavedBalances(key.token0, key.token1, salt, -int256(uint256(amount0)), -int256(uint256(amount1)));
+        CORE.withdrawTwo(key.token0, key.token1, recipient, amount0, amount1);
+        emit CreatorFeesClaimed(key.toPoolId(), recipient, amount0, amount1);
+    }
+
+    function _sendPrincipal(PoolKey memory key, Launch storage launch) private {
+        (uint128 amount0, uint128 amount1) = _reserves(key);
+        CORE.updateSavedBalances(
+            key.token0, key.token1, PoolId.unwrap(key.toPoolId()), -int256(uint256(amount0)), -int256(uint256(amount1))
+        );
+        LockedLaunchLiquidity.Registration memory registration = LockedLaunchLiquidity.Registration(
+            key.toPoolId(),
+            launch.owner,
+            terminalPool(key),
+            launch.migrationLower,
+            launch.migrationUpper,
+            amount0,
+            amount1
+        );
+        CORE.forward(address(LIQUIDITY), abi.encode(uint8(0), registration));
+    }
+
+    function _removableLiquidity(PoolKey memory key, Launch storage launch, uint128 liquidity)
+        private
+        view
+        returns (uint128)
+    {
+        (uint128 saved0, uint128 saved1) =
+            CORE.savedBalances(address(LIQUIDITY), key.token0, key.token1, PoolId.unwrap(key.toPoolId()));
+        return uint128(
             FixedPointMathLib.min(
                 liquidity,
                 maxLiquidity(
                     CORE.poolState(key.toPoolId()).sqrtRatio(),
                     tickToSqrtRatio(launch.positionId.tickLower()),
                     tickToSqrtRatio(launch.positionId.tickUpper()),
-                    uint128(type(int128).max),
-                    uint128(type(int128).max)
+                    uint128(FixedPointMathLib.min(type(uint128).max - saved0, uint128(type(int128).max))),
+                    uint128(FixedPointMathLib.min(type(uint128).max - saved1, uint128(type(int128).max)))
                 )
             )
         );
-        // Core clears fee accounting when the last liquidity is removed. Collect first.
+    }
+
+    function _finish(PoolKey memory key, Launch storage launch) private {
+        // Move reserves first to leave space for a bounded principal withdrawal.
+        _sendPrincipal(key, launch);
+        uint128 liquidity = CORE.poolPositions(key.toPoolId(), address(this), launch.positionId).liquidity;
+        uint128 removable = _removableLiquidity(key, launch, liquidity);
+        // Pool fee is zero; any donated position fees still belong to the creator.
         (uint128 fees0, uint128 fees1) = CORE.collectFees(key, launch.positionId);
-        PoolBalanceUpdate update = CORE.updatePosition(key, launch.positionId, -int128(liquidity));
-        (uint128 reserve0, uint128 reserve1) = _reserves(key);
+        _saveFees(key, fees0, fees1);
+        PoolBalanceUpdate update = CORE.updatePosition(key, launch.positionId, -int128(removable));
         CORE.updateSavedBalances(
-            key.token0,
-            key.token1,
-            PoolId.unwrap(key.toPoolId()),
-            -int256(uint256(reserve0)),
-            -int256(uint256(reserve1))
+            key.token0, key.token1, PoolId.unwrap(key.toPoolId()), -int256(update.delta0()), -int256(update.delta1())
         );
-        CORE.withdrawTwo(key.token0, key.token1, recipient, reserve0, reserve1);
-        CORE.withdrawTwo(key.token0, key.token1, recipient, uint128(-update.delta0()), uint128(-update.delta1()));
-        CORE.withdrawTwo(key.token0, key.token1, recipient, fees0, fees1);
-        emit LaunchWithdrawn(key.toPoolId(), recipient);
+        _sendPrincipal(key, launch);
+        launch.complete = removable == liquidity;
+        LIQUIDITY.migrate(key.toPoolId());
     }
 }

--- a/src/extensions/ScheduledLaunch.sol
+++ b/src/extensions/ScheduledLaunch.sol
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: ekubo-license-v1.eth
+pragma solidity =0.8.33;
+
+import {ICore, CallPoints} from "../interfaces/ICore.sol";
+import {BaseExtension} from "../base/BaseExtension.sol";
+import {BaseForwardee} from "../base/BaseForwardee.sol";
+import {BaseLocker} from "../base/BaseLocker.sol";
+import {MintableERC20} from "../MintableERC20.sol";
+import {CoreLib} from "../libraries/CoreLib.sol";
+import {FlashAccountantLib} from "../libraries/FlashAccountantLib.sol";
+import {PoolKey} from "../types/poolKey.sol";
+import {PoolId} from "../types/poolId.sol";
+import {createConcentratedPoolConfig} from "../types/poolConfig.sol";
+import {PositionId, createPositionId} from "../types/positionId.sol";
+import {PoolBalanceUpdate} from "../types/poolBalanceUpdate.sol";
+import {SwapParameters, createSwapParameters} from "../types/swapParameters.sol";
+import {Locker} from "../types/locker.sol";
+import {SqrtRatio} from "../types/sqrtRatio.sol";
+import {tickToSqrtRatio} from "../math/ticks.sol";
+import {MIN_TICK, MAX_TICK, MAX_TICK_SPACING} from "../math/constants.sol";
+import {maxLiquidity} from "../math/liquidity.sol";
+import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
+
+function scheduledLaunchCallPoints() pure returns (CallPoints memory) {
+    return CallPoints({
+        beforeInitializePool: true,
+        afterInitializePool: false,
+        beforeSwap: true,
+        afterSwap: false,
+        beforeUpdatePosition: false,
+        afterUpdatePosition: false,
+        beforeCollectFees: false,
+        afterCollectFees: false
+    });
+}
+
+/// @notice Fixed-supply launches with linear inventory release and a fixed price target.
+/// @dev Create via Core.forward with abi.encode(LaunchConfig). The forwarding locker owes
+/// quoteAmount to Core. Automatic management ends after endTime; the owner may then withdraw.
+contract ScheduledLaunch is BaseExtension, BaseForwardee, BaseLocker {
+    using CoreLib for ICore;
+    using FlashAccountantLib for *;
+
+    /// @dev Ticks express raw quote units per launch token, independent of address ordering.
+    struct LaunchConfig {
+        address owner;
+        address quoteToken;
+        string name;
+        string symbol;
+        uint8 decimals;
+        uint128 totalSupply;
+        uint128 quoteAmount;
+        uint64 startTime;
+        uint64 endTime;
+        int32 targetTick;
+        int32 upperTick;
+        uint32 tickSpacing;
+        uint64 fee;
+    }
+
+    struct Launch {
+        address owner;
+        address token;
+        uint64 startTime;
+        uint64 endTime;
+        uint128 totalSupply;
+        uint128 deployed;
+        int32 targetTick;
+        PositionId positionId;
+        bool complete;
+    }
+
+    mapping(PoolId => Launch) private _launches;
+
+    error InvalidLaunch();
+    error UnknownLaunch();
+    error InitializationThroughForwardOnly();
+    error LaunchNotStarted();
+    error LaunchNotComplete();
+    error OwnerOnly();
+    error InvalidRecipient();
+
+    event LaunchCreated(PoolId indexed poolId, address indexed token, address indexed owner, LaunchConfig config);
+    event LaunchAdvanced(PoolId indexed poolId, uint128 deployed, bool complete);
+    event LaunchWithdrawn(PoolId indexed poolId, address indexed recipient);
+
+    constructor(ICore core) BaseExtension(core) BaseForwardee(core) BaseLocker(core) {}
+
+    function getCallPoints() internal pure override returns (CallPoints memory) {
+        return scheduledLaunchCallPoints();
+    }
+
+    function getLaunch(PoolId poolId) external view returns (Launch memory) {
+        return _launches[poolId];
+    }
+
+    /// @notice Returns cumulative released supply, including tokens already deployed.
+    function released(PoolId poolId) public view returns (uint128) {
+        Launch storage launch = _launches[poolId];
+        if (launch.owner == address(0)) revert UnknownLaunch();
+        if (block.timestamp <= launch.startTime) return 0;
+        if (block.timestamp >= launch.endTime) return launch.totalSupply;
+        return uint128(
+            uint256(launch.totalSupply) * (block.timestamp - launch.startTime) / (launch.endTime - launch.startTime)
+        );
+    }
+
+    /// @dev Core skips this hook when this extension itself initializes the pool.
+    function beforeInitializePool(address, PoolKey calldata, int32) external pure override {
+        revert InitializationThroughForwardOnly();
+    }
+
+    function beforeSwap(Locker, PoolKey memory key, SwapParameters) external override onlyCore {
+        Launch storage launch = _launches[key.toPoolId()];
+        if (launch.owner == address(0)) revert UnknownLaunch();
+        if (block.timestamp < launch.startTime) revert LaunchNotStarted();
+        if (!launch.complete) advance(key);
+    }
+
+    /// @notice Anyone may advance a launch, including completing it without a trade.
+    function advance(PoolKey memory key) public {
+        Launch storage launch = _launches[key.toPoolId()];
+        if (launch.owner == address(0)) revert UnknownLaunch();
+        if (!launch.complete) lock(abi.encode(key, address(0)));
+    }
+
+    /// @notice After completion, withdraw reserves, fees, and liquidity up to Core's per-call amount limits.
+    /// @dev Repeat to remove any liquidity remaining after a large withdrawal.
+    /// @dev This is an owner action, not automatic pool management. Liquidity is not permanently locked.
+    function withdraw(PoolKey memory key, address recipient) external {
+        Launch storage launch = _launches[key.toPoolId()];
+        if (msg.sender != launch.owner) revert OwnerOnly();
+        if (!launch.complete) revert LaunchNotComplete();
+        if (recipient == address(0)) revert InvalidRecipient();
+        lock(abi.encode(key, recipient));
+    }
+
+    function handleForwardData(Locker, bytes memory data) internal override returns (bytes memory) {
+        LaunchConfig memory config = abi.decode(data, (LaunchConfig));
+        _validateConfig(config);
+        MintableERC20 token = new MintableERC20(address(this), config.name, config.symbol, config.decimals);
+        token.mint(address(this), config.totalSupply);
+        token.renounceOwnership();
+        PoolKey memory key = _initialize(config, address(token));
+        CORE.pay(address(token), config.totalSupply);
+        bool tokenIs0 = key.token0 == address(token);
+        CORE.updateSavedBalances(
+            key.token0,
+            key.token1,
+            PoolId.unwrap(key.toPoolId()),
+            int256(uint256(tokenIs0 ? config.totalSupply : config.quoteAmount)),
+            int256(uint256(tokenIs0 ? config.quoteAmount : config.totalSupply))
+        );
+        emit LaunchCreated(key.toPoolId(), address(token), config.owner, config);
+        return abi.encode(key);
+    }
+
+    function _validateConfig(LaunchConfig memory config) private view {
+        if (config.owner == address(0) || config.totalSupply == 0) revert InvalidLaunch();
+        if (config.startTime < block.timestamp || config.endTime <= config.startTime) revert InvalidLaunch();
+        if (config.totalSupply > uint128(type(int128).max) || config.quoteAmount > uint128(type(int128).max)) {
+            revert InvalidLaunch();
+        }
+        _validateTicks(config);
+    }
+
+    function _validateTicks(LaunchConfig memory config) private pure {
+        if (config.targetTick < MIN_TICK || config.upperTick > MAX_TICK || config.targetTick >= config.upperTick) {
+            revert InvalidLaunch();
+        }
+        if (config.tickSpacing == 0 || config.tickSpacing > MAX_TICK_SPACING) revert InvalidLaunch();
+        // PositionId.validate checks aligned bounds after accounting for token ordering.
+    }
+
+    function _initialize(LaunchConfig memory config, address token) private returns (PoolKey memory key) {
+        if (config.quoteToken == token) revert InvalidLaunch();
+        bool tokenIs0 = token < config.quoteToken;
+        key = PoolKey({
+            token0: tokenIs0 ? token : config.quoteToken,
+            token1: tokenIs0 ? config.quoteToken : token,
+            config: createConcentratedPoolConfig(config.fee, config.tickSpacing, address(this))
+        });
+        key.config.validate();
+        int32 targetTick = tokenIs0 ? config.targetTick : -config.targetTick;
+        PositionId positionId = createPositionId(
+            bytes24(0),
+            tokenIs0 ? config.targetTick : -config.upperTick,
+            tokenIs0 ? config.upperTick : -config.targetTick
+        );
+        positionId.validate(key.config);
+        _launches[key.toPoolId()] = Launch({
+            owner: config.owner,
+            token: token,
+            startTime: config.startTime,
+            endTime: config.endTime,
+            totalSupply: config.totalSupply,
+            deployed: 0,
+            targetTick: targetTick,
+            positionId: positionId,
+            complete: false
+        });
+        CORE.initializePool(key, targetTick);
+    }
+
+    function handleLockData(uint256, bytes memory data) internal override returns (bytes memory) {
+        (PoolKey memory key, address recipient) = abi.decode(data, (PoolKey, address));
+        if (recipient == address(0)) _advance(key);
+        else _withdraw(key, recipient);
+        return "";
+    }
+
+    function _advance(PoolKey memory key) private {
+        PoolId poolId = key.toPoolId();
+        Launch storage launch = _launches[poolId];
+        if (block.timestamp < launch.startTime) return;
+        uint128 available = released(poolId) - launch.deployed;
+        if (available != 0) _sell(key, launch, available);
+        _addLiquidity(key, launch);
+        if (block.timestamp >= launch.endTime) launch.complete = true;
+        emit LaunchAdvanced(poolId, launch.deployed, launch.complete);
+    }
+
+    function _sell(PoolKey memory key, Launch storage launch, uint128 available) private {
+        SqrtRatio current = CORE.poolState(key.toPoolId()).sqrtRatio();
+        SqrtRatio target = tickToSqrtRatio(launch.targetTick);
+        bool tokenIs1 = launch.token == key.token1;
+        if (tokenIs1 ? current >= target : current <= target) return;
+        (uint128 reserve0, uint128 reserve1) = _reserves(key);
+        // Leave room for the maximum signed output delta in Core's uint128 saved balance.
+        if ((tokenIs1 ? reserve0 : reserve1) > uint128(type(int128).max)) return;
+        int128 amount = _saleAmount(current, tokenIs1, available);
+        if (amount == 0) return;
+        (PoolBalanceUpdate update,) = CORE.swap(0, key, createSwapParameters(target, amount, tokenIs1, 0));
+        _saveUpdate(key, launch, update);
+    }
+
+    /// @dev At a descending economic price, input * current price bounds quote output.
+    /// Two rounded-down sqrt-price conversions avoid squaring a Q128 ratio into overflow.
+    function _saleAmount(SqrtRatio current, bool tokenIs1, uint128 available) private pure returns (int128) {
+        uint256 numerator = tokenIs1 ? current.toFixed() : 1 << 128;
+        uint256 denominator = tokenIs1 ? 1 << 128 : current.toFixed();
+        uint256 limit = FixedPointMathLib.fullMulDiv(uint128(type(int128).max), numerator, denominator);
+        limit = FixedPointMathLib.fullMulDiv(limit, numerator, denominator);
+        return int128(uint128(FixedPointMathLib.min(available, limit)));
+    }
+
+    function _addLiquidity(PoolKey memory key, Launch storage launch) private {
+        (uint128 amount0, uint128 amount1) = _reserves(key);
+        uint128 available = released(key.toPoolId()) - launch.deployed;
+        if (key.token0 == launch.token) amount0 = available;
+        else amount1 = available;
+        uint128 liquidity = maxLiquidity(
+            CORE.poolState(key.toPoolId()).sqrtRatio(),
+            tickToSqrtRatio(launch.positionId.tickLower()),
+            tickToSqrtRatio(launch.positionId.tickUpper()),
+            uint128(FixedPointMathLib.min(amount0, uint128(type(int128).max))),
+            uint128(FixedPointMathLib.min(amount1, uint128(type(int128).max)))
+        );
+        liquidity = uint128(FixedPointMathLib.min(liquidity, _liquidityCapacity(key, launch.positionId)));
+        if (liquidity != 0) {
+            _saveUpdate(key, launch, CORE.updatePosition(key, launch.positionId, int128(liquidity)));
+        }
+    }
+
+    function _liquidityCapacity(PoolKey memory key, PositionId positionId) private view returns (uint128) {
+        (, uint128 lower) = CORE.poolTicks(key.toPoolId(), positionId.tickLower());
+        (, uint128 upper) = CORE.poolTicks(key.toPoolId(), positionId.tickUpper());
+        return key.config.concentratedMaxLiquidityPerTick() - uint128(FixedPointMathLib.max(lower, upper));
+    }
+
+    function _saveUpdate(PoolKey memory key, Launch storage launch, PoolBalanceUpdate update) private {
+        int128 spent = launch.token == key.token0 ? update.delta0() : update.delta1();
+        // This helper is only used for exact-input launch sales and positive liquidity additions.
+        launch.deployed += uint128(spent);
+        CORE.updateSavedBalances(
+            key.token0, key.token1, PoolId.unwrap(key.toPoolId()), -int256(update.delta0()), -int256(update.delta1())
+        );
+    }
+
+    function _reserves(PoolKey memory key) private view returns (uint128, uint128) {
+        return CORE.savedBalances(address(this), key.token0, key.token1, PoolId.unwrap(key.toPoolId()));
+    }
+
+    function _withdraw(PoolKey memory key, address recipient) private {
+        Launch storage launch = _launches[key.toPoolId()];
+        uint128 liquidity = CORE.poolPositions(key.toPoolId(), address(this), launch.positionId).liquidity;
+        liquidity = uint128(
+            FixedPointMathLib.min(
+                liquidity,
+                maxLiquidity(
+                    CORE.poolState(key.toPoolId()).sqrtRatio(),
+                    tickToSqrtRatio(launch.positionId.tickLower()),
+                    tickToSqrtRatio(launch.positionId.tickUpper()),
+                    uint128(type(int128).max),
+                    uint128(type(int128).max)
+                )
+            )
+        );
+        // Core clears fee accounting when the last liquidity is removed. Collect first.
+        (uint128 fees0, uint128 fees1) = CORE.collectFees(key, launch.positionId);
+        PoolBalanceUpdate update = CORE.updatePosition(key, launch.positionId, -int128(liquidity));
+        (uint128 reserve0, uint128 reserve1) = _reserves(key);
+        CORE.updateSavedBalances(
+            key.token0,
+            key.token1,
+            PoolId.unwrap(key.toPoolId()),
+            -int256(uint256(reserve0)),
+            -int256(uint256(reserve1))
+        );
+        CORE.withdrawTwo(key.token0, key.token1, recipient, reserve0, reserve1);
+        CORE.withdrawTwo(key.token0, key.token1, recipient, uint128(-update.delta0()), uint128(-update.delta1()));
+        CORE.withdrawTwo(key.token0, key.token1, recipient, fees0, fees1);
+        emit LaunchWithdrawn(key.toPoolId(), recipient);
+    }
+}

--- a/src/math/launchLiquidity.sol
+++ b/src/math/launchLiquidity.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: ekubo-license-v1.eth
+pragma solidity =0.8.33;
+
+import {SqrtRatio, MIN_SQRT_RATIO, MAX_SQRT_RATIO, toSqrtRatio} from "../types/sqrtRatio.sol";
+import {nextSqrtRatioFromAmount0, nextSqrtRatioFromAmount1} from "./sqrtRatio.sol";
+import {amount0Delta, amount1Delta} from "./delta.sol";
+import {computeFee, amountBeforeFee} from "./fee.sol";
+import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
+
+/// @dev Full-range pools follow XYK in virtual reserves X=L/s, Y=L*s. Fees are
+/// excluded from price-impacting input. Solve for equal deposit capacity on both
+/// sides after that swap, using Core's rounding and finite full-range endpoints.
+/// Bisection takes at most 127 iterations, independent of pool ticks/history.
+library LaunchLiquidityMath {
+    struct Market {
+        SqrtRatio price;
+        SqrtRatio lower;
+        SqrtRatio upper;
+        uint128 liquidity;
+        uint64 fee;
+        uint128 amount0;
+        uint128 amount1;
+        uint128 ownLiquidity;
+    }
+
+    function liquidityFor(SqrtRatio price, uint128 amount0, uint128 amount1) internal pure returns (uint128) {
+        if (price <= MIN_SQRT_RATIO) return _capacity0(MIN_SQRT_RATIO, amount0);
+        if (price >= MAX_SQRT_RATIO) return _capacity1(MAX_SQRT_RATIO, amount1);
+        return uint128(FixedPointMathLib.min(_capacity0(price, amount0), _capacity1(price, amount1)));
+    }
+
+    function excessToken0(SqrtRatio price, uint128 amount0, uint128 amount1) internal pure returns (bool) {
+        if (price <= MIN_SQRT_RATIO) return false;
+        if (price >= MAX_SQRT_RATIO) return true;
+        return _capacity0(price, amount0) > _capacity1(price, amount1);
+    }
+
+    function _capacity0(SqrtRatio price, uint128 amount) private pure returns (uint128) {
+        uint256 lower = price.toFixed();
+        uint256 upper = MAX_SQRT_RATIO.toFixed();
+        uint256 numerator = FixedPointMathLib.fullMulDivN(lower, upper, 128);
+        return _cappedMulDiv(amount, numerator, upper - lower);
+    }
+
+    function _capacity1(SqrtRatio price, uint128 amount) private pure returns (uint128) {
+        return uint128(
+            FixedPointMathLib.min(
+                (uint256(amount) << 128) / (price.toFixed() - MIN_SQRT_RATIO.toFixed()), type(uint128).max
+            )
+        );
+    }
+
+    /// @dev Saturate at Core's liquidity capacity rather than overflowing for an
+    /// asset-heavy portfolio very near a full-range endpoint.
+    function _cappedMulDiv(uint256 a, uint256 b, uint256 denominator) private pure returns (uint128) {
+        uint256 high;
+        assembly ("memory-safe") {
+            let low := mul(a, b)
+            let mm := mulmod(a, b, not(0))
+            high := sub(sub(mm, low), lt(mm, low))
+        }
+        if (high >= denominator) return type(uint128).max;
+        return uint128(FixedPointMathLib.min(FixedPointMathLib.fullMulDiv(a, b, denominator), type(uint128).max));
+    }
+
+    /// @notice Finds the representable full-range deposit price for an empty pool.
+    /// @dev Caller must supply both assets. Does not rely on an empty pool's current price.
+    function depositPrice(uint128 amount0, uint128 amount1) internal pure returns (SqrtRatio) {
+        // Search fixed-point values: compact SqrtRatio encodings contain invalid gaps.
+        uint256 lo = MIN_SQRT_RATIO.toFixed();
+        uint256 hi = MAX_SQRT_RATIO.toFixed();
+        while (hi - lo > 1) {
+            uint256 mid = lo + (hi - lo) / 2;
+            if (excessToken0(toSqrtRatio(mid, false), amount0, amount1)) hi = mid;
+            else lo = mid;
+        }
+        SqrtRatio lower = toSqrtRatio(lo, false);
+        SqrtRatio upper = toSqrtRatio(hi, true);
+        return liquidityFor(lower, amount0, amount1) >= liquidityFor(upper, amount0, amount1) ? lower : upper;
+    }
+
+    /// @notice Limits input such that output at the current price fits headroom.
+    function inputLimit(SqrtRatio price, bool token1, uint128 headroom) internal pure returns (uint128) {
+        uint256 numerator = token1 ? price.toFixed() : 1 << 128;
+        uint256 denominator = token1 ? 1 << 128 : price.toFixed();
+        uint256 limit = FixedPointMathLib.fullMulDiv(headroom, numerator, denominator);
+        limit = FixedPointMathLib.fullMulDiv(limit, numerator, denominator);
+        return uint128(FixedPointMathLib.min(limit, uint128(type(int128).max)));
+    }
+
+    function optimalSwap(Market memory market) internal pure returns (bool token1, uint128 amount) {
+        token1 = !excessToken0(market.price, market.amount0, market.amount1);
+        uint128 headroom = type(uint128).max - (token1 ? market.amount0 : market.amount1);
+        headroom = uint128(FixedPointMathLib.min(headroom, uint128(type(int128).max)));
+        uint128 hi = uint128(
+            FixedPointMathLib.min(token1 ? market.amount1 : market.amount0, inputLimit(market.price, token1, headroom))
+        );
+        uint128 lo;
+        while (lo < hi) {
+            uint128 mid = lo + (hi - lo) / 2;
+            (SqrtRatio price, uint128 a0, uint128 a1) = preview(market, token1, mid);
+            if (excessToken0(price, a0, a1) != token1) lo = mid + 1;
+            else hi = mid;
+        }
+        amount = _bestNeighbor(market, token1, lo);
+    }
+
+    function _bestNeighbor(Market memory market, bool token1, uint128 crossing) private pure returns (uint128) {
+        uint128 best = liquidityFor(market.price, market.amount0, market.amount1);
+        uint128 result;
+        if (crossing != 0) {
+            uint128 candidate = _capacityAfter(market, token1, crossing - 1);
+            if (candidate > best) best = candidate;
+            result = crossing - 1;
+        }
+        if (_capacityAfter(market, token1, crossing) > best) result = crossing;
+        return result;
+    }
+
+    function _capacityAfter(Market memory market, bool token1, uint128 amount) private pure returns (uint128) {
+        (SqrtRatio price, uint128 a0, uint128 a1) = preview(market, token1, amount);
+        return liquidityFor(price, a0, a1);
+    }
+
+    function preview(Market memory market, bool token1, uint128 amount)
+        internal
+        pure
+        returns (SqrtRatio price, uint128 amount0, uint128 amount1)
+    {
+        int128 net = int128(amount - computeFee(amount, market.fee));
+        price = token1
+            ? nextSqrtRatioFromAmount1(market.price, market.liquidity, net)
+            : nextSqrtRatioFromAmount0(market.price, market.liquidity, net);
+        SqrtRatio limit = token1 ? market.upper : market.lower;
+        if (token1 ? price > limit : price < limit) {
+            price = limit;
+            uint128 netUsed = token1
+                ? amount1Delta(market.price, price, market.liquidity, true)
+                : amount0Delta(market.price, price, market.liquidity, true);
+            amount = amountBeforeFee(netUsed, market.fee);
+            net = int128(netUsed);
+        }
+        uint128 output = token1
+            ? amount0Delta(market.price, price, market.liquidity, false)
+            : amount1Delta(market.price, price, market.liquidity, false);
+        uint128 cost = amount - _rebate(market, price, amount, uint128(net));
+        amount0 = token1 ? market.amount0 + output : market.amount0 - cost;
+        amount1 = token1 ? market.amount1 - cost : market.amount1 + output;
+    }
+
+    /// @dev Match Core's two floors when recycling this position's share of internal fees.
+    function _rebate(Market memory market, SqrtRatio price, uint128 gross, uint128 net) private pure returns (uint128) {
+        uint128 fees = price == market.price ? gross : gross - net;
+        uint256 feesPerLiquidity = (uint256(fees) << 128) / market.liquidity;
+        return uint128(FixedPointMathLib.fullMulDivN(feesPerLiquidity, market.ownLiquidity, 128));
+    }
+}

--- a/test/extensions/ScheduledLaunch.t.sol
+++ b/test/extensions/ScheduledLaunch.t.sol
@@ -4,10 +4,10 @@ pragma solidity =0.8.33;
 import {FullTest} from "../FullTest.sol";
 import {TestToken} from "../TestToken.sol";
 import {ScheduledLaunch, scheduledLaunchCallPoints} from "../../src/extensions/ScheduledLaunch.sol";
+import {LockedLaunchLiquidity} from "../../src/LockedLaunchLiquidity.sol";
 import {MintableERC20} from "../../src/MintableERC20.sol";
 import {BaseLocker} from "../../src/base/BaseLocker.sol";
 import {BaseForwardee} from "../../src/base/BaseForwardee.sol";
-import {UsesCore} from "../../src/base/UsesCore.sol";
 import {ICore} from "../../src/interfaces/ICore.sol";
 import {CoreLib} from "../../src/libraries/CoreLib.sol";
 import {FlashAccountantLib} from "../../src/libraries/FlashAccountantLib.sol";
@@ -16,16 +16,19 @@ import {PoolId} from "../../src/types/poolId.sol";
 import {PoolState} from "../../src/types/poolState.sol";
 import {PoolBalanceUpdate} from "../../src/types/poolBalanceUpdate.sol";
 import {createConcentratedPoolConfig} from "../../src/types/poolConfig.sol";
-import {PositionId, createPositionId, BoundsTickSpacing} from "../../src/types/positionId.sol";
+import {PositionId, createPositionId} from "../../src/types/positionId.sol";
+import {Position} from "../../src/types/position.sol";
 import {Locker} from "../../src/types/locker.sol";
-import {SwapParameters} from "../../src/types/swapParameters.sol";
-import {SqrtRatio} from "../../src/types/sqrtRatio.sol";
+import {SwapParameters, createSwapParameters} from "../../src/types/swapParameters.sol";
+import {SqrtRatio, MIN_SQRT_RATIO, MAX_SQRT_RATIO} from "../../src/types/sqrtRatio.sol";
 import {tickToSqrtRatio} from "../../src/math/ticks.sol";
+import {MIN_TICK, MAX_TICK} from "../../src/math/constants.sol";
+import {computeFee} from "../../src/math/fee.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 import {Ownable} from "solady/auth/Ownable.sol";
 
-/// @dev A forwarding locker pays optional quote funding in the same atomic lock.
-contract LaunchCreator is BaseLocker {
+/// @dev Test-only forwarding/funding adapter. Production routers must apply user slippage limits.
+contract LaunchActor is BaseLocker {
     using FlashAccountantLib for *;
 
     constructor(ICore core) BaseLocker(core) {}
@@ -35,37 +38,81 @@ contract LaunchCreator is BaseLocker {
         payable
         returns (PoolKey memory)
     {
-        return abi.decode(lock(abi.encode(extension, config, msg.sender)), (PoolKey));
+        return abi.decode(lock(abi.encode(uint8(0), extension, config, msg.sender)), (PoolKey));
     }
 
-    function handleLockData(uint256, bytes memory data) internal override returns (bytes memory result) {
-        (ScheduledLaunch extension, ScheduledLaunch.LaunchConfig memory config, address payer) =
-            abi.decode(data, (ScheduledLaunch, ScheduledLaunch.LaunchConfig, address));
-        result = ACCOUNTANT.forward(address(extension), abi.encode(config));
-        if (config.quoteAmount != 0) {
-            if (config.quoteToken == address(0)) {
-                SafeTransferLib.safeTransferETH(address(ACCOUNTANT), config.quoteAmount);
-            } else {
-                ACCOUNTANT.payFrom(payer, config.quoteToken, config.quoteAmount);
-            }
-        }
+    function swap(ScheduledLaunch extension, PoolKey memory key, SwapParameters params)
+        external
+        payable
+        returns (PoolBalanceUpdate)
+    {
+        return abi.decode(lock(abi.encode(uint8(1), extension, key, params, msg.sender)), (PoolBalanceUpdate));
+    }
+
+    function fund(LockedLaunchLiquidity vault, PoolId id, uint128 a0, uint128 a1) external payable {
+        lock(abi.encode(uint8(2), vault, id, a0, a1, msg.sender));
+    }
+
+    function handleLockData(uint256, bytes memory data) internal override returns (bytes memory) {
+        uint8 action = abi.decode(data, (uint8));
+        if (action == 0) return _create(data);
+        if (action == 1) return _swap(data);
+        return _fund(data);
+    }
+
+    function _create(bytes memory data) private returns (bytes memory result) {
+        (, ScheduledLaunch extension, ScheduledLaunch.LaunchConfig memory config, address payer) =
+            abi.decode(data, (uint8, ScheduledLaunch, ScheduledLaunch.LaunchConfig, address));
+        result = ACCOUNTANT.forward(address(extension), abi.encode(uint8(0), config));
+        _pay(payer, config.quoteToken, config.quoteAmount);
+    }
+
+    function _swap(bytes memory data) private returns (bytes memory) {
+        (, ScheduledLaunch extension, PoolKey memory key, SwapParameters params, address payer) =
+            abi.decode(data, (uint8, ScheduledLaunch, PoolKey, SwapParameters, address));
+        (PoolBalanceUpdate update,) = abi.decode(
+            ACCOUNTANT.forward(address(extension), abi.encode(uint8(1), key, params)), (PoolBalanceUpdate, PoolState)
+        );
+        _settle(payer, key.token0, update.delta0());
+        _settle(payer, key.token1, update.delta1());
+        return abi.encode(update);
+    }
+
+    function _fund(bytes memory data) private returns (bytes memory) {
+        (, LockedLaunchLiquidity vault, PoolId id, uint128 a0, uint128 a1, address payer) =
+            abi.decode(data, (uint8, LockedLaunchLiquidity, PoolId, uint128, uint128, address));
+        ACCOUNTANT.forward(address(vault), abi.encode(uint8(1), id, a0, a1));
+        PoolKey memory key = vault.getTerminal(id).poolKey;
+        _pay(payer, key.token0, a0);
+        _pay(payer, key.token1, a1);
+        return "";
+    }
+
+    function _settle(address payer, address token, int128 delta) private {
+        if (delta < 0) ACCOUNTANT.withdraw(token, payer, uint128(-delta));
+        else _pay(payer, token, uint128(delta));
+    }
+
+    function _pay(address payer, address token, uint128 amount) private {
+        if (amount == 0) return;
+        if (token == address(0)) SafeTransferLib.safeTransferETH(address(ACCOUNTANT), amount);
+        else ACCOUNTANT.payFrom(payer, token, amount);
     }
 }
 
-contract CapacityLP is BaseLocker {
+contract OtherLP is BaseLocker {
     using FlashAccountantLib for *;
 
     constructor(ICore core) BaseLocker(core) {}
 
-    function fill(PoolKey memory key, PositionId positionId, uint128 liquidity) external {
-        lock(abi.encode(key, positionId, liquidity, msg.sender));
+    function deposit(PoolKey memory key, uint128 liquidity) external {
+        lock(abi.encode(key, liquidity, msg.sender));
     }
 
     function handleLockData(uint256, bytes memory data) internal override returns (bytes memory) {
-        (PoolKey memory key, PositionId positionId, uint128 liquidity, address payer) =
-            abi.decode(data, (PoolKey, PositionId, uint128, address));
-        PoolBalanceUpdate update =
-            ICore(payable(address(ACCOUNTANT))).updatePosition(key, positionId, int128(liquidity));
+        (PoolKey memory key, uint128 liquidity, address payer) = abi.decode(data, (PoolKey, uint128, address));
+        PoolBalanceUpdate update = ICore(payable(address(ACCOUNTANT)))
+            .updatePosition(key, createPositionId(bytes24(0), MIN_TICK, MAX_TICK), int128(liquidity));
         if (update.delta0() != 0) ACCOUNTANT.payFrom(payer, key.token0, uint128(update.delta0()));
         if (update.delta1() != 0) ACCOUNTANT.payFrom(payer, key.token1, uint128(update.delta1()));
         return "";
@@ -76,12 +123,15 @@ contract ScheduledLaunchTest is FullTest {
     using CoreLib for *;
 
     ScheduledLaunch extension;
-    LaunchCreator creator;
+    LockedLaunchLiquidity vault;
+    LaunchActor actor;
     address constant LOW_QUOTE = address(0x10000);
     address constant HIGH_QUOTE = address(type(uint160).max);
     uint128 constant SUPPLY = 1_000_000e18;
     uint64 constant START = 100;
     uint64 constant END = 1100;
+    uint64 constant INITIAL_FEE = uint64(uint256(1 << 64) / 10);
+    uint64 constant FINAL_FEE = uint64(uint256(1 << 64) / 100);
 
     function setUp() public override {
         super.setUp();
@@ -89,11 +139,12 @@ contract ScheduledLaunchTest is FullTest {
         address target = address(uint160(scheduledLaunchCallPoints().toUint8()) << 152);
         deployCodeTo("ScheduledLaunch.sol", abi.encode(core), target);
         extension = ScheduledLaunch(target);
-        creator = new LaunchCreator(core);
+        vault = extension.LIQUIDITY();
+        actor = new LaunchActor(core);
         deployCodeTo("TestToken.sol", abi.encode(address(this)), LOW_QUOTE);
         deployCodeTo("TestToken.sol", abi.encode(address(this)), HIGH_QUOTE);
-        TestToken(LOW_QUOTE).approve(address(creator), type(uint256).max);
-        TestToken(HIGH_QUOTE).approve(address(creator), type(uint256).max);
+        TestToken(LOW_QUOTE).approve(address(actor), type(uint256).max);
+        TestToken(HIGH_QUOTE).approve(address(actor), type(uint256).max);
         TestToken(LOW_QUOTE).approve(address(router), type(uint256).max);
         TestToken(HIGH_QUOTE).approve(address(router), type(uint256).max);
     }
@@ -112,296 +163,380 @@ contract ScheduledLaunchTest is FullTest {
             targetTick: 0,
             upperTick: 100_000,
             tickSpacing: 100,
-            fee: 0
+            initialFee: INITIAL_FEE,
+            finalFee: FINAL_FEE,
+            migrationTickLower: MIN_TICK,
+            migrationTickUpper: MAX_TICK
         });
     }
 
     function _create(bool tokenIs0) internal returns (PoolKey memory key) {
-        key = creator.create(extension, _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE));
-        assertEq(extension.getLaunch(key.toPoolId()).token == key.token0, tokenIs0);
+        key = actor.create(extension, _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE));
+        address token = extension.getLaunch(key.toPoolId()).token;
+        assertEq(token == key.token0, tokenIs0);
+        MintableERC20(token).approve(address(actor), type(uint256).max);
+        MintableERC20(token).approve(address(router), type(uint256).max);
     }
 
-    function _quoteReserve(PoolKey memory key) internal view returns (uint128) {
-        (uint128 r0, uint128 r1) =
-            core.savedBalances(address(extension), key.token0, key.token1, PoolId.unwrap(key.toPoolId()));
-        return extension.getLaunch(key.toPoolId()).token == key.token0 ? r1 : r0;
+    function _balances(address holder, PoolKey memory key, bytes32 salt) internal view returns (uint128, uint128) {
+        return core.savedBalances(holder, key.token0, key.token1, salt);
     }
 
-    function _buy(PoolKey memory key, uint128 amount) internal returns (uint128 bought) {
-        bool quoteIs1 = extension.getLaunch(key.toPoolId()).token == key.token0;
-        PoolBalanceUpdate update = router.swapAllowPartialFill(key, quoteIs1, int128(amount), SqrtRatio.wrap(0), 0);
-        bought = uint128(-(quoteIs1 ? update.delta0() : update.delta1()));
+    function _fees(PoolKey memory key) internal view returns (uint128, uint128) {
+        return _balances(address(extension), key, extension.creatorFeeSalt(key.toPoolId()));
     }
 
-    function testFuzz_createMetadataOwnerAndFunding(bool tokenIs0) public {
+    function _buy(PoolKey memory key, uint128 amount) internal returns (uint128) {
+        bool tokenIs0 = extension.getLaunch(key.toPoolId()).token == key.token0;
+        PoolBalanceUpdate update =
+            actor.swap(extension, key, createSwapParameters(SqrtRatio.wrap(0), int128(amount), tokenIs0, 0));
+        return uint128(-(tokenIs0 ? update.delta0() : update.delta1()));
+    }
+
+    function _finish(PoolKey memory key) internal {
+        vm.warp(END);
+        extension.advance(key);
+        assertTrue(extension.getLaunch(key.toPoolId()).complete);
+        assertEq(
+            core.poolPositions(key.toPoolId(), address(extension), extension.getLaunch(key.toPoolId()).positionId)
+            .liquidity,
+            0
+        );
+    }
+
+    function _locked(PoolKey memory key) internal view returns (uint128) {
+        PoolKey memory terminal = extension.terminalPool(key);
+        return core.poolPositions(terminal.toPoolId(), address(vault), vault.positionId(key.toPoolId())).liquidity;
+    }
+
+    function _seedTerminal(PoolKey memory key, int32 tick, uint128 liquidity) internal returns (OtherLP lp) {
+        PoolKey memory terminal = extension.terminalPool(key);
+        core.initializePool(terminal, tick);
+        lp = new OtherLP(core);
+        MintableERC20(key.token0).approve(address(lp), type(uint256).max);
+        MintableERC20(key.token1).approve(address(lp), type(uint256).max);
+        lp.deposit(terminal, liquidity);
+    }
+
+    function testFuzz_creationAndFeeSchedule(bool tokenIs0, uint64 elapsed) public {
         PoolKey memory key = _create(tokenIs0);
         ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
-        MintableERC20 token = MintableERC20(launch.token);
         assertEq(launch.owner, address(this));
-        assertEq(token.owner(), address(0));
-        assertEq(token.name(), "Launch");
-        assertEq(token.symbol(), "LAUNCH");
-        assertEq(token.decimals(), 18);
-        assertEq(token.totalSupply(), SUPPLY);
-        assertEq(token.balanceOf(address(core)), SUPPLY);
-        assertEq(token.balanceOf(address(extension)), 0);
-        assertEq(core.poolState(key.toPoolId()).tick(), 0);
+        assertEq(MintableERC20(launch.token).owner(), address(0));
+        assertEq(MintableERC20(launch.token).totalSupply(), SUPPLY);
+        assertEq(MintableERC20(launch.token).name(), "Launch");
+        assertEq(MintableERC20(launch.token).symbol(), "LAUNCH");
+        assertEq(MintableERC20(launch.token).balanceOf(address(core)), SUPPLY);
+        assertEq(key.config.fee(), 0);
+        assertEq(extension.feeAt(key.toPoolId()), INITIAL_FEE);
+        elapsed = uint64(bound(elapsed, 0, END - START));
+        vm.warp(START + elapsed);
+        assertEq(
+            extension.feeAt(key.toPoolId()),
+            INITIAL_FEE - uint64(uint256(INITIAL_FEE - FINAL_FEE) * elapsed / (END - START))
+        );
+        assertEq(extension.released(key.toPoolId()), uint128(uint256(SUPPLY) * elapsed / (END - START)));
+        PoolKey memory terminal = extension.terminalPool(key);
+        assertEq(terminal.config.fee(), FINAL_FEE);
+        assertEq(terminal.config.extension(), address(0));
+        assertTrue(terminal.config.isFullRange());
         vm.expectRevert(Ownable.Unauthorized.selector);
-        token.mint(address(this), 1);
+        MintableERC20(launch.token).mint(address(this), 1);
     }
 
-    function test_directInitializationAndForgedCallbacksRevert() public {
-        PoolKey memory key = PoolKey(LOW_QUOTE, HIGH_QUOTE, createConcentratedPoolConfig(0, 100, address(extension)));
+    function testFuzz_externalFeesAndInternalExemption(bool tokenIs0) public {
+        PoolKey memory key = _create(tokenIs0);
+        vm.warp(START + 100);
+        uint128 bought = _buy(key, 10_000e18);
+        (uint128 fee0, uint128 fee1) = _fees(key);
+        uint128 fee = tokenIs0 ? fee0 : fee1;
+        assertGt(fee, 0);
+        assertEq(fee, computeFee(bought + fee, extension.feeAt(key.toPoolId())));
+        vm.warp(START + 200);
+        extension.advance(key);
+        assertEq(SqrtRatio.unwrap(core.poolState(key.toPoolId()).sqrtRatio()), SqrtRatio.unwrap(tickToSqrtRatio(0)));
+        (uint128 after0, uint128 after1) = _fees(key);
+        assertEq(fee0, after0);
+        assertEq(fee1, after1);
+        (uint128 r0, uint128 r1) = _balances(address(extension), key, PoolId.unwrap(key.toPoolId()));
+        uint128 deployed = extension.getLaunch(key.toPoolId()).deployed;
+        assertEq(tokenIs0 ? r0 : r1, SUPPLY - deployed);
+        assertGt(tokenIs0 ? r1 : r0, 0);
+        extension.claimFees(key, address(777));
+        assertEq(MintableERC20(extension.getLaunch(key.toPoolId()).token).balanceOf(address(777)), fee);
+        (after0, after1) = _fees(key);
+        assertEq(after0, 0);
+        assertEq(after1, 0);
+        assertEq(extension.getLaunch(key.toPoolId()).deployed, deployed);
+    }
+
+    function testFuzz_exactOutputAndPartialInput(bool tokenIs0) public {
+        PoolKey memory key = _create(tokenIs0);
+        vm.warp(START + 100);
+        uint128 tokenBefore = uint128(MintableERC20(extension.getLaunch(key.toPoolId()).token).balanceOf(address(this)));
+        actor.swap(extension, key, createSwapParameters(SqrtRatio.wrap(0), -int128(100e18), !tokenIs0, 0));
+        assertEq(
+            MintableERC20(extension.getLaunch(key.toPoolId()).token).balanceOf(address(this)) - tokenBefore, 100e18
+        );
+        (uint128 fee0, uint128 fee1) = _fees(key);
+        assertGt(tokenIs0 ? fee1 : fee0, 0);
+        int32 limit = tokenIs0 ? int32(1000) : int32(-1000);
+        PoolBalanceUpdate update =
+            actor.swap(extension, key, createSwapParameters(tickToSqrtRatio(limit), int128(1_000_000e18), tokenIs0, 0));
+        assertLt(uint128(tokenIs0 ? update.delta1() : update.delta0()), 1_000_000e18);
+        assertGt(uint128(-(tokenIs0 ? update.delta0() : update.delta1())), 0);
+    }
+
+    function test_directCallsAndOutsideScheduleRevert() public {
+        PoolKey memory key = _create(true);
+        PoolKey memory otherKey =
+            PoolKey(LOW_QUOTE, HIGH_QUOTE, createConcentratedPoolConfig(0, 100, address(extension)));
         vm.expectRevert(ScheduledLaunch.InitializationThroughForwardOnly.selector);
-        core.initializePool(key, 0);
+        core.initializePool(otherKey, 0);
+        vm.expectRevert(ScheduledLaunch.SwapsThroughForwardOnly.selector);
+        router.swapAllowPartialFill(key, true, 1e18, SqrtRatio.wrap(0), 0);
+        vm.expectRevert(ScheduledLaunch.LaunchNotStarted.selector);
+        actor.swap(extension, key, createSwapParameters(SqrtRatio.wrap(0), 1e18, true, 0));
+        vm.warp(END);
+        vm.expectRevert(ScheduledLaunch.LaunchEnded.selector);
+        actor.swap(extension, key, createSwapParameters(SqrtRatio.wrap(0), 1e18, true, 0));
         vm.expectRevert(BaseForwardee.BaseForwardeeAccountantOnly.selector);
         extension.forwarded_2374103877(Locker.wrap(bytes32(0)));
         vm.expectRevert(BaseLocker.BaseLockerAccountantOnly.selector);
         extension.locked_6416899205(0);
-        vm.expectRevert(UsesCore.CoreOnly.selector);
-        extension.beforeSwap(Locker.wrap(bytes32(0)), key, SwapParameters.wrap(bytes32(0)));
+        vm.expectRevert(LockedLaunchLiquidity.ExtensionOnly.selector);
+        vault.createToken("x", "x", 18, 1);
     }
 
-    function testFuzz_linearReleaseAndNoBuyers(bool tokenIs0, uint64 elapsed) public {
+    function testFuzz_freshMigrationLocksPrincipal(bool tokenIs0) public {
         PoolKey memory key = _create(tokenIs0);
-        elapsed = uint64(bound(elapsed, 0, END - START));
-        vm.warp(START + elapsed);
-        uint128 expected = uint128(uint256(SUPPLY) * elapsed / (END - START));
-        assertEq(extension.released(key.toPoolId()), expected);
-        extension.advance(key);
-        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
-        assertLe(launch.deployed, expected);
-        assertApproxEqAbs(launch.deployed, expected, 1);
-        assertEq(_quoteReserve(key), 0);
-        assertEq(launch.complete, elapsed == END - START);
-        uint128 deployed = launch.deployed;
-        extension.advance(key);
-        assertEq(extension.getLaunch(key.toPoolId()).deployed, deployed);
-    }
-
-    function test_preStartSwapRevertsAndAdvanceDoesNotRelease() public {
-        PoolKey memory key = _create(true);
-        extension.advance(key);
-        assertEq(extension.released(key.toPoolId()), 0);
-        vm.expectRevert(ScheduledLaunch.LaunchNotStarted.selector);
-        router.swapAllowPartialFill(key, true, 1e18, SqrtRatio.wrap(0), 0);
-    }
-
-    function testFuzz_sellTowardTargetAndRetainQuote(bool tokenIs0) public {
-        PoolKey memory key = _create(tokenIs0);
-        vm.warp(START + 100);
-        uint128 bought = _buy(key, 10_000e18);
-        assertGt(bought, 0);
-        assertTrue(core.poolState(key.toPoolId()).sqrtRatio() != tickToSqrtRatio(0));
-        vm.warp(START + 200);
-        extension.advance(key);
-        assertEq(SqrtRatio.unwrap(core.poolState(key.toPoolId()).sqrtRatio()), SqrtRatio.unwrap(tickToSqrtRatio(0)));
-        assertGt(_quoteReserve(key), 0);
-        assertEq(extension.getLaunch(key.toPoolId()).complete, false);
-        assertLe(extension.getLaunch(key.toPoolId()).deployed, SUPPLY / 5);
-    }
-
-    function testFuzz_insufficientReleasedInventory(bool tokenIs0) public {
-        PoolKey memory key = _create(tokenIs0);
-        vm.warp(START + 100);
-        _buy(key, 50_000e18);
-        vm.warp(START + 101);
-        extension.advance(key);
-        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
-        assertLe(launch.deployed, extension.released(key.toPoolId()));
-        assertTrue(core.poolState(key.toPoolId()).sqrtRatio() != tickToSqrtRatio(0));
-        vm.warp(END);
-        extension.advance(key);
-        assertTrue(extension.getLaunch(key.toPoolId()).complete);
-    }
-
-    function testFuzz_sellerPushesBelowTargetThenReleaseStillWorks(bool tokenIs0) public {
-        PoolKey memory key = _create(tokenIs0);
-        vm.warp(START + 100);
-        uint128 bought = _buy(key, 10_000e18);
-        vm.warp(START + 200);
-        extension.advance(key);
-        address launchToken = extension.getLaunch(key.toPoolId()).token;
-        MintableERC20(launchToken).approve(address(router), type(uint256).max);
-        int32 below = tokenIs0 ? int32(-1000) : int32(1000);
-        router.swapAllowPartialFill(key, !tokenIs0, int128(bought), tickToSqrtRatio(below), 0);
-        assertEq(SqrtRatio.unwrap(core.poolState(key.toPoolId()).sqrtRatio()), SqrtRatio.unwrap(tickToSqrtRatio(below)));
-        uint128 quoteBefore = _quoteReserve(key);
-        uint128 deployedBefore = extension.getLaunch(key.toPoolId()).deployed;
-        vm.warp(START + 300);
-        extension.advance(key);
-        assertEq(_quoteReserve(key), quoteBefore);
-        assertGt(extension.getLaunch(key.toPoolId()).deployed, deployedBefore);
-        assertEq(SqrtRatio.unwrap(core.poolState(key.toPoolId()).sqrtRatio()), SqrtRatio.unwrap(tickToSqrtRatio(below)));
-    }
-
-    function testFuzz_ownerWithdrawalAndPostCompletionNoOp(bool tokenIs0) public {
-        PoolKey memory key = _create(tokenIs0);
-        vm.expectRevert(ScheduledLaunch.LaunchNotComplete.selector);
-        extension.withdraw(key, address(this));
-        vm.warp(END);
-        extension.advance(key);
-        vm.prank(address(123));
-        vm.expectRevert(ScheduledLaunch.OwnerOnly.selector);
-        extension.withdraw(key, address(this));
-        vm.expectRevert(ScheduledLaunch.InvalidRecipient.selector);
-        extension.withdraw(key, address(0));
-        bytes32 beforeState = keccak256(abi.encode(extension.getLaunch(key.toPoolId())));
-        _buy(key, 1e18);
-        extension.advance(key);
-        assertEq(keccak256(abi.encode(extension.getLaunch(key.toPoolId()))), beforeState);
-        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
-        extension.withdraw(key, address(this));
-        assertEq(core.poolPositions(key.toPoolId(), address(extension), launch.positionId).liquidity, 0);
-        assertApproxEqAbs(MintableERC20(launch.token).balanceOf(address(this)), SUPPLY, 2);
-        extension.withdraw(key, address(this));
-    }
-
-    function testFuzz_optionalQuoteSeedAndIsolation(bool tokenIs0) public {
-        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
-        config.quoteAmount = 123e18;
-        PoolKey memory first = creator.create(extension, config);
-        config.quoteAmount = 456e18;
-        PoolKey memory second = creator.create(extension, config);
-        assertEq(_quoteReserve(first), 123e18);
-        assertEq(_quoteReserve(second), 456e18);
-        vm.warp(END);
-        extension.advance(first);
-        extension.withdraw(first, address(555));
-        assertEq(_quoteReserve(first), 0);
-        assertEq(_quoteReserve(second), 456e18);
-        assertEq(extension.getLaunch(second.toPoolId()).deployed, 0);
-        assertEq(TestToken(config.quoteToken).balanceOf(address(555)), 123e18);
-    }
-
-    function test_nativeQuote() public {
-        ScheduledLaunch.LaunchConfig memory config = _config(address(0));
-        config.quoteAmount = 1 ether;
-        vm.deal(address(this), 10 ether);
-        PoolKey memory key = creator.create{value: 1 ether}(extension, config);
-        assertEq(_quoteReserve(key), 1 ether);
-        vm.warp(END);
-        extension.advance(key);
-        extension.withdraw(key, address(555));
-        assertEq(address(555).balance, 1 ether);
-    }
-
-    function testFuzz_targetOrientation(bool tokenIs0, int32 targetTick) public {
-        targetTick = int32(bound(targetTick, -100_000, 100_000) / 100 * 100);
-        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
-        config.targetTick = targetTick;
-        config.upperTick = targetTick + 100_000;
-        PoolKey memory key = creator.create(extension, config);
-        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
-        assertEq(launch.targetTick, tokenIs0 ? targetTick : -targetTick);
-        vm.warp(END);
-        extension.advance(key);
-        assertApproxEqAbs(extension.getLaunch(key.toPoolId()).deployed, SUPPLY, 1);
-    }
-
-    function test_invalidConfigurations() public {
-        ScheduledLaunch.LaunchConfig memory config = _config(HIGH_QUOTE);
-        config.owner = address(0);
-        vm.expectRevert(ScheduledLaunch.InvalidLaunch.selector);
-        creator.create(extension, config);
-        config = _config(HIGH_QUOTE);
-        config.endTime = config.startTime;
-        vm.expectRevert(ScheduledLaunch.InvalidLaunch.selector);
-        creator.create(extension, config);
-        config = _config(HIGH_QUOTE);
-        config.totalSupply = 0;
-        vm.expectRevert(ScheduledLaunch.InvalidLaunch.selector);
-        creator.create(extension, config);
-        config = _config(HIGH_QUOTE);
-        config.upperTick = config.targetTick;
-        vm.expectRevert(ScheduledLaunch.InvalidLaunch.selector);
-        creator.create(extension, config);
-        config = _config(HIGH_QUOTE);
-        config.tickSpacing = 0;
-        vm.expectRevert(ScheduledLaunch.InvalidLaunch.selector);
-        creator.create(extension, config);
-        config = _config(HIGH_QUOTE);
-        config.targetTick = 1;
-        vm.expectRevert(BoundsTickSpacing.selector);
-        creator.create(extension, config);
-    }
-
-    function testFuzz_supplyAndExtremeTicks(bool tokenIs0, uint128 supply, int32 target) public {
-        supply = uint128(bound(supply, 1, uint128(type(int128).max)));
-        target = int32(bound(target, -887228, 886228) * 100);
-        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
-        config.totalSupply = supply;
-        config.targetTick = target;
-        config.upperTick = target + 100_000;
-        PoolKey memory key = creator.create(extension, config);
-        vm.warp(END);
-        extension.advance(key);
-        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
-        assertTrue(launch.complete);
-        assertLe(launch.deployed, supply);
-        extension.withdraw(key, address(this));
-        assertApproxEqAbs(MintableERC20(launch.token).balanceOf(address(this)), supply, 2);
-    }
-
-    function testFuzz_tradingSequencePreservesReleaseAccounting(bool tokenIs0, uint256 seed) public {
-        PoolKey memory key = _create(tokenIs0);
-        address launchToken = extension.getLaunch(key.toPoolId()).token;
-        MintableERC20(launchToken).approve(address(router), type(uint256).max);
-        for (uint256 i = 1; i <= 12; i++) {
-            vm.warp(START + i * 90);
-            seed = uint256(keccak256(abi.encode(seed, i)));
-            if (seed % 2 == 0) {
-                _buy(key, uint128(seed % 10_000e18));
-            } else {
-                uint128 balance = uint128(MintableERC20(launchToken).balanceOf(address(this)));
-                router.swapAllowPartialFill(
-                    key, !tokenIs0, int128(balance / 2), tickToSqrtRatio(tokenIs0 ? int32(-1000) : int32(1000)), 0
-                );
-            }
-            extension.advance(key);
-            ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
-            assertLe(launch.deployed, extension.released(key.toPoolId()));
-            (uint128 r0, uint128 r1) =
-                core.savedBalances(address(extension), key.token0, key.token1, PoolId.unwrap(key.toPoolId()));
-            assertEq(tokenIs0 ? r0 : r1, SUPPLY - launch.deployed);
-        }
-        assertTrue(extension.getLaunch(key.toPoolId()).complete);
-        extension.withdraw(key, address(this));
-        // Each swap/deposit rounds independently; bound accumulated dust across the 12 steps.
-        assertApproxEqAbs(MintableERC20(launchToken).balanceOf(address(this)), SUPPLY, 40);
-    }
-
-    function testFuzz_nonzeroFeesRemainWithdrawable(bool tokenIs0) public {
-        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
-        config.fee = uint64(uint256(1 << 64) / 100);
-        PoolKey memory key = creator.create(extension, config);
         vm.warp(START + 100);
         _buy(key, 10_000e18);
-        vm.warp(END);
+        vm.warp(START + 200);
         extension.advance(key);
-        _buy(key, 1e18);
-        extension.withdraw(key, address(this));
-        assertApproxEqAbs(MintableERC20(extension.getLaunch(key.toPoolId()).token).balanceOf(address(this)), SUPPLY, 4);
+        _finish(key);
+        assertGt(_locked(key), 0);
+        PoolKey memory terminal = extension.terminalPool(key);
+        assertTrue(core.poolState(terminal.toPoolId()).isInitialized());
+        uint128 liquidity = _locked(key);
+        vault.claimFees(key.toPoolId(), address(this));
+        extension.claimFees(key, address(this));
+        assertEq(_locked(key), liquidity);
+        (bool success,) = address(extension)
+            .call(abi.encodeWithSignature("withdraw((address,address,bytes32),address)", key, address(this)));
+        assertFalse(success);
+        (success,) =
+            address(vault).call(abi.encodeWithSignature("withdraw(bytes32,address)", key.toPoolId(), address(this)));
+        assertFalse(success);
+        extension.advance(key);
+        assertEq(_locked(key), liquidity);
     }
 
-    function testFuzz_thirdPartyTickCapacityDoesNotBlockCompletion(bool tokenIs0) public {
+    function testFuzz_noBuyersWaitsForFunding(bool tokenIs0) public {
         PoolKey memory key = _create(tokenIs0);
-        CapacityLP lp = new CapacityLP(core);
-        TestToken(tokenIs0 ? key.token1 : key.token0).approve(address(lp), type(uint256).max);
-        PositionId positionId =
-            createPositionId(bytes24(0), tokenIs0 ? int32(-100_000) : int32(0), tokenIs0 ? int32(0) : int32(100_000));
-        lp.fill(key, positionId, key.config.concentratedMaxLiquidityPerTick());
-        vm.warp(END);
+        _finish(key);
+        assertEq(_locked(key), 0);
+        (uint128 a0, uint128 a1) = _balances(address(vault), key, PoolId.unwrap(key.toPoolId()));
+        assertEq(tokenIs0 ? a0 : a1, SUPPLY);
+        assertEq(tokenIs0 ? a1 : a0, 0);
+        actor.fund(vault, key.toPoolId(), tokenIs0 ? 0 : 1e18, tokenIs0 ? 1e18 : 0);
+        vault.migrate(key.toPoolId());
+        assertGt(_locked(key), 0);
+    }
+
+    function testFuzz_noBuyersWithQuoteSeedMigrates(bool tokenIs0) public {
+        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
+        config.quoteAmount = 100_000e18;
+        PoolKey memory key = actor.create(extension, config);
+        _finish(key);
+        assertGt(_locked(key), 0);
+        (uint128 f0, uint128 f1) = _fees(key);
+        assertEq(f0, 0);
+        assertEq(f1, 0);
+    }
+
+    function testFuzz_existingPoolBalancesAndCreatorGetsOnlyOwnFees(bool tokenIs0) public {
+        PoolKey memory key = _create(tokenIs0);
+        vm.warp(START + 100);
+        _buy(key, 10_000e18);
+        OtherLP lp = _seedTerminal(key, 0, 1_000e18);
+        _finish(key);
+        assertGt(_locked(key), 0);
+        (uint128 residual0, uint128 residual1) = _balances(address(vault), key, PoolId.unwrap(key.toPoolId()));
+        assertLe(residual0, 10_000);
+        assertLe(residual1, 10_000);
+        PoolKey memory terminal = extension.terminalPool(key);
+        router.swapAllowPartialFill(terminal, tokenIs0, int128(100e18), SqrtRatio.wrap(0), 0);
+        Position memory own = core.poolPositions(terminal.toPoolId(), address(vault), vault.positionId(key.toPoolId()));
+        Position memory other =
+            core.poolPositions(terminal.toPoolId(), address(lp), createPositionId(bytes24(0), MIN_TICK, MAX_TICK));
+        (uint128 own0, uint128 own1) = own.fees(core.getPoolFeesPerLiquidity(terminal.toPoolId()));
+        (uint128 other0, uint128 other1) = other.fees(core.getPoolFeesPerLiquidity(terminal.toPoolId()));
+        assertGt(tokenIs0 ? own1 : own0, 0);
+        assertGt(tokenIs0 ? other1 : other0, 0);
+        vault.claimFees(key.toPoolId(), address(777));
+        assertEq(MintableERC20(key.token0).balanceOf(address(777)), own0);
+        assertEq(MintableERC20(key.token1).balanceOf(address(777)), own1);
+        assertEq(_locked(key), own.liquidity);
+        other = core.poolPositions(terminal.toPoolId(), address(lp), createPositionId(bytes24(0), MIN_TICK, MAX_TICK));
+        (uint128 after0, uint128 after1) = other.fees(core.getPoolFeesPerLiquidity(terminal.toPoolId()));
+        assertEq(after0, other0);
+        assertEq(after1, other1);
+    }
+
+    function testFuzz_emptyDestinationPriceCannotGrief(bool tokenIs0) public {
+        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
+        config.quoteAmount = SUPPLY;
+        PoolKey memory key = actor.create(extension, config);
+        core.initializePool(extension.terminalPool(key), 5_000_000);
+        _finish(key);
+        assertGt(_locked(key), 0);
+        assertApproxEqAbs(core.poolState(extension.terminalPool(key).toPoolId()).tick(), 0, 1);
+    }
+
+    function testFuzz_outsideMigrationBoundsRetainsLockedFunds(bool tokenIs0) public {
+        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
+        config.migrationTickLower = -10_000;
+        config.migrationTickUpper = 10_000;
+        PoolKey memory key = actor.create(extension, config);
+        vm.warp(START + 100);
+        _buy(key, 10_000e18);
+        _seedTerminal(key, tokenIs0 ? int32(200_000) : int32(-200_000), 100e18);
+        _finish(key);
+        assertEq(_locked(key), 0);
+        (uint128 a0, uint128 a1) = _balances(address(vault), key, PoolId.unwrap(key.toPoolId()));
+        assertGt(a0, 0);
+        assertGt(a1, 0);
+        vm.prank(address(123));
+        vm.expectRevert(LockedLaunchLiquidity.OwnerOnly.selector);
+        vault.claimFees(key.toPoolId(), address(123));
+    }
+
+    function test_nativeQuoteMigration() public {
+        ScheduledLaunch.LaunchConfig memory config = _config(address(0));
+        config.quoteAmount = 1 ether;
+        vm.deal(address(this), 1 ether);
+        PoolKey memory key = actor.create{value: 1 ether}(extension, config);
+        _finish(key);
+        assertGt(_locked(key), 0);
+        vm.deal(address(this), 1 ether);
+        router.swapAllowPartialFill{value: 1e15}(extension.terminalPool(key), false, int128(1e15), SqrtRatio.wrap(0), 0);
+        uint128 principal = _locked(key);
+        vault.claimFees(key.toPoolId(), address(777));
+        assertGt(address(777).balance, 0);
+        assertEq(_locked(key), principal);
+    }
+
+    function test_invalidConfigurationAndRollback() public {
+        ScheduledLaunch.LaunchConfig memory config = _config(HIGH_QUOTE);
+        config.finalFee = config.initialFee + 1;
+        vm.expectRevert(ScheduledLaunch.InvalidLaunch.selector);
+        actor.create(extension, config);
+        config = _config(HIGH_QUOTE);
+        config.migrationTickLower = config.migrationTickUpper;
+        vm.expectRevert(ScheduledLaunch.InvalidLaunch.selector);
+        actor.create(extension, config);
+        config = _config(HIGH_QUOTE);
+        config.quoteAmount = 1;
+        TestToken(HIGH_QUOTE).approve(address(actor), 0);
+        uint64 nonce = vm.getNonce(address(vault));
+        address predicted = vm.computeCreateAddress(address(vault), nonce);
+        vm.expectRevert();
+        actor.create(extension, config);
+        assertEq(predicted.code.length, 0);
+        assertEq(vm.getNonce(address(vault)), nonce);
+    }
+
+    function testFuzz_launchIsolation(bool tokenIs0) public {
+        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
+        config.quoteAmount = 100e18;
+        PoolKey memory a = actor.create(extension, config);
+        PoolKey memory b = actor.create(extension, config);
+        _finish(a);
+        assertGt(_locked(a), 0);
+        assertFalse(extension.getLaunch(b.toPoolId()).complete);
+        (uint128 r0, uint128 r1) = _balances(address(extension), b, PoolId.unwrap(b.toPoolId()));
+        assertEq(tokenIs0 ? r0 : r1, SUPPLY);
+        assertEq(tokenIs0 ? r1 : r0, 100e18);
+    }
+
+    function testFuzz_releasesBelowTargetStillWork(bool tokenIs0) public {
+        PoolKey memory key = _create(tokenIs0);
+        vm.warp(START + 100);
+        uint128 bought = _buy(key, 10_000e18);
+        vm.warp(START + 200);
         extension.advance(key);
-        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
-        assertTrue(launch.complete);
-        assertEq(launch.deployed, 0);
-        extension.withdraw(key, address(this));
-        assertEq(MintableERC20(launch.token).balanceOf(address(this)), SUPPLY);
-        assertEq(
-            core.poolPositions(key.toPoolId(), address(lp), positionId).liquidity,
-            key.config.concentratedMaxLiquidityPerTick()
+        actor.swap(
+            extension,
+            key,
+            createSwapParameters(tickToSqrtRatio(tokenIs0 ? int32(-1000) : int32(1000)), int128(bought), !tokenIs0, 0)
         );
+        uint128 deployed = extension.getLaunch(key.toPoolId()).deployed;
+        vm.warp(START + 300);
+        extension.advance(key);
+        assertGt(extension.getLaunch(key.toPoolId()).deployed, deployed);
+        assertEq(core.poolState(key.toPoolId()).tick(), tokenIs0 ? int32(-1000) : int32(1000));
+    }
+
+    function testFuzz_largeLaunchMigrationCanFinishInChunks(bool tokenIs0) public {
+        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
+        config.targetTick = 50_000_000;
+        config.upperTick = 50_100_000;
+        PoolKey memory key = actor.create(extension, config);
+        vm.warp(START + 100);
+        for (uint256 i = 0; i < 3; i++) {
+            _buy(key, uint128(type(int128).max));
+        }
+        vm.warp(END);
+        for (uint256 i = 0; i < 8; i++) {
+            extension.advance(key);
+        }
+        assertTrue(extension.getLaunch(key.toPoolId()).complete);
+        assertEq(
+            core.poolPositions(key.toPoolId(), address(extension), extension.getLaunch(key.toPoolId()).positionId)
+            .liquidity,
+            0
+        );
+        assertGt(_locked(key), 0);
+    }
+
+    function testFuzz_rebalanceFeesRecycleIntoPrincipal(bool tokenIs0) public {
+        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
+        config.quoteAmount = SUPPLY;
+        PoolKey memory key = actor.create(extension, config);
+        _finish(key);
+        uint128 before = _locked(key);
+        // Donation and rebalancing against our own LP must not turn principal into creator fees.
+        actor.fund(vault, key.toPoolId(), tokenIs0 ? 0 : 1000e18, tokenIs0 ? 1000e18 : 0);
+        vault.migrate(key.toPoolId());
+        assertGt(_locked(key), before);
+        (uint128 residue0, uint128 residue1) = _balances(address(vault), key, PoolId.unwrap(key.toPoolId()));
+        // Near price 1, Core's compact ratio has ~62 fractional bits. At this
+        // position size one representable price step can leave sub-token dust.
+        uint128 roundingBound = SUPPLY / (1 << 60) + 100;
+        assertLe(residue0, roundingBound);
+        assertLe(residue1, roundingBound);
+        vault.claimFees(key.toPoolId(), address(777));
+        assertEq(MintableERC20(key.token0).balanceOf(address(777)), 0);
+        assertEq(MintableERC20(key.token1).balanceOf(address(777)), 0);
+    }
+
+    function testFuzz_rebalancePreservesPreviouslyEarnedCreatorFees(bool tokenIs0) public {
+        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
+        config.quoteAmount = SUPPLY;
+        PoolKey memory key = actor.create(extension, config);
+        _finish(key);
+        PoolKey memory terminal = extension.terminalPool(key);
+        router.swapAllowPartialFill(terminal, tokenIs0, int128(100e18), SqrtRatio.wrap(0), 0);
+        Position memory position =
+            core.poolPositions(terminal.toPoolId(), address(vault), vault.positionId(key.toPoolId()));
+        (uint128 before0, uint128 before1) = position.fees(core.getPoolFeesPerLiquidity(terminal.toPoolId()));
+        assertGt(tokenIs0 ? before1 : before0, 0);
+        actor.fund(vault, key.toPoolId(), tokenIs0 ? 0 : 1000e18, tokenIs0 ? 1000e18 : 0);
+        vault.migrate(key.toPoolId());
+        vault.claimFees(key.toPoolId(), address(777));
+        assertEq(MintableERC20(key.token0).balanceOf(address(777)), before0);
+        assertEq(MintableERC20(key.token1).balanceOf(address(777)), before1);
     }
 
     function test_deployWithMinedHookPrefix() public {
@@ -417,56 +552,9 @@ contract ScheduledLaunchTest is FullTest {
         }
         ScheduledLaunch deployed = new ScheduledLaunch{salt: bytes32(salt)}(core);
         assertTrue(core.isExtensionRegistered(address(deployed)));
+        assertEq(deployed.LIQUIDITY().EXTENSION(), address(deployed));
         assertLe(address(deployed).code.length, 24_576);
-        PoolKey memory key = creator.create(deployed, _config(HIGH_QUOTE));
-        assertEq(deployed.getLaunch(key.toPoolId()).owner, address(this));
-    }
-
-    function testFuzz_largeQuoteAmountsDoNotBlockSales(bool tokenIs0) public {
-        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
-        config.targetTick = 50_000_000;
-        config.upperTick = 50_100_000;
-        PoolKey memory key = creator.create(extension, config);
-        vm.warp(START + 100);
-        _buy(key, uint128(type(int128).max));
-        _buy(key, uint128(type(int128).max));
-        vm.warp(START + 200);
-        extension.advance(key);
-        assertGt(_quoteReserve(key), 0);
-        vm.warp(END);
-        extension.advance(key);
-        assertTrue(extension.getLaunch(key.toPoolId()).complete);
-    }
-
-    function testFuzz_largePrincipalWithdrawsInChunks(bool tokenIs0) public {
-        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
-        config.targetTick = 50_000_000;
-        config.upperTick = 50_100_000;
-        PoolKey memory key = creator.create(extension, config);
-        vm.warp(END);
-        extension.advance(key);
-        for (uint256 i = 0; i < 3; i++) {
-            _buy(key, uint128(type(int128).max));
-        }
-        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
-        extension.withdraw(key, address(this));
-        assertGt(core.poolPositions(key.toPoolId(), address(extension), launch.positionId).liquidity, 0);
-        for (uint256 i = 0; i < 4; i++) {
-            extension.withdraw(key, address(this));
-        }
-        assertEq(core.poolPositions(key.toPoolId(), address(extension), launch.positionId).liquidity, 0);
-        assertApproxEqAbs(MintableERC20(launch.token).balanceOf(address(this)), SUPPLY, 6);
-    }
-
-    function test_unfundedSeedRollsBackDeployment() public {
-        ScheduledLaunch.LaunchConfig memory config = _config(HIGH_QUOTE);
-        config.quoteAmount = 1;
-        TestToken(HIGH_QUOTE).approve(address(creator), 0);
-        uint64 nonce = vm.getNonce(address(extension));
-        address predicted = vm.computeCreateAddress(address(extension), nonce);
-        vm.expectRevert();
-        creator.create(extension, config);
-        assertEq(predicted.code.length, 0);
-        assertEq(vm.getNonce(address(extension)), nonce);
+        assertLe(address(deployed.LIQUIDITY()).code.length, 24_576);
+        assertLe(type(ScheduledLaunch).creationCode.length + 32, 49_152);
     }
 }

--- a/test/extensions/ScheduledLaunch.t.sol
+++ b/test/extensions/ScheduledLaunch.t.sol
@@ -1,0 +1,472 @@
+// SPDX-License-Identifier: ekubo-license-v1.eth
+pragma solidity =0.8.33;
+
+import {FullTest} from "../FullTest.sol";
+import {TestToken} from "../TestToken.sol";
+import {ScheduledLaunch, scheduledLaunchCallPoints} from "../../src/extensions/ScheduledLaunch.sol";
+import {MintableERC20} from "../../src/MintableERC20.sol";
+import {BaseLocker} from "../../src/base/BaseLocker.sol";
+import {BaseForwardee} from "../../src/base/BaseForwardee.sol";
+import {UsesCore} from "../../src/base/UsesCore.sol";
+import {ICore} from "../../src/interfaces/ICore.sol";
+import {CoreLib} from "../../src/libraries/CoreLib.sol";
+import {FlashAccountantLib} from "../../src/libraries/FlashAccountantLib.sol";
+import {PoolKey} from "../../src/types/poolKey.sol";
+import {PoolId} from "../../src/types/poolId.sol";
+import {PoolState} from "../../src/types/poolState.sol";
+import {PoolBalanceUpdate} from "../../src/types/poolBalanceUpdate.sol";
+import {createConcentratedPoolConfig} from "../../src/types/poolConfig.sol";
+import {PositionId, createPositionId, BoundsTickSpacing} from "../../src/types/positionId.sol";
+import {Locker} from "../../src/types/locker.sol";
+import {SwapParameters} from "../../src/types/swapParameters.sol";
+import {SqrtRatio} from "../../src/types/sqrtRatio.sol";
+import {tickToSqrtRatio} from "../../src/math/ticks.sol";
+import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
+import {Ownable} from "solady/auth/Ownable.sol";
+
+/// @dev A forwarding locker pays optional quote funding in the same atomic lock.
+contract LaunchCreator is BaseLocker {
+    using FlashAccountantLib for *;
+
+    constructor(ICore core) BaseLocker(core) {}
+
+    function create(ScheduledLaunch extension, ScheduledLaunch.LaunchConfig memory config)
+        external
+        payable
+        returns (PoolKey memory)
+    {
+        return abi.decode(lock(abi.encode(extension, config, msg.sender)), (PoolKey));
+    }
+
+    function handleLockData(uint256, bytes memory data) internal override returns (bytes memory result) {
+        (ScheduledLaunch extension, ScheduledLaunch.LaunchConfig memory config, address payer) =
+            abi.decode(data, (ScheduledLaunch, ScheduledLaunch.LaunchConfig, address));
+        result = ACCOUNTANT.forward(address(extension), abi.encode(config));
+        if (config.quoteAmount != 0) {
+            if (config.quoteToken == address(0)) {
+                SafeTransferLib.safeTransferETH(address(ACCOUNTANT), config.quoteAmount);
+            } else {
+                ACCOUNTANT.payFrom(payer, config.quoteToken, config.quoteAmount);
+            }
+        }
+    }
+}
+
+contract CapacityLP is BaseLocker {
+    using FlashAccountantLib for *;
+
+    constructor(ICore core) BaseLocker(core) {}
+
+    function fill(PoolKey memory key, PositionId positionId, uint128 liquidity) external {
+        lock(abi.encode(key, positionId, liquidity, msg.sender));
+    }
+
+    function handleLockData(uint256, bytes memory data) internal override returns (bytes memory) {
+        (PoolKey memory key, PositionId positionId, uint128 liquidity, address payer) =
+            abi.decode(data, (PoolKey, PositionId, uint128, address));
+        PoolBalanceUpdate update =
+            ICore(payable(address(ACCOUNTANT))).updatePosition(key, positionId, int128(liquidity));
+        if (update.delta0() != 0) ACCOUNTANT.payFrom(payer, key.token0, uint128(update.delta0()));
+        if (update.delta1() != 0) ACCOUNTANT.payFrom(payer, key.token1, uint128(update.delta1()));
+        return "";
+    }
+}
+
+contract ScheduledLaunchTest is FullTest {
+    using CoreLib for *;
+
+    ScheduledLaunch extension;
+    LaunchCreator creator;
+    address constant LOW_QUOTE = address(0x10000);
+    address constant HIGH_QUOTE = address(type(uint160).max);
+    uint128 constant SUPPLY = 1_000_000e18;
+    uint64 constant START = 100;
+    uint64 constant END = 1100;
+
+    function setUp() public override {
+        super.setUp();
+        vm.warp(1);
+        address target = address(uint160(scheduledLaunchCallPoints().toUint8()) << 152);
+        deployCodeTo("ScheduledLaunch.sol", abi.encode(core), target);
+        extension = ScheduledLaunch(target);
+        creator = new LaunchCreator(core);
+        deployCodeTo("TestToken.sol", abi.encode(address(this)), LOW_QUOTE);
+        deployCodeTo("TestToken.sol", abi.encode(address(this)), HIGH_QUOTE);
+        TestToken(LOW_QUOTE).approve(address(creator), type(uint256).max);
+        TestToken(HIGH_QUOTE).approve(address(creator), type(uint256).max);
+        TestToken(LOW_QUOTE).approve(address(router), type(uint256).max);
+        TestToken(HIGH_QUOTE).approve(address(router), type(uint256).max);
+    }
+
+    function _config(address quote) internal view returns (ScheduledLaunch.LaunchConfig memory) {
+        return ScheduledLaunch.LaunchConfig({
+            owner: address(this),
+            quoteToken: quote,
+            name: "Launch",
+            symbol: "LAUNCH",
+            decimals: 18,
+            totalSupply: SUPPLY,
+            quoteAmount: 0,
+            startTime: START,
+            endTime: END,
+            targetTick: 0,
+            upperTick: 100_000,
+            tickSpacing: 100,
+            fee: 0
+        });
+    }
+
+    function _create(bool tokenIs0) internal returns (PoolKey memory key) {
+        key = creator.create(extension, _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE));
+        assertEq(extension.getLaunch(key.toPoolId()).token == key.token0, tokenIs0);
+    }
+
+    function _quoteReserve(PoolKey memory key) internal view returns (uint128) {
+        (uint128 r0, uint128 r1) =
+            core.savedBalances(address(extension), key.token0, key.token1, PoolId.unwrap(key.toPoolId()));
+        return extension.getLaunch(key.toPoolId()).token == key.token0 ? r1 : r0;
+    }
+
+    function _buy(PoolKey memory key, uint128 amount) internal returns (uint128 bought) {
+        bool quoteIs1 = extension.getLaunch(key.toPoolId()).token == key.token0;
+        PoolBalanceUpdate update = router.swapAllowPartialFill(key, quoteIs1, int128(amount), SqrtRatio.wrap(0), 0);
+        bought = uint128(-(quoteIs1 ? update.delta0() : update.delta1()));
+    }
+
+    function testFuzz_createMetadataOwnerAndFunding(bool tokenIs0) public {
+        PoolKey memory key = _create(tokenIs0);
+        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
+        MintableERC20 token = MintableERC20(launch.token);
+        assertEq(launch.owner, address(this));
+        assertEq(token.owner(), address(0));
+        assertEq(token.name(), "Launch");
+        assertEq(token.symbol(), "LAUNCH");
+        assertEq(token.decimals(), 18);
+        assertEq(token.totalSupply(), SUPPLY);
+        assertEq(token.balanceOf(address(core)), SUPPLY);
+        assertEq(token.balanceOf(address(extension)), 0);
+        assertEq(core.poolState(key.toPoolId()).tick(), 0);
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        token.mint(address(this), 1);
+    }
+
+    function test_directInitializationAndForgedCallbacksRevert() public {
+        PoolKey memory key = PoolKey(LOW_QUOTE, HIGH_QUOTE, createConcentratedPoolConfig(0, 100, address(extension)));
+        vm.expectRevert(ScheduledLaunch.InitializationThroughForwardOnly.selector);
+        core.initializePool(key, 0);
+        vm.expectRevert(BaseForwardee.BaseForwardeeAccountantOnly.selector);
+        extension.forwarded_2374103877(Locker.wrap(bytes32(0)));
+        vm.expectRevert(BaseLocker.BaseLockerAccountantOnly.selector);
+        extension.locked_6416899205(0);
+        vm.expectRevert(UsesCore.CoreOnly.selector);
+        extension.beforeSwap(Locker.wrap(bytes32(0)), key, SwapParameters.wrap(bytes32(0)));
+    }
+
+    function testFuzz_linearReleaseAndNoBuyers(bool tokenIs0, uint64 elapsed) public {
+        PoolKey memory key = _create(tokenIs0);
+        elapsed = uint64(bound(elapsed, 0, END - START));
+        vm.warp(START + elapsed);
+        uint128 expected = uint128(uint256(SUPPLY) * elapsed / (END - START));
+        assertEq(extension.released(key.toPoolId()), expected);
+        extension.advance(key);
+        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
+        assertLe(launch.deployed, expected);
+        assertApproxEqAbs(launch.deployed, expected, 1);
+        assertEq(_quoteReserve(key), 0);
+        assertEq(launch.complete, elapsed == END - START);
+        uint128 deployed = launch.deployed;
+        extension.advance(key);
+        assertEq(extension.getLaunch(key.toPoolId()).deployed, deployed);
+    }
+
+    function test_preStartSwapRevertsAndAdvanceDoesNotRelease() public {
+        PoolKey memory key = _create(true);
+        extension.advance(key);
+        assertEq(extension.released(key.toPoolId()), 0);
+        vm.expectRevert(ScheduledLaunch.LaunchNotStarted.selector);
+        router.swapAllowPartialFill(key, true, 1e18, SqrtRatio.wrap(0), 0);
+    }
+
+    function testFuzz_sellTowardTargetAndRetainQuote(bool tokenIs0) public {
+        PoolKey memory key = _create(tokenIs0);
+        vm.warp(START + 100);
+        uint128 bought = _buy(key, 10_000e18);
+        assertGt(bought, 0);
+        assertTrue(core.poolState(key.toPoolId()).sqrtRatio() != tickToSqrtRatio(0));
+        vm.warp(START + 200);
+        extension.advance(key);
+        assertEq(SqrtRatio.unwrap(core.poolState(key.toPoolId()).sqrtRatio()), SqrtRatio.unwrap(tickToSqrtRatio(0)));
+        assertGt(_quoteReserve(key), 0);
+        assertEq(extension.getLaunch(key.toPoolId()).complete, false);
+        assertLe(extension.getLaunch(key.toPoolId()).deployed, SUPPLY / 5);
+    }
+
+    function testFuzz_insufficientReleasedInventory(bool tokenIs0) public {
+        PoolKey memory key = _create(tokenIs0);
+        vm.warp(START + 100);
+        _buy(key, 50_000e18);
+        vm.warp(START + 101);
+        extension.advance(key);
+        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
+        assertLe(launch.deployed, extension.released(key.toPoolId()));
+        assertTrue(core.poolState(key.toPoolId()).sqrtRatio() != tickToSqrtRatio(0));
+        vm.warp(END);
+        extension.advance(key);
+        assertTrue(extension.getLaunch(key.toPoolId()).complete);
+    }
+
+    function testFuzz_sellerPushesBelowTargetThenReleaseStillWorks(bool tokenIs0) public {
+        PoolKey memory key = _create(tokenIs0);
+        vm.warp(START + 100);
+        uint128 bought = _buy(key, 10_000e18);
+        vm.warp(START + 200);
+        extension.advance(key);
+        address launchToken = extension.getLaunch(key.toPoolId()).token;
+        MintableERC20(launchToken).approve(address(router), type(uint256).max);
+        int32 below = tokenIs0 ? int32(-1000) : int32(1000);
+        router.swapAllowPartialFill(key, !tokenIs0, int128(bought), tickToSqrtRatio(below), 0);
+        assertEq(SqrtRatio.unwrap(core.poolState(key.toPoolId()).sqrtRatio()), SqrtRatio.unwrap(tickToSqrtRatio(below)));
+        uint128 quoteBefore = _quoteReserve(key);
+        uint128 deployedBefore = extension.getLaunch(key.toPoolId()).deployed;
+        vm.warp(START + 300);
+        extension.advance(key);
+        assertEq(_quoteReserve(key), quoteBefore);
+        assertGt(extension.getLaunch(key.toPoolId()).deployed, deployedBefore);
+        assertEq(SqrtRatio.unwrap(core.poolState(key.toPoolId()).sqrtRatio()), SqrtRatio.unwrap(tickToSqrtRatio(below)));
+    }
+
+    function testFuzz_ownerWithdrawalAndPostCompletionNoOp(bool tokenIs0) public {
+        PoolKey memory key = _create(tokenIs0);
+        vm.expectRevert(ScheduledLaunch.LaunchNotComplete.selector);
+        extension.withdraw(key, address(this));
+        vm.warp(END);
+        extension.advance(key);
+        vm.prank(address(123));
+        vm.expectRevert(ScheduledLaunch.OwnerOnly.selector);
+        extension.withdraw(key, address(this));
+        vm.expectRevert(ScheduledLaunch.InvalidRecipient.selector);
+        extension.withdraw(key, address(0));
+        bytes32 beforeState = keccak256(abi.encode(extension.getLaunch(key.toPoolId())));
+        _buy(key, 1e18);
+        extension.advance(key);
+        assertEq(keccak256(abi.encode(extension.getLaunch(key.toPoolId()))), beforeState);
+        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
+        extension.withdraw(key, address(this));
+        assertEq(core.poolPositions(key.toPoolId(), address(extension), launch.positionId).liquidity, 0);
+        assertApproxEqAbs(MintableERC20(launch.token).balanceOf(address(this)), SUPPLY, 2);
+        extension.withdraw(key, address(this));
+    }
+
+    function testFuzz_optionalQuoteSeedAndIsolation(bool tokenIs0) public {
+        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
+        config.quoteAmount = 123e18;
+        PoolKey memory first = creator.create(extension, config);
+        config.quoteAmount = 456e18;
+        PoolKey memory second = creator.create(extension, config);
+        assertEq(_quoteReserve(first), 123e18);
+        assertEq(_quoteReserve(second), 456e18);
+        vm.warp(END);
+        extension.advance(first);
+        extension.withdraw(first, address(555));
+        assertEq(_quoteReserve(first), 0);
+        assertEq(_quoteReserve(second), 456e18);
+        assertEq(extension.getLaunch(second.toPoolId()).deployed, 0);
+        assertEq(TestToken(config.quoteToken).balanceOf(address(555)), 123e18);
+    }
+
+    function test_nativeQuote() public {
+        ScheduledLaunch.LaunchConfig memory config = _config(address(0));
+        config.quoteAmount = 1 ether;
+        vm.deal(address(this), 10 ether);
+        PoolKey memory key = creator.create{value: 1 ether}(extension, config);
+        assertEq(_quoteReserve(key), 1 ether);
+        vm.warp(END);
+        extension.advance(key);
+        extension.withdraw(key, address(555));
+        assertEq(address(555).balance, 1 ether);
+    }
+
+    function testFuzz_targetOrientation(bool tokenIs0, int32 targetTick) public {
+        targetTick = int32(bound(targetTick, -100_000, 100_000) / 100 * 100);
+        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
+        config.targetTick = targetTick;
+        config.upperTick = targetTick + 100_000;
+        PoolKey memory key = creator.create(extension, config);
+        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
+        assertEq(launch.targetTick, tokenIs0 ? targetTick : -targetTick);
+        vm.warp(END);
+        extension.advance(key);
+        assertApproxEqAbs(extension.getLaunch(key.toPoolId()).deployed, SUPPLY, 1);
+    }
+
+    function test_invalidConfigurations() public {
+        ScheduledLaunch.LaunchConfig memory config = _config(HIGH_QUOTE);
+        config.owner = address(0);
+        vm.expectRevert(ScheduledLaunch.InvalidLaunch.selector);
+        creator.create(extension, config);
+        config = _config(HIGH_QUOTE);
+        config.endTime = config.startTime;
+        vm.expectRevert(ScheduledLaunch.InvalidLaunch.selector);
+        creator.create(extension, config);
+        config = _config(HIGH_QUOTE);
+        config.totalSupply = 0;
+        vm.expectRevert(ScheduledLaunch.InvalidLaunch.selector);
+        creator.create(extension, config);
+        config = _config(HIGH_QUOTE);
+        config.upperTick = config.targetTick;
+        vm.expectRevert(ScheduledLaunch.InvalidLaunch.selector);
+        creator.create(extension, config);
+        config = _config(HIGH_QUOTE);
+        config.tickSpacing = 0;
+        vm.expectRevert(ScheduledLaunch.InvalidLaunch.selector);
+        creator.create(extension, config);
+        config = _config(HIGH_QUOTE);
+        config.targetTick = 1;
+        vm.expectRevert(BoundsTickSpacing.selector);
+        creator.create(extension, config);
+    }
+
+    function testFuzz_supplyAndExtremeTicks(bool tokenIs0, uint128 supply, int32 target) public {
+        supply = uint128(bound(supply, 1, uint128(type(int128).max)));
+        target = int32(bound(target, -887228, 886228) * 100);
+        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
+        config.totalSupply = supply;
+        config.targetTick = target;
+        config.upperTick = target + 100_000;
+        PoolKey memory key = creator.create(extension, config);
+        vm.warp(END);
+        extension.advance(key);
+        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
+        assertTrue(launch.complete);
+        assertLe(launch.deployed, supply);
+        extension.withdraw(key, address(this));
+        assertApproxEqAbs(MintableERC20(launch.token).balanceOf(address(this)), supply, 2);
+    }
+
+    function testFuzz_tradingSequencePreservesReleaseAccounting(bool tokenIs0, uint256 seed) public {
+        PoolKey memory key = _create(tokenIs0);
+        address launchToken = extension.getLaunch(key.toPoolId()).token;
+        MintableERC20(launchToken).approve(address(router), type(uint256).max);
+        for (uint256 i = 1; i <= 12; i++) {
+            vm.warp(START + i * 90);
+            seed = uint256(keccak256(abi.encode(seed, i)));
+            if (seed % 2 == 0) {
+                _buy(key, uint128(seed % 10_000e18));
+            } else {
+                uint128 balance = uint128(MintableERC20(launchToken).balanceOf(address(this)));
+                router.swapAllowPartialFill(
+                    key, !tokenIs0, int128(balance / 2), tickToSqrtRatio(tokenIs0 ? int32(-1000) : int32(1000)), 0
+                );
+            }
+            extension.advance(key);
+            ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
+            assertLe(launch.deployed, extension.released(key.toPoolId()));
+            (uint128 r0, uint128 r1) =
+                core.savedBalances(address(extension), key.token0, key.token1, PoolId.unwrap(key.toPoolId()));
+            assertEq(tokenIs0 ? r0 : r1, SUPPLY - launch.deployed);
+        }
+        assertTrue(extension.getLaunch(key.toPoolId()).complete);
+        extension.withdraw(key, address(this));
+        // Each swap/deposit rounds independently; bound accumulated dust across the 12 steps.
+        assertApproxEqAbs(MintableERC20(launchToken).balanceOf(address(this)), SUPPLY, 40);
+    }
+
+    function testFuzz_nonzeroFeesRemainWithdrawable(bool tokenIs0) public {
+        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
+        config.fee = uint64(uint256(1 << 64) / 100);
+        PoolKey memory key = creator.create(extension, config);
+        vm.warp(START + 100);
+        _buy(key, 10_000e18);
+        vm.warp(END);
+        extension.advance(key);
+        _buy(key, 1e18);
+        extension.withdraw(key, address(this));
+        assertApproxEqAbs(MintableERC20(extension.getLaunch(key.toPoolId()).token).balanceOf(address(this)), SUPPLY, 4);
+    }
+
+    function testFuzz_thirdPartyTickCapacityDoesNotBlockCompletion(bool tokenIs0) public {
+        PoolKey memory key = _create(tokenIs0);
+        CapacityLP lp = new CapacityLP(core);
+        TestToken(tokenIs0 ? key.token1 : key.token0).approve(address(lp), type(uint256).max);
+        PositionId positionId =
+            createPositionId(bytes24(0), tokenIs0 ? int32(-100_000) : int32(0), tokenIs0 ? int32(0) : int32(100_000));
+        lp.fill(key, positionId, key.config.concentratedMaxLiquidityPerTick());
+        vm.warp(END);
+        extension.advance(key);
+        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
+        assertTrue(launch.complete);
+        assertEq(launch.deployed, 0);
+        extension.withdraw(key, address(this));
+        assertEq(MintableERC20(launch.token).balanceOf(address(this)), SUPPLY);
+        assertEq(
+            core.poolPositions(key.toPoolId(), address(lp), positionId).liquidity,
+            key.config.concentratedMaxLiquidityPerTick()
+        );
+    }
+
+    function test_deployWithMinedHookPrefix() public {
+        bytes32 initHash = keccak256(abi.encodePacked(type(ScheduledLaunch).creationCode, abi.encode(core)));
+        uint256 salt;
+        uint8 prefix = scheduledLaunchCallPoints().toUint8();
+        while (true) {
+            address predicted = address(
+                uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), address(this), bytes32(salt), initHash))))
+            );
+            if (uint8(uint160(predicted) >> 152) == prefix) break;
+            salt++;
+        }
+        ScheduledLaunch deployed = new ScheduledLaunch{salt: bytes32(salt)}(core);
+        assertTrue(core.isExtensionRegistered(address(deployed)));
+        assertLe(address(deployed).code.length, 24_576);
+        PoolKey memory key = creator.create(deployed, _config(HIGH_QUOTE));
+        assertEq(deployed.getLaunch(key.toPoolId()).owner, address(this));
+    }
+
+    function testFuzz_largeQuoteAmountsDoNotBlockSales(bool tokenIs0) public {
+        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
+        config.targetTick = 50_000_000;
+        config.upperTick = 50_100_000;
+        PoolKey memory key = creator.create(extension, config);
+        vm.warp(START + 100);
+        _buy(key, uint128(type(int128).max));
+        _buy(key, uint128(type(int128).max));
+        vm.warp(START + 200);
+        extension.advance(key);
+        assertGt(_quoteReserve(key), 0);
+        vm.warp(END);
+        extension.advance(key);
+        assertTrue(extension.getLaunch(key.toPoolId()).complete);
+    }
+
+    function testFuzz_largePrincipalWithdrawsInChunks(bool tokenIs0) public {
+        ScheduledLaunch.LaunchConfig memory config = _config(tokenIs0 ? HIGH_QUOTE : LOW_QUOTE);
+        config.targetTick = 50_000_000;
+        config.upperTick = 50_100_000;
+        PoolKey memory key = creator.create(extension, config);
+        vm.warp(END);
+        extension.advance(key);
+        for (uint256 i = 0; i < 3; i++) {
+            _buy(key, uint128(type(int128).max));
+        }
+        ScheduledLaunch.Launch memory launch = extension.getLaunch(key.toPoolId());
+        extension.withdraw(key, address(this));
+        assertGt(core.poolPositions(key.toPoolId(), address(extension), launch.positionId).liquidity, 0);
+        for (uint256 i = 0; i < 4; i++) {
+            extension.withdraw(key, address(this));
+        }
+        assertEq(core.poolPositions(key.toPoolId(), address(extension), launch.positionId).liquidity, 0);
+        assertApproxEqAbs(MintableERC20(launch.token).balanceOf(address(this)), SUPPLY, 6);
+    }
+
+    function test_unfundedSeedRollsBackDeployment() public {
+        ScheduledLaunch.LaunchConfig memory config = _config(HIGH_QUOTE);
+        config.quoteAmount = 1;
+        TestToken(HIGH_QUOTE).approve(address(creator), 0);
+        uint64 nonce = vm.getNonce(address(extension));
+        address predicted = vm.computeCreateAddress(address(extension), nonce);
+        vm.expectRevert();
+        creator.create(extension, config);
+        assertEq(predicted.code.length, 0);
+        assertEq(vm.getNonce(address(extension)), nonce);
+    }
+}

--- a/test/math/launchLiquidity.t.sol
+++ b/test/math/launchLiquidity.t.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: ekubo-license-v1.eth
+pragma solidity =0.8.33;
+
+import {Test} from "forge-std/Test.sol";
+import {LaunchLiquidityMath} from "../../src/math/launchLiquidity.sol";
+import {SqrtRatio, MIN_SQRT_RATIO, MAX_SQRT_RATIO, toSqrtRatio} from "../../src/types/sqrtRatio.sol";
+import {tickToSqrtRatio} from "../../src/math/ticks.sol";
+import {maxLiquidity} from "../../src/math/liquidity.sol";
+
+contract LaunchLiquidityMathTest is Test {
+    function _capacity(LaunchLiquidityMath.Market memory m, bool token1, uint128 amount)
+        private
+        pure
+        returns (uint128)
+    {
+        (SqrtRatio price, uint128 a0, uint128 a1) = LaunchLiquidityMath.preview(m, token1, amount);
+        return LaunchLiquidityMath.liquidityFor(price, a0, a1);
+    }
+
+    function testFuzz_optimalAgainstBruteForce(uint128 a0, uint128 a1, uint128 liquidity, uint64 fee, int32 tick)
+        public
+    {
+        a0 = uint128(bound(a0, 0, 100));
+        a1 = uint128(bound(a1, 0, 100));
+        liquidity = uint128(bound(liquidity, 100, 100_000));
+        fee = uint64(bound(fee, 0, uint64(uint256(1 << 64) / 10)));
+        tick = int32(bound(tick, -100_000, 100_000));
+        LaunchLiquidityMath.Market memory m = LaunchLiquidityMath.Market(
+            tickToSqrtRatio(tick), MIN_SQRT_RATIO, MAX_SQRT_RATIO, liquidity, fee, a0, a1, liquidity / 2
+        );
+        (bool token1, uint128 amount) = LaunchLiquidityMath.optimalSwap(m);
+        uint128 chosen = _capacity(m, token1, amount);
+        uint128 best;
+        for (uint128 i = 0; i <= a0; i++) {
+            uint128 candidate = _capacity(m, false, i);
+            if (candidate > best) best = candidate;
+        }
+        for (uint128 i = 0; i <= a1; i++) {
+            uint128 candidate = _capacity(m, true, i);
+            if (candidate > best) best = candidate;
+        }
+        assertEq(chosen, best);
+        assertGe(chosen, LaunchLiquidityMath.liquidityFor(m.price, a0, a1));
+    }
+
+    function testFuzz_emptyPoolPriceUsesBothBalances(uint128 a0, uint128 a1) public {
+        a0 = uint128(bound(a0, 1e6, 1e30));
+        a1 = uint128(bound(a1, 1e6, 1e30));
+        SqrtRatio price = LaunchLiquidityMath.depositPrice(a0, a1);
+        uint128 liquidity = LaunchLiquidityMath.liquidityFor(price, a0, a1);
+        assertGt(liquidity, 0);
+        assertEq(liquidity, maxLiquidity(price, MIN_SQRT_RATIO, MAX_SQRT_RATIO, a0, a1));
+        assertGe(liquidity, LaunchLiquidityMath.liquidityFor(toSqrtRatio(price.toFixed() - 1, false), a0, a1));
+        assertGe(liquidity, LaunchLiquidityMath.liquidityFor(toSqrtRatio(price.toFixed() + 1, true), a0, a1));
+    }
+
+    function testFuzz_extremeMarketNeverSpendsMoreThanInventory(
+        uint128 a0,
+        uint128 a1,
+        uint128 liquidity,
+        uint64 fee,
+        int32 tick
+    ) public {
+        liquidity = uint128(bound(liquidity, 1, type(uint128).max));
+        tick = int32(bound(tick, -88700000, 88700000));
+        LaunchLiquidityMath.Market memory m = LaunchLiquidityMath.Market(
+            tickToSqrtRatio(tick),
+            tickToSqrtRatio(tick - 1000),
+            tickToSqrtRatio(tick + 1000),
+            liquidity,
+            fee,
+            a0,
+            a1,
+            liquidity / 2
+        );
+        (bool token1, uint128 amount) = LaunchLiquidityMath.optimalSwap(m);
+        assertLe(amount, token1 ? a1 : a0);
+        (SqrtRatio price, uint128 after0, uint128 after1) = LaunchLiquidityMath.preview(m, token1, amount);
+        assertTrue(price.isValid());
+        assertTrue(price >= m.lower && price <= m.upper);
+        assertGe(
+            LaunchLiquidityMath.liquidityFor(price, after0, after1), LaunchLiquidityMath.liquidityFor(m.price, a0, a1)
+        );
+    }
+
+    function test_compactEncodingBoundaries() public {
+        SqrtRatio price = LaunchLiquidityMath.depositPrice(1 << 96, 1 << 32);
+        assertTrue(price.isValid());
+        price = LaunchLiquidityMath.depositPrice(1 << 32, 1 << 96);
+        assertTrue(price.isValid());
+        price = LaunchLiquidityMath.depositPrice(1 << 100, 1 << 100);
+        assertTrue(price.isValid());
+    }
+
+    function test_extremeBudgetsNearEndpointsDoNotOverflow() public {
+        SqrtRatio high = SqrtRatio.wrap(SqrtRatio.unwrap(MAX_SQRT_RATIO) - 1);
+        SqrtRatio low = SqrtRatio.wrap(SqrtRatio.unwrap(MIN_SQRT_RATIO) + 1);
+        assertGt(LaunchLiquidityMath.liquidityFor(high, type(uint128).max, type(uint128).max), 0);
+        assertGt(LaunchLiquidityMath.liquidityFor(low, type(uint128).max, type(uint128).max), 0);
+        LaunchLiquidityMath.depositPrice(type(uint128).max, 1);
+        LaunchLiquidityMath.depositPrice(1, type(uint128).max);
+    }
+}


### PR DESCRIPTION
Adds a scheduled token launch that ends by migrating principal into permanently locked, no-extension full-range liquidity. External launch trades pay a linearly declining creator fee; the final scheduled fee becomes the terminal pool's fixed fee. The creator can claim launch fees and fees earned by the launch's own terminal position, but cannot withdraw principal or collect another LP's fees.

Creation atomically deploys the existing `MintableERC20`, mints the fixed launch inventory, records its owner/schedule, and renounces minting authority. The launch pool has zero Core fee and requires forwarded swaps; internal inventory sales pay no creator surcharge. Released tokens sell toward a fixed target before remaining balances are added as launch liquidity.

At expiry, permissionless advancement transfers reserves and removes only the launch-owned position into `LockedLaunchLiquidity`. It selects a funded deposit price for an empty destination, or solves the fee-adjusted XYK balancing swap against existing full-range liquidity using Core's rounding and recycling the position's own internal-fee rebate. Creator-configured immutable price bounds protect migration from out-of-range execution. Internal rebalancing fees earned by the launch's own terminal position are recycled into principal; previously earned external-trade fees remain claimable by the creator.

Behavior and integration details:

- Principal has no withdrawal, approval, upgrade, or arbitrary-call path. The permanent contract can add liquidity and claim position fees. The terminal pool itself has no extension.
- Create through `forward(abi.encode(uint8(0), LaunchConfig))`; trade through `forward(abi.encode(uint8(1), PoolKey, SwapParameters))`. Routers settle fee-inclusive deltas and enforce user slippage limits. Launch trades stop at expiry; anyone can then call `advance`.
- Exact-input creator fees are deducted from actual output; exact-output fees are added to actual input. Internal release sales never enter that fee path. The migration swap still pays the terminal pool's normal fee to its LPs.
- Full-range migration needs both assets or existing liquidity to trade against. With neither, principal remains locked pending permissionless funding/retry. Price bounds, dust, and Core capacity limits can also leave locked reserves pending; exceptionally large source positions migrate over multiple advances.
- Includes deployment tooling, API/lifecycle documentation, both token orderings, and native/ERC-20 quote support.

Validation:

- `forge snapshot --offline` with CI's Foundry v1.5.1: **987 tests passed**, zero failures, and no tracked gas snapshot changes.
- 23 launch/migration/math tests passed with 1,024 cases per fuzz test, including brute-force optimal-swap comparison, exact-output/partial fills, fee separation, immutable principal, existing LP fee ownership, internal-fee recycling, price bounds, empty-pool price manipulation, delayed funding, extreme balances, compact price boundaries, and chunked migration.
- Runtime sizes: launch extension 19,395 bytes; locked-liquidity contract 20,351 bytes. Extension initcode is 40,690 bytes including the child contract, below the 49,152-byte limit.
- Changed Solidity files pass formatting and the complexity threshold of 7.
