### PR TITLE
Add per-pool owner fee share to SignedExclusiveSwap

### DIFF
--- a/signed-exclusive-swap-extension.md
+++ b/signed-exclusive-swap-extension.md
@@ -62,7 +62,7 @@ where:
 6. Extension consumes the nonce. This happens only after the bounds check passes, so a swap that violates its bounds costs less gas and does not burn the nonce.
 7. Extension applies `fee` to the swapper result:
    - exact-in: fee is charged on output amount,
-   - exact-out: fee is charged on required input amount.
+   - exact-out: fee is charged on required input amount; the total input including the fee must fit `int128`, otherwise the swap reverts.
 8. For a nonzero collected fee, the owner share is calculated with `computeFee` and saved separately in Core under salt zero. The remainder is saved under the pool ID and later donated to that pool's LPs.
 
 ## Why `minBalanceUpdate` is useful
@@ -79,11 +79,11 @@ It provides four protections at once:
 
 The extension does not immediately donate the LP share of its signed fee to LPs.
 
-Instead, on a pool's first touch at a new block *timestamp* (`swap`, `beforeUpdatePosition`, or `beforeCollectFees` path, or the public `accumulatePoolFees`), it:
+On a pool's first swap or public `accumulatePoolFees` call at a new block *timestamp*, it:
 - donates previously collected LP fees into pool LP accounting,
 - records the pool as updated for the current block timestamp.
 
-This prevents liquidity from being added purely to capture fees that were earned earlier. Note that the gate is the block timestamp, not the block number, so on chains that produce more than one block per second donation happens at most once per second.
+Position updates and fee collection always flush pending LP fees first, even at the same timestamp. This prevents newly added liquidity from capturing fees earned before it joined and lets withdrawing LPs collect their pending fees before their position is removed. These hooks are callable only by Core. Ordinary swaps and public accumulation remain timestamp-gated, so multiple swaps in the same second can share a pending fee bucket.
 
 ## Replay protection
 

--- a/signed-exclusive-swap-extension.md
+++ b/signed-exclusive-swap-extension.md
@@ -114,7 +114,7 @@ These controls reduce the value of quote farming and make selective execution ma
 ## Controller management
 
 - Contract is `Ownable`.
-- Owner initializes pools by setting a `ControllerAddress controller` via `initializePool(poolKey, tick, controller)`; the EOA/contract flag is encoded in the controller address (high bit at position 159).
+- Owner initializes pools by setting a `ControllerAddress controller` via `initializePool(poolKey, tick, controller, ownerFee)`; the EOA/contract flag is encoded in the controller address (high bit at position 159).
 - Direct `Core.initializePool(...)` for this extension is blocked by `beforeInitializePool`.
 - Owner can update per-pool controller for already initialized pools via `setPoolController(...)`.
 - Controller signatures support both EOAs and ERC-1271 contract wallets; which path is used is determined by bit 159 of the controller address itself, not a separate flag. Addresses below `2^159` are verified via ECDSA, addresses at or above it via ERC-1271. Initialization and controller updates enforce that the address's code presence matches the encoded type.
@@ -125,10 +125,10 @@ These controls reduce the value of quote farming and make selective execution ma
 
 ## Owner fee share
 
-The owner can call `setOwnerFee(PoolKey,uint64)` to set a Q0.64 share of subsequently collected swap fees for an initialized pool (the same representation as regular pool fees). Each pool defaults to zero. `PoolStateUpdated` records changes, and `ownerFee(PoolId)` reads the configured share. For example, `1 << 63` takes half of the collected fee, not half of the swap amount.
+The owner can call `setOwnerFee(PoolKey,uint64)` to set a Q0.64 share of subsequently collected swap fees for an initialized pool (the same representation as regular pool fees). The initial share is supplied to `initializePool(poolKey, tick, controller, ownerFee)`. `PoolStateUpdated` records changes. Read the share through ExposedStorage at the pool ID slot and decode it with `SignedExclusiveSwapPoolState.ownerFee()`. For example, `1 << 63` takes half of the collected fee, not half of the swap amount.
 
 The fee occupies bits [63..0] of `SignedExclusiveSwapPoolState`, alongside the 160-bit controller and 32-bit last-update timestamp. Swaps read the fee from the already loaded state, requiring no additional storage read.
 
-During each swap, a nonzero collected fee is split using `computeFee(collectedFee, ownerFee)`, rounding the owner's share up. A nonzero owner share is saved immediately through `CORE.updateSavedBalances` under salt zero, aggregated by ordered token pair. The remaining fee goes to the pool's pending LP balance. The swapper's total fee is unchanged, and rate changes do not affect fees already saved for LPs.
+During each swap, a nonzero collected fee is split using `computeFee(collectedFee, ownerFee)`, rounding the owner's share up. Only a nonzero computed owner share is saved immediately through `CORE.updateSavedBalances` under salt zero, aggregated by ordered token pair. The remaining fee goes to the pool's pending LP balance. The swapper's total fee is unchanged, and rate changes do not affect fees already saved for LPs.
 
 The owner can collect these balances with `withdrawOwnerFees(token0, token1, amount0, amount1, recipient)`. Pending LP balances remain separate under the pool ID salt.

--- a/signed-exclusive-swap-extension.md
+++ b/signed-exclusive-swap-extension.md
@@ -79,11 +79,13 @@ It provides four protections at once:
 
 The extension does not immediately donate the LP share of its signed fee to LPs.
 
-On a pool's first swap or public `accumulatePoolFees` call at a new block *timestamp*, it:
+On a pool's first touch at a new block *timestamp* (`swap`, `beforeUpdatePosition`, `beforeCollectFees`, or public `accumulatePoolFees`), it:
 - donates previously collected LP fees into pool LP accounting,
 - records the pool as updated for the current block timestamp.
 
-Position updates and fee collection always flush pending LP fees first, even at the same timestamp. This prevents newly added liquidity from capturing fees earned before it joined and lets withdrawing LPs collect their pending fees before their position is removed. These hooks are callable only by Core. Ordinary swaps and public accumulation remain timestamp-gated, so multiple swaps in the same second can share a pending fee bucket.
+Position updates and fee collection at the same timestamp do not flush pending LP fees. Donations go to liquidity active at donation time, so liquidity added before donation can receive earlier fees, withdrawing liquidity can miss pending fees, and a donation with no active liquidity is burned. The gate uses the timestamp rather than the block number; on chains with multiple blocks per second, those blocks can share a pending fee bucket.
+
+This attribution tradeoff is intentional. The controller authorizes swaps and their fees, and has an arbitrage incentive to leave the pool at the correct price at the end of the block. Flushing on position changes would not prevent controller-authorized swaps from moving the active range before donation, so it does not provide a useful attribution guarantee for this design. The end-of-block price is an economic expectation, not an enforced invariant. Perfect attribution to the liquidity used throughout a swap requires per-step fee accounting in Core. See the [acknowledged V12 finding](https://v12.sh/runs/7702/274639).
 
 ## Replay protection
 

--- a/signed-exclusive-swap-extension.md
+++ b/signed-exclusive-swap-extension.md
@@ -125,7 +125,9 @@ These controls reduce the value of quote farming and make selective execution ma
 
 ## Owner fee share
 
-The owner can call `setOwnerFee(uint64)` to set a Q0.64 share of subsequently collected swap fees (the same representation as regular pool fees). It defaults to zero. `OwnerFeeUpdated` records changes. For example, `1 << 63` takes half of the collected fee, not half of the swap amount.
+The owner can call `setOwnerFee(PoolKey,uint64)` to set a Q0.64 share of subsequently collected swap fees for an initialized pool (the same representation as regular pool fees). Each pool defaults to zero. `PoolStateUpdated` records changes, and `ownerFee(PoolId)` reads the configured share. For example, `1 << 63` takes half of the collected fee, not half of the swap amount.
+
+The fee occupies bits [63..0] of `SignedExclusiveSwapPoolState`, alongside the 160-bit controller and 32-bit last-update timestamp. Swaps read the fee from the already loaded state, requiring no additional storage read.
 
 During each swap, a nonzero collected fee is split using `computeFee(collectedFee, ownerFee)`, rounding the owner's share up. A nonzero owner share is saved immediately through `CORE.updateSavedBalances` under salt zero, aggregated by ordered token pair. The remaining fee goes to the pool's pending LP balance. The swapper's total fee is unchanged, and rate changes do not affect fees already saved for LPs.
 

--- a/signed-exclusive-swap-extension.md
+++ b/signed-exclusive-swap-extension.md
@@ -11,7 +11,7 @@ It enforces:
 - signatures can optionally restrict which locker is allowed to use them,
 - pool fee must be zero for pools using this extension,
 - pools must be initialized through the extension's owner-only `initializePool(...)`,
-- signed fees are collected by the extension first and donated to LPs on the next block touch.
+- signed fees are split between the owner and LPs; the LP share is donated on the next block touch.
 
 ## Payload
 
@@ -63,7 +63,7 @@ where:
 7. Extension applies `fee` to the swapper result:
    - exact-in: fee is charged on output amount,
    - exact-out: fee is charged on required input amount.
-8. Charged fee is stored in Core saved balances owned by the extension itself, salted by the pool ID, and is later donated to that pool's LPs.
+8. For a nonzero collected fee, the owner share is calculated with `computeFee` and saved separately in Core under salt zero. The remainder is saved under the pool ID and later donated to that pool's LPs.
 
 ## Why `minBalanceUpdate` is useful
 
@@ -77,10 +77,10 @@ It provides four protections at once:
 
 ## Fee donation timing
 
-The extension does not immediately donate its signed fee to LPs.
+The extension does not immediately donate the LP share of its signed fee to LPs.
 
 Instead, on a pool's first touch at a new block *timestamp* (`swap`, `beforeUpdatePosition`, or `beforeCollectFees` path, or the public `accumulatePoolFees`), it:
-- donates previously collected extension fees into pool LP accounting,
+- donates previously collected LP fees into pool LP accounting,
 - records the pool as updated for the current block timestamp.
 
 This prevents liquidity from being added purely to capture fees that were earned earlier. Note that the gate is the block timestamp, not the block number, so on chains that produce more than one block per second donation happens at most once per second.
@@ -122,3 +122,11 @@ These controls reduce the value of quote farming and make selective execution ma
 ## Broadcasting quotes
 
 `broadcastSignedSwaps(SignedSwapBroadcast[])` is a permissionless entrypoint that validates a batch of signed payloads (deadline window, nonce still available, signature against the pool's current controller) and emits one `SignedSwapBroadcasted` event per valid payload. It executes nothing and consumes no nonces; it exists so a controller can publish live quotes on-chain for takers to discover. The whole call reverts if any payload fails validation.
+
+## Owner fee share
+
+The owner can call `setOwnerFee(uint64)` to set a Q0.64 share of subsequently collected swap fees (the same representation as regular pool fees). It defaults to zero. `OwnerFeeUpdated` records changes. For example, `1 << 63` takes half of the collected fee, not half of the swap amount.
+
+During each swap, a nonzero collected fee is split using `computeFee(collectedFee, ownerFee)`, rounding the owner's share up. A nonzero owner share is saved immediately through `CORE.updateSavedBalances` under salt zero, aggregated by ordered token pair. The remaining fee goes to the pool's pending LP balance. The swapper's total fee is unchanged, and rate changes do not affect fees already saved for LPs.
+
+The owner can collect these balances with `withdrawOwnerFees(token0, token1, amount0, amount1, recipient)`. Pending LP balances remain separate under the pool ID salt.

--- a/snapshots/SignedExclusiveSwapTest.json
+++ b/snapshots/SignedExclusiveSwapTest.json
@@ -1,5 +1,5 @@
 {
-  "signedExclusiveSwap broadcastSignedSwaps (single)": "36654",
+  "signedExclusiveSwap broadcastSignedSwaps (single)": "36632",
   "signedExclusiveSwap token0 input (no meta fee)": "118829",
   "signedExclusiveSwap token0 input (with meta fee)": "143526",
   "signedExclusiveSwap token1 input (with meta fee)": "143737"

--- a/snapshots/SignedExclusiveSwapTest.json
+++ b/snapshots/SignedExclusiveSwapTest.json
@@ -1,6 +1,6 @@
 {
   "signedExclusiveSwap broadcastSignedSwaps (single)": "36632",
   "signedExclusiveSwap token0 input (no meta fee)": "118817",
-  "signedExclusiveSwap token0 input (with meta fee)": "143514",
-  "signedExclusiveSwap token1 input (with meta fee)": "143725"
+  "signedExclusiveSwap token0 input (with meta fee)": "143506",
+  "signedExclusiveSwap token1 input (with meta fee)": "143717"
 }

--- a/snapshots/SignedExclusiveSwapTest.json
+++ b/snapshots/SignedExclusiveSwapTest.json
@@ -1,6 +1,6 @@
 {
   "signedExclusiveSwap broadcastSignedSwaps (single)": "36654",
-  "signedExclusiveSwap token0 input (no meta fee)": "118826",
-  "signedExclusiveSwap token0 input (with meta fee)": "145592",
-  "signedExclusiveSwap token1 input (with meta fee)": "145805"
+  "signedExclusiveSwap token0 input (no meta fee)": "118829",
+  "signedExclusiveSwap token0 input (with meta fee)": "143526",
+  "signedExclusiveSwap token1 input (with meta fee)": "143737"
 }

--- a/snapshots/SignedExclusiveSwapTest.json
+++ b/snapshots/SignedExclusiveSwapTest.json
@@ -1,6 +1,6 @@
 {
-  "signedExclusiveSwap broadcastSignedSwaps (single)": "36621",
-  "signedExclusiveSwap token0 input (no meta fee)": "118832",
-  "signedExclusiveSwap token0 input (with meta fee)": "143353",
-  "signedExclusiveSwap token1 input (with meta fee)": "143566"
+  "signedExclusiveSwap broadcastSignedSwaps (single)": "36654",
+  "signedExclusiveSwap token0 input (no meta fee)": "118826",
+  "signedExclusiveSwap token0 input (with meta fee)": "145592",
+  "signedExclusiveSwap token1 input (with meta fee)": "145805"
 }

--- a/snapshots/SignedExclusiveSwapTest.json
+++ b/snapshots/SignedExclusiveSwapTest.json
@@ -1,6 +1,6 @@
 {
   "signedExclusiveSwap broadcastSignedSwaps (single)": "36632",
-  "signedExclusiveSwap token0 input (no meta fee)": "118829",
-  "signedExclusiveSwap token0 input (with meta fee)": "143526",
-  "signedExclusiveSwap token1 input (with meta fee)": "143737"
+  "signedExclusiveSwap token0 input (no meta fee)": "118817",
+  "signedExclusiveSwap token0 input (with meta fee)": "143514",
+  "signedExclusiveSwap token1 input (with meta fee)": "143725"
 }

--- a/src/extensions/SignedExclusiveSwap.sol
+++ b/src/extensions/SignedExclusiveSwap.sol
@@ -45,7 +45,7 @@ function signedExclusiveSwapCallPoints() pure returns (CallPoints memory) {
 }
 
 /// @notice Forward-only swap extension with controller-signed, per-swap fee customization.
-/// @dev After the owner share is deducted, LP fees are saved until the next timestamp or an earlier position update or fee collection.
+/// @dev After the owner share is deducted, LP fees are saved and donated on the first accumulation at a later timestamp.
 contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForwardee, ExposedStorage, Ownable {
     using CoreLib for *;
     using ExposedStorageLib for *;
@@ -129,44 +129,37 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
         revert SwapMustHappenThroughForward();
     }
 
-    /// @dev Prevents new liquidity from collecting extension fees that should belong to existing LPs.
+    /// @dev Accumulates prior-timestamp LP fees before updating a position.
     function beforeUpdatePosition(Locker, PoolKey memory poolKey, PositionId, int128)
         external
         override(BaseExtension, IExtension)
-        onlyCore
     {
-        _accumulatePoolFees(poolKey, poolKey.toPoolId());
+        accumulatePoolFees(poolKey);
     }
 
-    /// @dev Flushes pending LP fees before collection, including before a full withdrawal.
+    /// @dev Allows fee collection to observe extension donations up to the start of the current timestamp.
     function beforeCollectFees(Locker, PoolKey memory poolKey, PositionId)
         external
         override(BaseExtension, IExtension)
-        onlyCore
     {
-        _accumulatePoolFees(poolKey, poolKey.toPoolId());
+        accumulatePoolFees(poolKey);
     }
 
     /// @inheritdoc ISignedExclusiveSwap
     function accumulatePoolFees(PoolKey memory poolKey) public {
         PoolId poolId = poolKey.toPoolId();
         if (_getPoolState(poolId).lastUpdateTime() != uint32(block.timestamp)) {
-            _accumulatePoolFees(poolKey, poolId);
-        }
-    }
+            address target = address(CORE);
+            assembly ("memory-safe") {
+                let o := mload(0x40)
+                mstore(o, shl(224, 0xf83d08ba))
+                mcopy(add(o, 4), poolKey, 96)
+                mstore(add(o, 100), poolId)
 
-    /// @dev LP lifecycle hooks must flush even if a swap already updated this timestamp.
-    function _accumulatePoolFees(PoolKey memory poolKey, PoolId poolId) internal {
-        address target = address(CORE);
-        assembly ("memory-safe") {
-            let o := mload(0x40)
-            mstore(o, shl(224, 0xf83d08ba))
-            mcopy(add(o, 4), poolKey, 96)
-            mstore(add(o, 100), poolId)
-
-            if iszero(call(gas(), target, 0, o, 132, 0, 0)) {
-                returndatacopy(o, 0, returndatasize())
-                revert(o, returndatasize())
+                if iszero(call(gas(), target, 0, o, 132, 0, 0)) {
+                    returndatacopy(o, 0, returndatasize())
+                    revert(o, returndatasize())
+                }
             }
         }
     }

--- a/src/extensions/SignedExclusiveSwap.sol
+++ b/src/extensions/SignedExclusiveSwap.sol
@@ -45,7 +45,7 @@ function signedExclusiveSwapCallPoints() pure returns (CallPoints memory) {
 }
 
 /// @notice Forward-only swap extension with controller-signed, per-swap fee customization.
-/// @dev After the owner share is deducted, LP fees are first collected into extension saved balances, then donated to LPs at the start of the next block.
+/// @dev After the owner share is deducted, LP fees are saved until the next timestamp or an earlier position update or fee collection.
 contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForwardee, ExposedStorage, Ownable {
     using CoreLib for *;
     using ExposedStorageLib for *;
@@ -133,33 +133,40 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
     function beforeUpdatePosition(Locker, PoolKey memory poolKey, PositionId, int128)
         external
         override(BaseExtension, IExtension)
+        onlyCore
     {
-        accumulatePoolFees(poolKey);
+        _accumulatePoolFees(poolKey, poolKey.toPoolId());
     }
 
-    /// @dev Allows fee collection to observe extension donations up to the start of the current block.
+    /// @dev Flushes pending LP fees before collection, including before a full withdrawal.
     function beforeCollectFees(Locker, PoolKey memory poolKey, PositionId)
         external
         override(BaseExtension, IExtension)
+        onlyCore
     {
-        accumulatePoolFees(poolKey);
+        _accumulatePoolFees(poolKey, poolKey.toPoolId());
     }
 
     /// @inheritdoc ISignedExclusiveSwap
     function accumulatePoolFees(PoolKey memory poolKey) public {
         PoolId poolId = poolKey.toPoolId();
         if (_getPoolState(poolId).lastUpdateTime() != uint32(block.timestamp)) {
-            address target = address(CORE);
-            assembly ("memory-safe") {
-                let o := mload(0x40)
-                mstore(o, shl(224, 0xf83d08ba))
-                mcopy(add(o, 4), poolKey, 96)
-                mstore(add(o, 100), poolId)
+            _accumulatePoolFees(poolKey, poolId);
+        }
+    }
 
-                if iszero(call(gas(), target, 0, o, 132, 0, 0)) {
-                    returndatacopy(o, 0, returndatasize())
-                    revert(o, returndatasize())
-                }
+    /// @dev LP lifecycle hooks must flush even if a swap already updated this timestamp.
+    function _accumulatePoolFees(PoolKey memory poolKey, PoolId poolId) internal {
+        address target = address(CORE);
+        assembly ("memory-safe") {
+            let o := mload(0x40)
+            mstore(o, shl(224, 0xf83d08ba))
+            mcopy(add(o, 4), poolKey, 96)
+            mstore(add(o, 100), poolId)
+
+            if iszero(call(gas(), target, 0, o, 132, 0, 0)) {
+                returndatacopy(o, 0, returndatasize())
+                revert(o, returndatasize())
             }
         }
     }
@@ -284,18 +291,18 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
                 if (params.isExactOut()) {
                     if (balanceUpdate.delta0() > 0) {
                         uint128 inputAmount = uint128(uint256(int256(balanceUpdate.delta0())));
-                        int128 feeAmount = SafeCastLib.toInt128(amountBeforeFee(inputAmount, metaFeeX64) - inputAmount);
+                        int128 inputWithFee = SafeCastLib.toInt128(amountBeforeFee(inputAmount, metaFeeX64));
+                        int128 feeAmount = inputWithFee - balanceUpdate.delta0();
                         saveDelta0 += feeAmount
                             - int256(uint256(_saveOwnerFee(poolKey, uint128(feeAmount), false, state.ownerFee())));
-                        balanceUpdate =
-                            createPoolBalanceUpdate(balanceUpdate.delta0() + feeAmount, balanceUpdate.delta1());
+                        balanceUpdate = createPoolBalanceUpdate(inputWithFee, balanceUpdate.delta1());
                     } else if (balanceUpdate.delta1() > 0) {
                         uint128 inputAmount = uint128(uint256(int256(balanceUpdate.delta1())));
-                        int128 feeAmount = SafeCastLib.toInt128(amountBeforeFee(inputAmount, metaFeeX64) - inputAmount);
+                        int128 inputWithFee = SafeCastLib.toInt128(amountBeforeFee(inputAmount, metaFeeX64));
+                        int128 feeAmount = inputWithFee - balanceUpdate.delta1();
                         saveDelta1 += feeAmount
                             - int256(uint256(_saveOwnerFee(poolKey, uint128(feeAmount), true, state.ownerFee())));
-                        balanceUpdate =
-                            createPoolBalanceUpdate(balanceUpdate.delta0(), balanceUpdate.delta1() + feeAmount);
+                        balanceUpdate = createPoolBalanceUpdate(balanceUpdate.delta0(), inputWithFee);
                     }
                 } else {
                     if (balanceUpdate.delta0() < 0) {

--- a/src/extensions/SignedExclusiveSwap.sol
+++ b/src/extensions/SignedExclusiveSwap.sol
@@ -7,6 +7,8 @@ import {ISignedExclusiveSwap} from "../interfaces/extensions/ISignedExclusiveSwa
 import {BaseExtension} from "../base/BaseExtension.sol";
 import {BaseForwardee} from "../base/BaseForwardee.sol";
 import {ExposedStorage} from "../base/ExposedStorage.sol";
+import {FlashAccountantLib} from "../libraries/FlashAccountantLib.sol";
+import {IFlashAccountant} from "../interfaces/IFlashAccountant.sol";
 import {CoreLib} from "../libraries/CoreLib.sol";
 import {ExposedStorageLib} from "../libraries/ExposedStorageLib.sol";
 import {SignedExclusiveSwapLib} from "../libraries/SignedExclusiveSwapLib.sol";
@@ -43,7 +45,7 @@ function signedExclusiveSwapCallPoints() pure returns (CallPoints memory) {
 }
 
 /// @notice Forward-only swap extension with controller-signed, per-swap fee customization.
-/// @dev Fees are first collected into extension saved balances, then donated to LPs at the start of the next block.
+/// @dev After the owner share is deducted, LP fees are first collected into extension saved balances, then donated to LPs at the start of the next block.
 contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForwardee, ExposedStorage, Ownable {
     using CoreLib for *;
     using ExposedStorageLib for *;
@@ -56,6 +58,33 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
     uint32 internal constant _MAX_DEADLINE_FUTURE_WINDOW = 30 days;
 
     mapping(uint256 => Bitmap) public nonceBitmap;
+
+    /// @inheritdoc ISignedExclusiveSwap
+    uint64 public ownerFee;
+
+    /// @inheritdoc ISignedExclusiveSwap
+    function setOwnerFee(uint64 fee) external onlyOwner {
+        ownerFee = fee;
+        emit OwnerFeeUpdated(fee);
+    }
+
+    /// @inheritdoc ISignedExclusiveSwap
+    function withdrawOwnerFees(address token0, address token1, uint128 amount0, uint128 amount1, address recipient)
+        external
+        onlyOwner
+    {
+        (bool success, bytes memory result) = address(CORE)
+            .call(
+                abi.encodePacked(
+                    IFlashAccountant.lock.selector, abi.encode(token0, token1, amount0, amount1, recipient)
+                )
+            );
+        if (!success) {
+            assembly ("memory-safe") {
+                revert(add(result, 32), mload(result))
+            }
+        }
+    }
 
     constructor(ICore core, address owner) BaseExtension(core) BaseForwardee(core) {
         _initializeOwner(owner);
@@ -133,8 +162,17 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
         }
     }
 
-    /// @dev Core lock callback used by `accumulatePoolFees`.
+    /// @dev Core lock callback used by `accumulatePoolFees` and owner fee withdrawals.
     function locked_6416899205(uint256) external onlyCore {
+        // Withdrawal locks carry five words; fee accumulation locks carry four.
+        if (msg.data.length == 196) {
+            (address token0, address token1, uint128 amount0, uint128 amount1, address recipient) =
+                abi.decode(msg.data[36:], (address, address, uint128, uint128, address));
+            CORE.updateSavedBalances(token0, token1, bytes32(0), -int256(uint256(amount0)), -int256(uint256(amount1)));
+            FlashAccountantLib.withdrawTwo(CORE, token0, token1, recipient, amount0, amount1);
+            return;
+        }
+
         PoolKey memory poolKey;
         PoolId poolId;
         assembly ("memory-safe") {
@@ -245,13 +283,13 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
                     if (balanceUpdate.delta0() > 0) {
                         uint128 inputAmount = uint128(uint256(int256(balanceUpdate.delta0())));
                         int128 feeAmount = SafeCastLib.toInt128(amountBeforeFee(inputAmount, metaFeeX64) - inputAmount);
-                        saveDelta0 += feeAmount;
+                        saveDelta0 += feeAmount - int256(uint256(_saveOwnerFee(poolKey, uint128(feeAmount), false)));
                         balanceUpdate =
                             createPoolBalanceUpdate(balanceUpdate.delta0() + feeAmount, balanceUpdate.delta1());
                     } else if (balanceUpdate.delta1() > 0) {
                         uint128 inputAmount = uint128(uint256(int256(balanceUpdate.delta1())));
                         int128 feeAmount = SafeCastLib.toInt128(amountBeforeFee(inputAmount, metaFeeX64) - inputAmount);
-                        saveDelta1 += feeAmount;
+                        saveDelta1 += feeAmount - int256(uint256(_saveOwnerFee(poolKey, uint128(feeAmount), true)));
                         balanceUpdate =
                             createPoolBalanceUpdate(balanceUpdate.delta0(), balanceUpdate.delta1() + feeAmount);
                     }
@@ -260,14 +298,14 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
                         int128 feeAmount = SafeCastLib.toInt128(
                             computeFee(uint128(uint256(-int256(balanceUpdate.delta0()))), metaFeeX64)
                         );
-                        saveDelta0 += feeAmount;
+                        saveDelta0 += feeAmount - int256(uint256(_saveOwnerFee(poolKey, uint128(feeAmount), false)));
                         balanceUpdate =
                             createPoolBalanceUpdate(balanceUpdate.delta0() + feeAmount, balanceUpdate.delta1());
                     } else if (balanceUpdate.delta1() < 0) {
                         int128 feeAmount = SafeCastLib.toInt128(
                             computeFee(uint128(uint256(-int256(balanceUpdate.delta1()))), metaFeeX64)
                         );
-                        saveDelta1 += feeAmount;
+                        saveDelta1 += feeAmount - int256(uint256(_saveOwnerFee(poolKey, uint128(feeAmount), true)));
                         balanceUpdate =
                             createPoolBalanceUpdate(balanceUpdate.delta0(), balanceUpdate.delta1() + feeAmount);
                     }
@@ -279,6 +317,25 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
             }
 
             result = abi.encode(balanceUpdate, stateAfter);
+        }
+    }
+
+    /// @dev Saves only the owner's share of this swap's collected fee, never pending LP fees.
+    function _saveOwnerFee(PoolKey memory poolKey, uint128 collectedFee, bool isToken1)
+        internal
+        returns (uint128 share)
+    {
+        if (collectedFee != 0) {
+            share = computeFee(collectedFee, ownerFee);
+            if (share != 0) {
+                CORE.updateSavedBalances(
+                    poolKey.token0,
+                    poolKey.token1,
+                    bytes32(0),
+                    isToken1 ? int256(0) : int256(uint256(share)),
+                    isToken1 ? int256(uint256(share)) : int256(0)
+                );
+            }
         }
     }
 

--- a/src/extensions/SignedExclusiveSwap.sol
+++ b/src/extensions/SignedExclusiveSwap.sol
@@ -60,12 +60,17 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
     mapping(uint256 => Bitmap) public nonceBitmap;
 
     /// @inheritdoc ISignedExclusiveSwap
-    uint64 public ownerFee;
+    function ownerFee(PoolId poolId) external view returns (uint64) {
+        return _getPoolState(poolId).ownerFee();
+    }
 
     /// @inheritdoc ISignedExclusiveSwap
-    function setOwnerFee(uint64 fee) external onlyOwner {
-        ownerFee = fee;
-        emit OwnerFeeUpdated(fee);
+    function setOwnerFee(PoolKey memory poolKey, uint64 fee) external onlyOwner {
+        if (poolKey.config.extension() != address(this) || !CORE.poolState(poolKey.toPoolId()).isInitialized()) {
+            revert ICore.PoolNotInitialized();
+        }
+        PoolId poolId = poolKey.toPoolId();
+        _setPoolState(poolId, _getPoolState(poolId).withOwnerFee(fee));
     }
 
     /// @inheritdoc ISignedExclusiveSwap
@@ -108,7 +113,8 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
 
         sqrtRatio = CORE.initializePool(poolKey, tick);
         _setPoolState({
-            poolId: poolKey.toPoolId(), state: createSignedExclusiveSwapPoolState(controller, uint32(block.timestamp))
+            poolId: poolKey.toPoolId(),
+            state: createSignedExclusiveSwapPoolState(controller, uint32(block.timestamp), 0)
         });
     }
 
@@ -283,13 +289,15 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
                     if (balanceUpdate.delta0() > 0) {
                         uint128 inputAmount = uint128(uint256(int256(balanceUpdate.delta0())));
                         int128 feeAmount = SafeCastLib.toInt128(amountBeforeFee(inputAmount, metaFeeX64) - inputAmount);
-                        saveDelta0 += feeAmount - int256(uint256(_saveOwnerFee(poolKey, uint128(feeAmount), false)));
+                        saveDelta0 += feeAmount
+                            - int256(uint256(_saveOwnerFee(poolKey, uint128(feeAmount), false, state.ownerFee())));
                         balanceUpdate =
                             createPoolBalanceUpdate(balanceUpdate.delta0() + feeAmount, balanceUpdate.delta1());
                     } else if (balanceUpdate.delta1() > 0) {
                         uint128 inputAmount = uint128(uint256(int256(balanceUpdate.delta1())));
                         int128 feeAmount = SafeCastLib.toInt128(amountBeforeFee(inputAmount, metaFeeX64) - inputAmount);
-                        saveDelta1 += feeAmount - int256(uint256(_saveOwnerFee(poolKey, uint128(feeAmount), true)));
+                        saveDelta1 += feeAmount
+                            - int256(uint256(_saveOwnerFee(poolKey, uint128(feeAmount), true, state.ownerFee())));
                         balanceUpdate =
                             createPoolBalanceUpdate(balanceUpdate.delta0(), balanceUpdate.delta1() + feeAmount);
                     }
@@ -298,14 +306,16 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
                         int128 feeAmount = SafeCastLib.toInt128(
                             computeFee(uint128(uint256(-int256(balanceUpdate.delta0()))), metaFeeX64)
                         );
-                        saveDelta0 += feeAmount - int256(uint256(_saveOwnerFee(poolKey, uint128(feeAmount), false)));
+                        saveDelta0 += feeAmount
+                            - int256(uint256(_saveOwnerFee(poolKey, uint128(feeAmount), false, state.ownerFee())));
                         balanceUpdate =
                             createPoolBalanceUpdate(balanceUpdate.delta0() + feeAmount, balanceUpdate.delta1());
                     } else if (balanceUpdate.delta1() < 0) {
                         int128 feeAmount = SafeCastLib.toInt128(
                             computeFee(uint128(uint256(-int256(balanceUpdate.delta1()))), metaFeeX64)
                         );
-                        saveDelta1 += feeAmount - int256(uint256(_saveOwnerFee(poolKey, uint128(feeAmount), true)));
+                        saveDelta1 += feeAmount
+                            - int256(uint256(_saveOwnerFee(poolKey, uint128(feeAmount), true, state.ownerFee())));
                         balanceUpdate =
                             createPoolBalanceUpdate(balanceUpdate.delta0(), balanceUpdate.delta1() + feeAmount);
                     }
@@ -321,12 +331,12 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
     }
 
     /// @dev Saves only the owner's share of this swap's collected fee, never pending LP fees.
-    function _saveOwnerFee(PoolKey memory poolKey, uint128 collectedFee, bool isToken1)
+    function _saveOwnerFee(PoolKey memory poolKey, uint128 collectedFee, bool isToken1, uint64 fee)
         internal
         returns (uint128 share)
     {
         if (collectedFee != 0) {
-            share = computeFee(collectedFee, ownerFee);
+            share = computeFee(collectedFee, fee);
             if (share != 0) {
                 CORE.updateSavedBalances(
                     poolKey.token0,

--- a/src/extensions/SignedExclusiveSwap.sol
+++ b/src/extensions/SignedExclusiveSwap.sol
@@ -60,17 +60,11 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
     mapping(uint256 => Bitmap) public nonceBitmap;
 
     /// @inheritdoc ISignedExclusiveSwap
-    function ownerFee(PoolId poolId) external view returns (uint64) {
-        return _getPoolState(poolId).ownerFee();
-    }
-
-    /// @inheritdoc ISignedExclusiveSwap
     function setOwnerFee(PoolKey memory poolKey, uint64 fee) external onlyOwner {
-        if (poolKey.config.extension() != address(this) || !CORE.poolState(poolKey.toPoolId()).isInitialized()) {
-            revert ICore.PoolNotInitialized();
-        }
         PoolId poolId = poolKey.toPoolId();
-        _setPoolState(poolId, _getPoolState(poolId).withOwnerFee(fee));
+        SignedExclusiveSwapPoolState state = _getPoolState(poolId);
+        if (ControllerAddress.unwrap(state.controller()) == address(0)) revert ICore.PoolNotInitialized();
+        _setPoolState(poolId, state.withOwnerFee(fee));
     }
 
     /// @inheritdoc ISignedExclusiveSwap
@@ -102,7 +96,7 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
     }
 
     /// @inheritdoc ISignedExclusiveSwap
-    function initializePool(PoolKey memory poolKey, int32 tick, ControllerAddress controller)
+    function initializePool(PoolKey memory poolKey, int32 tick, ControllerAddress controller, uint64 ownerFee)
         external
         onlyOwner
         returns (SqrtRatio sqrtRatio)
@@ -114,7 +108,9 @@ contract SignedExclusiveSwap is ISignedExclusiveSwap, BaseExtension, BaseForward
         sqrtRatio = CORE.initializePool(poolKey, tick);
         _setPoolState({
             poolId: poolKey.toPoolId(),
-            state: createSignedExclusiveSwapPoolState(controller, uint32(block.timestamp), 0)
+            state: createSignedExclusiveSwapPoolState({
+                _controller: controller, _lastUpdateTime: uint32(block.timestamp), _ownerFee: ownerFee
+            })
         });
     }
 

--- a/src/interfaces/extensions/ISignedExclusiveSwap.sol
+++ b/src/interfaces/extensions/ISignedExclusiveSwap.sol
@@ -23,15 +23,13 @@ interface ISignedExclusiveSwap is IExposedStorage, ILocker, IForwardee, IExtensi
         bytes signature;
     }
 
-    /// @notice Emitted when the owner share of subsequently collected swap fees changes.
-    event OwnerFeeUpdated(uint64 fee);
+    /// @notice The pool's owner share of collected swap fees as a Q0.64 fraction, initially zero.
+    function ownerFee(PoolId poolId) external view returns (uint64);
 
-    /// @notice The owner's share of collected swap fees as a Q0.64 fraction, initially zero.
-    function ownerFee() external view returns (uint64);
-
-    /// @notice Sets the owner's Q0.64 share of future swap fees. Only callable by the owner.
-    /// @dev The share is calculated with computeFee (rounded up) and deducted from LP fees.
-    function setOwnerFee(uint64 fee) external;
+    /// @notice Sets the pool's owner Q0.64 share of future swap fees. Only callable by the owner.
+    /// @dev Stored in the pool state; emits PoolStateUpdated. The pool must be initialized.
+    /// The share is calculated with computeFee (rounded up) and deducted from LP fees.
+    function setOwnerFee(PoolKey memory poolKey, uint64 fee) external;
 
     /// @notice Withdraws owner fees saved in Core under salt zero. Only callable by the owner.
     /// @dev Balances are aggregated by ordered token pair, separately from pending LP fees.

--- a/src/interfaces/extensions/ISignedExclusiveSwap.sol
+++ b/src/interfaces/extensions/ISignedExclusiveSwap.sol
@@ -23,9 +23,6 @@ interface ISignedExclusiveSwap is IExposedStorage, ILocker, IForwardee, IExtensi
         bytes signature;
     }
 
-    /// @notice The pool's owner share of collected swap fees as a Q0.64 fraction, initially zero.
-    function ownerFee(PoolId poolId) external view returns (uint64);
-
     /// @notice Sets the pool's owner Q0.64 share of future swap fees. Only callable by the owner.
     /// @dev Stored in the pool state; emits PoolStateUpdated. The pool must be initialized.
     /// The share is calculated with computeFee (rounded up) and deducted from LP fees.
@@ -80,7 +77,8 @@ interface ISignedExclusiveSwap is IExposedStorage, ILocker, IForwardee, IExtensi
     /// @param poolKey Pool configuration to initialize. Must point its extension to this contract.
     /// @param tick Initial tick for the pool.
     /// @param controller Initial pool controller with EOA/contract type encoded in bit 159 (high bit: 0 = EOA, 1 = contract).
-    function initializePool(PoolKey memory poolKey, int32 tick, ControllerAddress controller)
+    /// @param ownerFee Initial Q0.64 owner share of collected swap fees.
+    function initializePool(PoolKey memory poolKey, int32 tick, ControllerAddress controller, uint64 ownerFee)
         external
         returns (SqrtRatio sqrtRatio);
 

--- a/src/interfaces/extensions/ISignedExclusiveSwap.sol
+++ b/src/interfaces/extensions/ISignedExclusiveSwap.sol
@@ -23,6 +23,21 @@ interface ISignedExclusiveSwap is IExposedStorage, ILocker, IForwardee, IExtensi
         bytes signature;
     }
 
+    /// @notice Emitted when the owner share of subsequently collected swap fees changes.
+    event OwnerFeeUpdated(uint64 fee);
+
+    /// @notice The owner's share of collected swap fees as a Q0.64 fraction, initially zero.
+    function ownerFee() external view returns (uint64);
+
+    /// @notice Sets the owner's Q0.64 share of future swap fees. Only callable by the owner.
+    /// @dev The share is calculated with computeFee (rounded up) and deducted from LP fees.
+    function setOwnerFee(uint64 fee) external;
+
+    /// @notice Withdraws owner fees saved in Core under salt zero. Only callable by the owner.
+    /// @dev Balances are aggregated by ordered token pair, separately from pending LP fees.
+    function withdrawOwnerFees(address token0, address token1, uint128 amount0, uint128 amount1, address recipient)
+        external;
+
     /// @notice Emitted when a pool state is updated.
     event PoolStateUpdated(PoolId indexed poolId, SignedExclusiveSwapPoolState poolState);
     /// @notice Emitted when a signed swap payload is validated and broadcast.

--- a/src/types/signedExclusiveSwapPoolState.sol
+++ b/src/types/signedExclusiveSwapPoolState.sol
@@ -6,9 +6,17 @@ import {ControllerAddress} from "./controllerAddress.sol";
 /// @dev Layout:
 /// - bits [255..96]: controller (160 bits)
 /// - bits [95..64]: last update time (uint32)
+/// - bits [63..0]: owner fee share (uint64, Q0.64)
 type SignedExclusiveSwapPoolState is bytes32;
 
-using {controller, lastUpdateTime, withLastUpdateTime, withController} for SignedExclusiveSwapPoolState global;
+using {
+    controller,
+    lastUpdateTime,
+    withLastUpdateTime,
+    withController,
+    ownerFee,
+    withOwnerFee
+} for SignedExclusiveSwapPoolState global;
 
 function controller(SignedExclusiveSwapPoolState state) pure returns (ControllerAddress result) {
     assembly ("memory-safe") {
@@ -22,12 +30,12 @@ function lastUpdateTime(SignedExclusiveSwapPoolState state) pure returns (uint32
     }
 }
 
-function createSignedExclusiveSwapPoolState(ControllerAddress _controller, uint32 _lastUpdateTime)
+function createSignedExclusiveSwapPoolState(ControllerAddress _controller, uint32 _lastUpdateTime, uint64 _ownerFee)
     pure
     returns (SignedExclusiveSwapPoolState state)
 {
     assembly ("memory-safe") {
-        state := or(shl(96, _controller), shl(64, _lastUpdateTime))
+        state := or(or(shl(96, _controller), shl(64, _lastUpdateTime)), and(_ownerFee, 0xffffffffffffffff))
     }
 }
 
@@ -49,5 +57,20 @@ function withController(SignedExclusiveSwapPoolState state, ControllerAddress _c
             and(state, 0x0000000000000000000000000000000000000000ffffffffffffffffffffffff),
             shl(96, _controller)
         )
+    }
+}
+
+function ownerFee(SignedExclusiveSwapPoolState state) pure returns (uint64 result) {
+    assembly ("memory-safe") {
+        result := and(state, 0xffffffffffffffff)
+    }
+}
+
+function withOwnerFee(SignedExclusiveSwapPoolState state, uint64 _ownerFee)
+    pure
+    returns (SignedExclusiveSwapPoolState updated)
+{
+    assembly ("memory-safe") {
+        updated := or(and(state, not(0xffffffffffffffff)), and(_ownerFee, 0xffffffffffffffff))
     }
 }

--- a/test/extensions/SignedExclusiveSwap.t.sol
+++ b/test/extensions/SignedExclusiveSwap.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: ekubo-license-v1.eth
 pragma solidity =0.8.33;
 
+import {computeFee} from "../../src/math/fee.sol";
 import {FullTest} from "../FullTest.sol";
 import {PoolKey} from "../../src/types/poolKey.sol";
 import {PoolId} from "../../src/types/poolId.sol";
@@ -214,8 +215,8 @@ contract SignedExclusiveSwapTest is FullTest {
         uint32 deadline = uint32(block.timestamp + 1 hours);
         uint32 nonce = 7;
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta = createSignedSwapMeta(address(harness), deadline, fee, nonce);
 
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);
@@ -250,6 +251,135 @@ contract SignedExclusiveSwapTest is FullTest {
         assertEq(saved1After, 1);
     }
 
+    function test_owner_fee_administration() public {
+        assertEq(signedExclusiveSwap.ownerFee(), 0);
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        signedExclusiveSwap.setOwnerFee(1);
+        vm.prank(admin);
+        vm.expectEmit(address(signedExclusiveSwap));
+        emit ISignedExclusiveSwap.OwnerFeeUpdated(type(uint64).max);
+        signedExclusiveSwap.setOwnerFee(type(uint64).max);
+        assertEq(signedExclusiveSwap.ownerFee(), type(uint64).max);
+        vm.expectRevert(Ownable.Unauthorized.selector);
+        signedExclusiveSwap.withdrawOwnerFees(address(token0), address(token1), 0, 0, address(this));
+    }
+
+    function _ownerFeeSwap(PoolKey memory poolKey, bool isToken1, int128 amount, uint32 fee)
+        internal
+        returns (PoolBalanceUpdate balanceUpdate)
+    {
+        SignedSwapMeta meta =
+            createSignedSwapMeta(address(harness), uint32(block.timestamp + 1 hours), fee, type(uint64).max);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            controllerPk, signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE)
+        );
+        (balanceUpdate,) = harness.swapSigned(
+            address(signedExclusiveSwap),
+            poolKey,
+            createSwapParameters({
+                _isToken1: isToken1, _amount: amount, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit(),
+            meta,
+            MIN_BALANCE_UPDATE,
+            abi.encodePacked(r, s, v),
+            address(this),
+            address(this)
+        );
+    }
+
+    function test_fuzz_owner_fee_split(bool isToken1, bool exactOut, uint64 shareRate, uint128 amount) public {
+        amount = uint128(bound(amount, 1, 100_000));
+        PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000);
+        createPosition(poolKey, -100_000, 100_000, 1_000_000, 1_000_000);
+        token0.approve(address(harness), type(uint256).max);
+        token1.approve(address(harness), type(uint256).max);
+        uint256 snapshot = vm.snapshotState();
+        int128 swapAmount = exactOut ? -int128(amount) : int128(amount);
+        PoolBalanceUpdate baseline = _ownerFeeSwap(poolKey, isToken1, swapAmount, uint32(1 << 26));
+        (uint128 total0, uint128 total1) = core.savedBalances(
+            address(signedExclusiveSwap), poolKey.token0, poolKey.token1, PoolId.unwrap(poolKey.toPoolId())
+        );
+        assertTrue(vm.revertToState(snapshot));
+        vm.prank(admin);
+        signedExclusiveSwap.setOwnerFee(shareRate);
+        PoolBalanceUpdate actual = _ownerFeeSwap(poolKey, isToken1, swapAmount, uint32(1 << 26));
+        assertEq(PoolBalanceUpdate.unwrap(actual), PoolBalanceUpdate.unwrap(baseline));
+        uint128 expected0 = computeFee(total0, shareRate);
+        uint128 expected1 = computeFee(total1, shareRate);
+        (uint128 owner0, uint128 owner1) =
+            core.savedBalances(address(signedExclusiveSwap), poolKey.token0, poolKey.token1, bytes32(0));
+        assertEq(owner0, expected0);
+        assertEq(owner1, expected1);
+        (uint128 lp0, uint128 lp1) = core.savedBalances(
+            address(signedExclusiveSwap), poolKey.token0, poolKey.token1, PoolId.unwrap(poolKey.toPoolId())
+        );
+        assertEq(uint256(lp0) + owner0, total0);
+        assertEq(uint256(lp1) + owner1, total1);
+
+        // Changing the rate does not take another share of already saved LP fees.
+        vm.prank(admin);
+        signedExclusiveSwap.setOwnerFee(type(uint64).max);
+        advanceTime(1);
+        signedExclusiveSwap.accumulatePoolFees(poolKey);
+        (uint128 after0, uint128 after1) =
+            core.savedBalances(address(signedExclusiveSwap), poolKey.token0, poolKey.token1, bytes32(0));
+        assertEq(after0, owner0);
+        assertEq(after1, owner1);
+        uint256 balance0 = token0.balanceOf(address(this));
+        uint256 balance1 = token1.balanceOf(address(this));
+        vm.prank(admin);
+        signedExclusiveSwap.withdrawOwnerFees(poolKey.token0, poolKey.token1, owner0, owner1, address(this));
+        assertEq(token0.balanceOf(address(this)), balance0 + owner0);
+        assertEq(token1.balanceOf(address(this)), balance1 + owner1);
+        (after0, after1) = core.savedBalances(address(signedExclusiveSwap), poolKey.token0, poolKey.token1, bytes32(0));
+        assertEq(after0, 0);
+        assertEq(after1, 0);
+    }
+
+    function test_owner_fee_inline_donation_and_rate_change() public {
+        PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000);
+        createPosition(poolKey, -100_000, 100_000, 1_000_000, 1_000_000);
+        token0.approve(address(harness), type(uint256).max);
+        token1.approve(address(harness), type(uint256).max);
+        _ownerFeeSwap(poolKey, false, 100_000, uint32(1 << 26));
+        advanceTime(1);
+        uint256 snapshot = vm.snapshotState();
+        _ownerFeeSwap(poolKey, false, 100_000, uint32(1 << 26));
+        (, uint128 total) = core.savedBalances(
+            address(signedExclusiveSwap), poolKey.token0, poolKey.token1, PoolId.unwrap(poolKey.toPoolId())
+        );
+        // Inline donation retains one unit of the old LP balance.
+        uint128 newFee = total - 1;
+        assertGt(newFee, 0);
+        assertTrue(vm.revertToState(snapshot));
+        vm.prank(admin);
+        signedExclusiveSwap.setOwnerFee(1 << 63);
+        _ownerFeeSwap(poolKey, false, 100_000, uint32(1 << 26));
+        (, uint128 ownerShare) =
+            core.savedBalances(address(signedExclusiveSwap), poolKey.token0, poolKey.token1, bytes32(0));
+        assertEq(ownerShare, (newFee + 1) / 2);
+        (, uint128 lpShare) = core.savedBalances(
+            address(signedExclusiveSwap), poolKey.token0, poolKey.token1, PoolId.unwrap(poolKey.toPoolId())
+        );
+        assertEq(lpShare + ownerShare, total);
+        vm.prank(admin);
+        vm.expectRevert();
+        signedExclusiveSwap.withdrawOwnerFees(poolKey.token0, poolKey.token1, 0, ownerShare + 1, address(this));
+    }
+
+    function test_owner_fee_rounds_up_entire_single_unit_fee() public {
+        test_fuzz_owner_fee_split(false, true, 1, 1);
+    }
+
+    function test_zero_collected_fee_skips_owner_balance_update() public {
+        PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000);
+        createPosition(poolKey, -100_000, 100_000, 1_000_000, 1_000_000);
+        vm.prank(admin);
+        signedExclusiveSwap.setOwnerFee(type(uint64).max);
+        vm.expectCall(address(core), abi.encodeWithSelector(ICore.updateSavedBalances.selector), uint64(0));
+        _ownerFeeSwap(poolKey, false, 0, type(uint32).max);
+    }
+
     function test_hash_signed_swap_payload_matches_solady_eip712() public view {
         PoolId poolId = signedExclusiveSwapPoolKey(20_000).toPoolId();
         SignedSwapMeta meta = createSignedSwapMeta(address(harness), uint32(block.timestamp + 1 hours), 1_234_567, 777);
@@ -277,8 +407,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta = createSignedSwapMeta(address(harness), uint32(block.timestamp + 1 hours), 0, 300);
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(controllerPk, digest);
@@ -307,8 +437,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         uint32 fee = uint32(uint256(1 << 32) / 200); // 0.5%
         SignedSwapMeta meta = createSignedSwapMeta(address(harness), uint32(block.timestamp + 1 hours), fee, 301);
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);
@@ -338,8 +468,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: true, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: true, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         uint32 fee = uint32(uint256(1 << 32) / 200); // 0.5%
         SignedSwapMeta meta = createSignedSwapMeta(address(harness), uint32(block.timestamp + 1 hours), fee, 302);
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);
@@ -389,8 +519,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 11);
 
@@ -430,8 +560,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         uint64 nonce = type(uint64).max;
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), nonce);
@@ -475,8 +605,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta = createSignedSwapMeta(
             address(0xBEEF), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 99
         );
@@ -513,8 +643,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta = createSignedSwapMeta(address(0), deadlineTooFar, uint32(uint256(1 << 32) / 500), 100);
 
         vm.expectRevert(ISignedExclusiveSwap.DeadlineTooFar.selector);
@@ -558,8 +688,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 121);
 
@@ -597,8 +727,8 @@ contract SignedExclusiveSwapTest is FullTest {
         signedExclusiveSwap.setPoolController(poolKey, ControllerAddress.wrap(address(contractController)));
 
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 131);
 
@@ -626,8 +756,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 211);
         PoolBalanceUpdate minBalanceUpdate = createPoolBalanceUpdate(type(int128).max, type(int128).max);
@@ -657,8 +787,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 212);
         PoolBalanceUpdate minBalanceUpdate = createPoolBalanceUpdate(50_000, -60_000);
@@ -690,8 +820,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 213);
         PoolBalanceUpdate minBalanceUpdate = createPoolBalanceUpdate(50_000, -40_000);
@@ -721,8 +851,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: true, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: true, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 214);
         PoolBalanceUpdate minBalanceUpdate = createPoolBalanceUpdate(-40_000, 50_000);
@@ -752,8 +882,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: true, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: true, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp - 1), uint32(uint256(1 << 32) / 500), 215);
         PoolBalanceUpdate minBalanceUpdate = createPoolBalanceUpdate(-40_000, 50_000);
@@ -783,8 +913,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: true, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: true, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 216);
         PoolBalanceUpdate minBalanceUpdateSigned = createPoolBalanceUpdate(-40_000, 50_000);
@@ -920,8 +1050,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta = createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), 0, 222);
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(controllerPk, digest);
@@ -959,8 +1089,8 @@ contract SignedExclusiveSwapTest is FullTest {
         vm.chainId(originalChainId + 1);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta = createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), 0, 223);
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(controllerPk, digest);
@@ -1068,8 +1198,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: false, _amount: -50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: false, _amount: -50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         uint32 fee = uint32(uint256(1 << 32) / 100); // 1%
         SignedSwapMeta meta = createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), fee, 224);
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);
@@ -1104,8 +1234,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-                _isToken1: true, _amount: -50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit();
+            _isToken1: true, _amount: -50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+        }).withDefaultSqrtRatioLimit();
         uint32 fee = uint32(uint256(1 << 32) / 100); // 1%
         SignedSwapMeta meta = createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), fee, 225);
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);

--- a/test/extensions/SignedExclusiveSwap.t.sol
+++ b/test/extensions/SignedExclusiveSwap.t.sol
@@ -17,6 +17,7 @@ import {
     SignedExclusiveSwapPoolState,
     createSignedExclusiveSwapPoolState
 } from "../../src/types/signedExclusiveSwapPoolState.sol";
+import {ExposedStorageLib} from "../../src/libraries/ExposedStorageLib.sol";
 import {CoreLib} from "../../src/libraries/CoreLib.sol";
 import {SignedExclusiveSwapLib} from "../../src/libraries/SignedExclusiveSwapLib.sol";
 import {SignedExclusiveSwap, signedExclusiveSwapCallPoints} from "../../src/extensions/SignedExclusiveSwap.sol";
@@ -141,6 +142,7 @@ contract SignedExclusiveSwapHarness is BaseLocker {
 }
 
 contract SignedExclusiveSwapTest is FullTest {
+    using ExposedStorageLib for *;
     using CoreLib for *;
     using SignedExclusiveSwapLib for *;
 
@@ -199,9 +201,20 @@ contract SignedExclusiveSwapTest is FullTest {
         internal
         returns (PoolKey memory poolKey)
     {
+        return createSignedExclusiveSwapPool(tick, tickSpacing, poolController, 0);
+    }
+
+    function createSignedExclusiveSwapPool(int32 tick, uint32 tickSpacing, ControllerAddress poolController, uint64 fee)
+        internal
+        returns (PoolKey memory poolKey)
+    {
         poolKey = signedExclusiveSwapPoolKey(tickSpacing);
         vm.prank(admin);
-        signedExclusiveSwap.initializePool(poolKey, tick, poolController);
+        signedExclusiveSwap.initializePool(poolKey, tick, poolController, fee);
+    }
+
+    function _poolState(PoolKey memory poolKey) internal view returns (SignedExclusiveSwapPoolState) {
+        return SignedExclusiveSwapPoolState.wrap(signedExclusiveSwap.sload(PoolId.unwrap(poolKey.toPoolId())));
     }
 
     function test_signed_swap_helper_and_deferred_fee_donation() public {
@@ -253,17 +266,20 @@ contract SignedExclusiveSwapTest is FullTest {
 
     function test_owner_fee_administration() public {
         PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000);
-        assertEq(signedExclusiveSwap.ownerFee(poolKey.toPoolId()), 0);
+        assertEq(_poolState(poolKey).ownerFee(), 0);
         vm.expectRevert(Ownable.Unauthorized.selector);
         signedExclusiveSwap.setOwnerFee(poolKey, 1);
         vm.prank(admin);
         vm.expectEmit(address(signedExclusiveSwap));
         emit ISignedExclusiveSwap.PoolStateUpdated(
             poolKey.toPoolId(),
-            createSignedExclusiveSwapPoolState(controller, uint32(block.timestamp), type(uint64).max)
+            createSignedExclusiveSwapPoolState({
+                _controller: controller, _lastUpdateTime: uint32(block.timestamp), _ownerFee: type(uint64).max
+            })
         );
+        vm.expectCall(address(core), bytes(""), uint64(0));
         signedExclusiveSwap.setOwnerFee(poolKey, type(uint64).max);
-        assertEq(signedExclusiveSwap.ownerFee(poolKey.toPoolId()), type(uint64).max);
+        assertEq(_poolState(poolKey).ownerFee(), type(uint64).max);
         vm.expectRevert(Ownable.Unauthorized.selector);
         signedExclusiveSwap.withdrawOwnerFees(address(token0), address(token1), 0, 0, address(this));
     }
@@ -273,17 +289,19 @@ contract SignedExclusiveSwapTest is FullTest {
         PoolKey memory otherPool = createSignedExclusiveSwapPool(0, 10_000);
         vm.prank(admin);
         signedExclusiveSwap.setOwnerFee(poolKey, 1 << 63);
-        assertEq(signedExclusiveSwap.ownerFee(poolKey.toPoolId()), 1 << 63);
-        assertEq(signedExclusiveSwap.ownerFee(otherPool.toPoolId()), 0);
+        assertEq(_poolState(poolKey).ownerFee(), 1 << 63);
+        assertEq(_poolState(otherPool).ownerFee(), 0);
         vm.prank(admin);
         signedExclusiveSwap.setPoolController(poolKey, controller);
         advanceTime(1);
         signedExclusiveSwap.accumulatePoolFees(poolKey);
-        assertEq(signedExclusiveSwap.ownerFee(poolKey.toPoolId()), 1 << 63);
+        assertEq(_poolState(poolKey).ownerFee(), 1 << 63);
     }
 
     function test_revert_owner_fee_uninitialized_pool() public {
         PoolKey memory poolKey = signedExclusiveSwapPoolKey(20_000);
+        signedExclusiveSwap.accumulatePoolFees(poolKey);
+        assertGt(_poolState(poolKey).lastUpdateTime(), 0);
         vm.prank(admin);
         vm.expectRevert(ICore.PoolNotInitialized.selector);
         signedExclusiveSwap.setOwnerFee(poolKey, 1);
@@ -324,22 +342,40 @@ contract SignedExclusiveSwapTest is FullTest {
         );
     }
 
-    function test_fuzz_owner_fee_split(bool isToken1, bool exactOut, uint64 shareRate, uint128 amount) public {
+    function test_fuzz_owner_fee_exact_in_token0(uint64 shareRate, uint128 amount, uint32 swapFee) public {
+        _testOwnerFeeSplit(false, false, shareRate, amount, swapFee);
+    }
+
+    function test_fuzz_owner_fee_exact_in_token1(uint64 shareRate, uint128 amount, uint32 swapFee) public {
+        _testOwnerFeeSplit(true, false, shareRate, amount, swapFee);
+    }
+
+    function test_fuzz_owner_fee_exact_out_token0(uint64 shareRate, uint128 amount, uint32 swapFee) public {
+        _testOwnerFeeSplit(false, true, shareRate, amount, swapFee);
+    }
+
+    function test_fuzz_owner_fee_exact_out_token1(uint64 shareRate, uint128 amount, uint32 swapFee) public {
+        _testOwnerFeeSplit(true, true, shareRate, amount, swapFee);
+    }
+
+    function _testOwnerFeeSplit(bool isToken1, bool exactOut, uint64 shareRate, uint128 amount, uint32 swapFee)
+        internal
+    {
         amount = uint128(bound(amount, 1, 100_000));
-        PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000);
+        PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000, controller, shareRate);
         createPosition(poolKey, -100_000, 100_000, 1_000_000, 1_000_000);
         token0.approve(address(harness), type(uint256).max);
         token1.approve(address(harness), type(uint256).max);
         uint256 snapshot = vm.snapshotState();
+        vm.prank(admin);
+        signedExclusiveSwap.setOwnerFee(poolKey, 0);
         int128 swapAmount = exactOut ? -int128(amount) : int128(amount);
-        PoolBalanceUpdate baseline = _ownerFeeSwap(poolKey, isToken1, swapAmount, uint32(1 << 26));
+        PoolBalanceUpdate baseline = _ownerFeeSwap(poolKey, isToken1, swapAmount, swapFee);
         (uint128 total0, uint128 total1) = core.savedBalances(
             address(signedExclusiveSwap), poolKey.token0, poolKey.token1, PoolId.unwrap(poolKey.toPoolId())
         );
         assertTrue(vm.revertToState(snapshot));
-        vm.prank(admin);
-        signedExclusiveSwap.setOwnerFee(poolKey, shareRate);
-        PoolBalanceUpdate actual = _ownerFeeSwap(poolKey, isToken1, swapAmount, uint32(1 << 26));
+        PoolBalanceUpdate actual = _ownerFeeSwap(poolKey, isToken1, swapAmount, swapFee);
         assertEq(PoolBalanceUpdate.unwrap(actual), PoolBalanceUpdate.unwrap(baseline));
         uint128 expected0 = computeFee(total0, shareRate);
         uint128 expected1 = computeFee(total1, shareRate);
@@ -371,6 +407,44 @@ contract SignedExclusiveSwapTest is FullTest {
         (after0, after1) = core.savedBalances(address(signedExclusiveSwap), poolKey.token0, poolKey.token1, bytes32(0));
         assertEq(after0, 0);
         assertEq(after1, 0);
+    }
+
+    function test_owner_fee_boundaries_all_swap_cases() public {
+        uint64[3] memory rates = [uint64(0), uint64(1), type(uint64).max];
+        for (uint256 direction; direction < 4; ++direction) {
+            for (uint256 i; i < rates.length; ++i) {
+                uint256 snapshot = vm.snapshotState();
+                _testOwnerFeeSplit(direction & 1 != 0, direction & 2 != 0, rates[i], 100_000, type(uint32).max);
+                assertTrue(vm.revertToState(snapshot));
+            }
+        }
+    }
+
+    function test_zero_owner_share_skips_saved_balance_call_all_swap_cases() public {
+        vm.expectCall(
+            address(core),
+            abi.encodeWithSelector(ICore.updateSavedBalances.selector, address(token0), address(token1), bytes32(0)),
+            uint64(0)
+        );
+        for (uint256 direction; direction < 4; ++direction) {
+            for (uint256 scenario; scenario < 4; ++scenario) {
+                uint256 snapshot = vm.snapshotState();
+                uint64 rate = scenario == 0 || scenario == 3 ? 0 : type(uint64).max;
+                PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000, controller, rate);
+                createPosition(poolKey, -100_000, 100_000, 1_000_000, 1_000_000);
+                token0.approve(address(harness), type(uint256).max);
+                token1.approve(address(harness), type(uint256).max);
+                uint32 swapFee = scenario == 1 || scenario == 3 ? 0 : uint32(1 << 26);
+                int128 amount = scenario == 2 ? int128(0) : int128(100_000);
+                if (direction & 2 != 0) amount = -amount;
+                _ownerFeeSwap(poolKey, direction & 1 != 0, amount, swapFee);
+                (uint128 owner0, uint128 owner1) =
+                    core.savedBalances(address(signedExclusiveSwap), poolKey.token0, poolKey.token1, bytes32(0));
+                assertEq(owner0, 0);
+                assertEq(owner1, 0);
+                assertTrue(vm.revertToState(snapshot));
+            }
+        }
     }
 
     function test_owner_fee_inline_donation_and_rate_change() public {
@@ -405,7 +479,7 @@ contract SignedExclusiveSwapTest is FullTest {
     }
 
     function test_owner_fee_rounds_up_entire_single_unit_fee() public {
-        test_fuzz_owner_fee_split(false, true, 1, 1);
+        _testOwnerFeeSplit(false, true, 1, 1, uint32(1 << 26));
     }
 
     function test_zero_collected_fee_skips_owner_balance_update() public {
@@ -699,14 +773,18 @@ contract SignedExclusiveSwapTest is FullTest {
 
     function test_initialize_pool_emits_pool_state_updated() public {
         PoolKey memory poolKey = signedExclusiveSwapPoolKey(20_000);
-        SignedExclusiveSwapPoolState expectedState =
-            createSignedExclusiveSwapPoolState(controller, uint32(block.timestamp), 0);
+        SignedExclusiveSwapPoolState expectedState = createSignedExclusiveSwapPoolState({
+            _controller: controller, _lastUpdateTime: uint32(block.timestamp), _ownerFee: 1 << 63
+        });
 
         vm.expectEmit(true, false, false, true, address(signedExclusiveSwap));
         emit ISignedExclusiveSwap.PoolStateUpdated(poolKey.toPoolId(), expectedState);
 
         vm.prank(admin);
-        signedExclusiveSwap.initializePool(poolKey, 0, controller);
+        signedExclusiveSwap.initializePool(poolKey, 0, controller, 1 << 63);
+        assertEq(
+            SignedExclusiveSwapPoolState.unwrap(_poolState(poolKey)), SignedExclusiveSwapPoolState.unwrap(expectedState)
+        );
     }
 
     function test_owner_initializes_pool_with_specified_controller() public {
@@ -1151,7 +1229,7 @@ contract SignedExclusiveSwapTest is FullTest {
         PoolKey memory poolKey = signedExclusiveSwapPoolKey(20_000);
 
         vm.expectRevert(Ownable.Unauthorized.selector);
-        signedExclusiveSwap.initializePool(poolKey, 0, controller);
+        signedExclusiveSwap.initializePool(poolKey, 0, controller, 0);
     }
 
     function test_revert_initialize_pool_wrong_extension() public {
@@ -1163,7 +1241,7 @@ contract SignedExclusiveSwapTest is FullTest {
 
         vm.prank(admin);
         vm.expectRevert(ISignedExclusiveSwap.PoolExtensionMustBeSelf.selector);
-        signedExclusiveSwap.initializePool(poolKey, 0, controller);
+        signedExclusiveSwap.initializePool(poolKey, 0, controller, 0);
     }
 
     function test_revert_initialize_pool_zero_controller() public {
@@ -1171,7 +1249,7 @@ contract SignedExclusiveSwapTest is FullTest {
 
         vm.prank(admin);
         vm.expectRevert(ISignedExclusiveSwap.InvalidController.selector);
-        signedExclusiveSwap.initializePool(poolKey, 0, ControllerAddress.wrap(address(0)));
+        signedExclusiveSwap.initializePool(poolKey, 0, ControllerAddress.wrap(address(0)), 0);
     }
 
     function test_revert_initialize_pool_contract_with_eoa_controller_encoding() public {
@@ -1183,7 +1261,7 @@ contract SignedExclusiveSwapTest is FullTest {
 
         vm.prank(admin);
         vm.expectRevert(ISignedExclusiveSwap.InvalidController.selector);
-        signedExclusiveSwap.initializePool(poolKey, 0, ControllerAddress.wrap(lowBitContract));
+        signedExclusiveSwap.initializePool(poolKey, 0, ControllerAddress.wrap(lowBitContract), 0);
     }
 
     function test_revert_initialize_pool_eoa_with_contract_controller_encoding() public {
@@ -1194,7 +1272,7 @@ contract SignedExclusiveSwapTest is FullTest {
 
         vm.prank(admin);
         vm.expectRevert(ISignedExclusiveSwap.InvalidController.selector);
-        signedExclusiveSwap.initializePool(poolKey, 0, ControllerAddress.wrap(highBitNoCode));
+        signedExclusiveSwap.initializePool(poolKey, 0, ControllerAddress.wrap(highBitNoCode), 0);
     }
 
     function test_owner_can_set_nonce_bitmap() public {

--- a/test/extensions/SignedExclusiveSwap.t.sol
+++ b/test/extensions/SignedExclusiveSwap.t.sol
@@ -26,6 +26,7 @@ import {BaseLocker} from "../../src/base/BaseLocker.sol";
 import {FlashAccountantLib} from "../../src/libraries/FlashAccountantLib.sol";
 import {ICore} from "../../src/interfaces/ICore.sol";
 import {Ownable} from "solady/auth/Ownable.sol";
+import {SafeCastLib} from "solady/utils/SafeCastLib.sol";
 import {EIP712} from "solady/utils/EIP712.sol";
 
 contract MockSigner1271 {
@@ -489,6 +490,57 @@ contract SignedExclusiveSwapTest is FullTest {
         signedExclusiveSwap.setOwnerFee(poolKey, type(uint64).max);
         vm.expectCall(address(core), abi.encodeWithSelector(ICore.updateSavedBalances.selector), uint64(0));
         _ownerFeeSwap(poolKey, false, 0, type(uint32).max);
+    }
+
+    function test_pending_fees_exclude_same_timestamp_new_liquidity(bool isToken1) public {
+        PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000, controller, 1 << 63);
+        (uint256 incumbent,) = createPosition(poolKey, -100_000, 100_000, 1_000_000, 1_000_000);
+        token0.approve(address(harness), type(uint256).max);
+        token1.approve(address(harness), type(uint256).max);
+        _ownerFeeSwap(poolKey, isToken1, 100_000, uint32(1 << 30));
+        (uint128 owner0, uint128 owner1) =
+            core.savedBalances(address(signedExclusiveSwap), poolKey.token0, poolKey.token1, bytes32(0));
+
+        (uint256 newcomer,) = createPosition(poolKey, -100_000, 100_000, 100_000_000, 100_000_000);
+        advanceTime(1);
+        (uint128 new0, uint128 new1) = positions.collectFees(newcomer, poolKey, -100_000, 100_000);
+        assertEq(new0, 0);
+        assertEq(new1, 0);
+        (uint128 old0, uint128 old1) = positions.collectFees(incumbent, poolKey, -100_000, 100_000);
+        assertGt(isToken1 ? old0 : old1, 0);
+        (uint128 after0, uint128 after1) =
+            core.savedBalances(address(signedExclusiveSwap), poolKey.token0, poolKey.token1, bytes32(0));
+        assertEq(after0, owner0);
+        assertEq(after1, owner1);
+    }
+
+    function test_pending_fees_paid_on_same_timestamp_full_withdrawal(bool isToken1) public {
+        PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000, controller, 1 << 63);
+        (uint256 id, uint128 liquidity) = createPosition(poolKey, -100_000, 100_000, 1_000_000, 1_000_000);
+        token0.approve(address(harness), type(uint256).max);
+        token1.approve(address(harness), type(uint256).max);
+        _ownerFeeSwap(poolKey, isToken1, 100_000, uint32(1 << 30));
+        (, uint128 principal0, uint128 principal1,,) =
+            positions.getPositionFeesAndLiquidity(id, poolKey, -100_000, 100_000);
+        (uint128 pending0, uint128 pending1) = core.savedBalances(
+            address(signedExclusiveSwap), poolKey.token0, poolKey.token1, PoolId.unwrap(poolKey.toPoolId())
+        );
+        (uint128 received0, uint128 received1) = positions.withdraw(id, poolKey, -100_000, 100_000, liquidity);
+        // One unit stays in saved balances and at most one is lost to fee-growth rounding.
+        assertApproxEqAbs(received0 - principal0, pending0, 2);
+        assertApproxEqAbs(received1 - principal1, pending1, 2);
+        assertEq(core.poolState(poolKey.toPoolId()).liquidity(), 0);
+    }
+
+    function test_exact_out_reverts_when_total_input_overflows(bool isToken1, uint128 rawInput) public {
+        rawInput = uint128(bound(rawInput, uint128(type(int128).max) / 2 + 1, uint128(type(int128).max)));
+        PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000);
+        PoolBalanceUpdate raw =
+            isToken1 ? createPoolBalanceUpdate(int128(rawInput), -1) : createPoolBalanceUpdate(-1, int128(rawInput));
+        // Isolate extension arithmetic from Core's price/liquidity limits.
+        vm.mockCall(address(core), bytes(hex"00000000"), abi.encode(raw, core.poolState(poolKey.toPoolId())));
+        vm.expectRevert(SafeCastLib.Overflow.selector);
+        _ownerFeeSwap(poolKey, isToken1, -1, uint32(1 << 31));
     }
 
     function test_hash_signed_swap_payload_matches_solady_eip712() public view {

--- a/test/extensions/SignedExclusiveSwap.t.sol
+++ b/test/extensions/SignedExclusiveSwap.t.sol
@@ -228,8 +228,8 @@ contract SignedExclusiveSwapTest is FullTest {
         uint32 deadline = uint32(block.timestamp + 1 hours);
         uint32 nonce = 7;
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta = createSignedSwapMeta(address(harness), deadline, fee, nonce);
 
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);
@@ -332,8 +332,8 @@ contract SignedExclusiveSwapTest is FullTest {
             address(signedExclusiveSwap),
             poolKey,
             createSwapParameters({
-                _isToken1: isToken1, _amount: amount, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-            }).withDefaultSqrtRatioLimit(),
+                    _isToken1: isToken1, _amount: amount, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+                }).withDefaultSqrtRatioLimit(),
             meta,
             MIN_BALANCE_UPDATE,
             abi.encodePacked(r, s, v),
@@ -518,8 +518,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta = createSignedSwapMeta(address(harness), uint32(block.timestamp + 1 hours), 0, 300);
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(controllerPk, digest);
@@ -548,8 +548,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         uint32 fee = uint32(uint256(1 << 32) / 200); // 0.5%
         SignedSwapMeta meta = createSignedSwapMeta(address(harness), uint32(block.timestamp + 1 hours), fee, 301);
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);
@@ -579,8 +579,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: true, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: true, _amount: 100_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         uint32 fee = uint32(uint256(1 << 32) / 200); // 0.5%
         SignedSwapMeta meta = createSignedSwapMeta(address(harness), uint32(block.timestamp + 1 hours), fee, 302);
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);
@@ -630,8 +630,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 11);
 
@@ -671,8 +671,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         uint64 nonce = type(uint64).max;
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), nonce);
@@ -716,8 +716,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta = createSignedSwapMeta(
             address(0xBEEF), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 99
         );
@@ -754,8 +754,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta = createSignedSwapMeta(address(0), deadlineTooFar, uint32(uint256(1 << 32) / 500), 100);
 
         vm.expectRevert(ISignedExclusiveSwap.DeadlineTooFar.selector);
@@ -803,8 +803,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 121);
 
@@ -842,8 +842,8 @@ contract SignedExclusiveSwapTest is FullTest {
         signedExclusiveSwap.setPoolController(poolKey, ControllerAddress.wrap(address(contractController)));
 
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 131);
 
@@ -871,8 +871,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 211);
         PoolBalanceUpdate minBalanceUpdate = createPoolBalanceUpdate(type(int128).max, type(int128).max);
@@ -902,8 +902,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 212);
         PoolBalanceUpdate minBalanceUpdate = createPoolBalanceUpdate(50_000, -60_000);
@@ -935,8 +935,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 213);
         PoolBalanceUpdate minBalanceUpdate = createPoolBalanceUpdate(50_000, -40_000);
@@ -966,8 +966,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: true, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: true, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 214);
         PoolBalanceUpdate minBalanceUpdate = createPoolBalanceUpdate(-40_000, 50_000);
@@ -997,8 +997,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: true, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: true, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp - 1), uint32(uint256(1 << 32) / 500), 215);
         PoolBalanceUpdate minBalanceUpdate = createPoolBalanceUpdate(-40_000, 50_000);
@@ -1028,8 +1028,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: true, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: true, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta =
             createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), uint32(uint256(1 << 32) / 500), 216);
         PoolBalanceUpdate minBalanceUpdateSigned = createPoolBalanceUpdate(-40_000, 50_000);
@@ -1165,8 +1165,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta = createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), 0, 222);
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(controllerPk, digest);
@@ -1204,8 +1204,8 @@ contract SignedExclusiveSwapTest is FullTest {
         vm.chainId(originalChainId + 1);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: 50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         SignedSwapMeta meta = createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), 0, 223);
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(controllerPk, digest);
@@ -1313,8 +1313,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: false, _amount: -50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: false, _amount: -50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         uint32 fee = uint32(uint256(1 << 32) / 100); // 1%
         SignedSwapMeta meta = createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), fee, 224);
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);
@@ -1349,8 +1349,8 @@ contract SignedExclusiveSwapTest is FullTest {
         token1.approve(address(harness), type(uint256).max);
 
         SwapParameters params = createSwapParameters({
-            _isToken1: true, _amount: -50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
-        }).withDefaultSqrtRatioLimit();
+                _isToken1: true, _amount: -50_000, _sqrtRatioLimit: SqrtRatio.wrap(0), _skipAhead: 0
+            }).withDefaultSqrtRatioLimit();
         uint32 fee = uint32(uint256(1 << 32) / 100); // 1%
         SignedSwapMeta meta = createSignedSwapMeta(address(0), uint32(block.timestamp + 1 hours), fee, 225);
         bytes32 digest = signedExclusiveSwap.hashSignedSwapPayload(poolKey.toPoolId(), meta, MIN_BALANCE_UPDATE);

--- a/test/extensions/SignedExclusiveSwap.t.sol
+++ b/test/extensions/SignedExclusiveSwap.t.sol
@@ -492,7 +492,7 @@ contract SignedExclusiveSwapTest is FullTest {
         _ownerFeeSwap(poolKey, false, 0, type(uint32).max);
     }
 
-    function test_pending_fees_exclude_same_timestamp_new_liquidity(bool isToken1) public {
+    function test_pending_fees_include_same_timestamp_new_liquidity(bool isToken1) public {
         PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000, controller, 1 << 63);
         (uint256 incumbent,) = createPosition(poolKey, -100_000, 100_000, 1_000_000, 1_000_000);
         token0.approve(address(harness), type(uint256).max);
@@ -504,8 +504,8 @@ contract SignedExclusiveSwapTest is FullTest {
         (uint256 newcomer,) = createPosition(poolKey, -100_000, 100_000, 100_000_000, 100_000_000);
         advanceTime(1);
         (uint128 new0, uint128 new1) = positions.collectFees(newcomer, poolKey, -100_000, 100_000);
-        assertEq(new0, 0);
-        assertEq(new1, 0);
+        assertGt(isToken1 ? new0 : new1, 0);
+        assertEq(isToken1 ? new1 : new0, 0);
         (uint128 old0, uint128 old1) = positions.collectFees(incumbent, poolKey, -100_000, 100_000);
         assertGt(isToken1 ? old0 : old1, 0);
         (uint128 after0, uint128 after1) =
@@ -514,7 +514,7 @@ contract SignedExclusiveSwapTest is FullTest {
         assertEq(after1, owner1);
     }
 
-    function test_pending_fees_paid_on_same_timestamp_full_withdrawal(bool isToken1) public {
+    function test_pending_fees_remain_on_same_timestamp_full_withdrawal(bool isToken1) public {
         PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000, controller, 1 << 63);
         (uint256 id, uint128 liquidity) = createPosition(poolKey, -100_000, 100_000, 1_000_000, 1_000_000);
         token0.approve(address(harness), type(uint256).max);
@@ -526,9 +526,14 @@ contract SignedExclusiveSwapTest is FullTest {
             address(signedExclusiveSwap), poolKey.token0, poolKey.token1, PoolId.unwrap(poolKey.toPoolId())
         );
         (uint128 received0, uint128 received1) = positions.withdraw(id, poolKey, -100_000, 100_000, liquidity);
-        // One unit stays in saved balances and at most one is lost to fee-growth rounding.
-        assertApproxEqAbs(received0 - principal0, pending0, 2);
-        assertApproxEqAbs(received1 - principal1, pending1, 2);
+        assertEq(received0, principal0);
+        assertEq(received1, principal1);
+        (uint128 after0, uint128 after1) = core.savedBalances(
+            address(signedExclusiveSwap), poolKey.token0, poolKey.token1, PoolId.unwrap(poolKey.toPoolId())
+        );
+        assertEq(after0, pending0);
+        assertEq(after1, pending1);
+        assertGt(isToken1 ? after0 : after1, 1);
         assertEq(core.poolState(poolKey.toPoolId()).liquidity(), 0);
     }
 

--- a/test/extensions/SignedExclusiveSwap.t.sol
+++ b/test/extensions/SignedExclusiveSwap.t.sol
@@ -252,16 +252,53 @@ contract SignedExclusiveSwapTest is FullTest {
     }
 
     function test_owner_fee_administration() public {
-        assertEq(signedExclusiveSwap.ownerFee(), 0);
+        PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000);
+        assertEq(signedExclusiveSwap.ownerFee(poolKey.toPoolId()), 0);
         vm.expectRevert(Ownable.Unauthorized.selector);
-        signedExclusiveSwap.setOwnerFee(1);
+        signedExclusiveSwap.setOwnerFee(poolKey, 1);
         vm.prank(admin);
         vm.expectEmit(address(signedExclusiveSwap));
-        emit ISignedExclusiveSwap.OwnerFeeUpdated(type(uint64).max);
-        signedExclusiveSwap.setOwnerFee(type(uint64).max);
-        assertEq(signedExclusiveSwap.ownerFee(), type(uint64).max);
+        emit ISignedExclusiveSwap.PoolStateUpdated(
+            poolKey.toPoolId(),
+            createSignedExclusiveSwapPoolState(controller, uint32(block.timestamp), type(uint64).max)
+        );
+        signedExclusiveSwap.setOwnerFee(poolKey, type(uint64).max);
+        assertEq(signedExclusiveSwap.ownerFee(poolKey.toPoolId()), type(uint64).max);
         vm.expectRevert(Ownable.Unauthorized.selector);
         signedExclusiveSwap.withdrawOwnerFees(address(token0), address(token1), 0, 0, address(this));
+    }
+
+    function test_owner_fee_is_per_pool() public {
+        PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000);
+        PoolKey memory otherPool = createSignedExclusiveSwapPool(0, 10_000);
+        vm.prank(admin);
+        signedExclusiveSwap.setOwnerFee(poolKey, 1 << 63);
+        assertEq(signedExclusiveSwap.ownerFee(poolKey.toPoolId()), 1 << 63);
+        assertEq(signedExclusiveSwap.ownerFee(otherPool.toPoolId()), 0);
+        vm.prank(admin);
+        signedExclusiveSwap.setPoolController(poolKey, controller);
+        advanceTime(1);
+        signedExclusiveSwap.accumulatePoolFees(poolKey);
+        assertEq(signedExclusiveSwap.ownerFee(poolKey.toPoolId()), 1 << 63);
+    }
+
+    function test_revert_owner_fee_uninitialized_pool() public {
+        PoolKey memory poolKey = signedExclusiveSwapPoolKey(20_000);
+        vm.prank(admin);
+        vm.expectRevert(ICore.PoolNotInitialized.selector);
+        signedExclusiveSwap.setOwnerFee(poolKey, 1);
+    }
+
+    function test_revert_owner_fee_wrong_extension() public {
+        PoolKey memory poolKey = PoolKey({
+            token0: address(token0),
+            token1: address(token1),
+            config: createConcentratedPoolConfig({_fee: 0, _tickSpacing: 20_000, _extension: address(0)})
+        });
+        core.initializePool(poolKey, 0);
+        vm.prank(admin);
+        vm.expectRevert(ICore.PoolNotInitialized.selector);
+        signedExclusiveSwap.setOwnerFee(poolKey, 1);
     }
 
     function _ownerFeeSwap(PoolKey memory poolKey, bool isToken1, int128 amount, uint32 fee)
@@ -301,7 +338,7 @@ contract SignedExclusiveSwapTest is FullTest {
         );
         assertTrue(vm.revertToState(snapshot));
         vm.prank(admin);
-        signedExclusiveSwap.setOwnerFee(shareRate);
+        signedExclusiveSwap.setOwnerFee(poolKey, shareRate);
         PoolBalanceUpdate actual = _ownerFeeSwap(poolKey, isToken1, swapAmount, uint32(1 << 26));
         assertEq(PoolBalanceUpdate.unwrap(actual), PoolBalanceUpdate.unwrap(baseline));
         uint128 expected0 = computeFee(total0, shareRate);
@@ -318,7 +355,7 @@ contract SignedExclusiveSwapTest is FullTest {
 
         // Changing the rate does not take another share of already saved LP fees.
         vm.prank(admin);
-        signedExclusiveSwap.setOwnerFee(type(uint64).max);
+        signedExclusiveSwap.setOwnerFee(poolKey, type(uint64).max);
         advanceTime(1);
         signedExclusiveSwap.accumulatePoolFees(poolKey);
         (uint128 after0, uint128 after1) =
@@ -353,7 +390,7 @@ contract SignedExclusiveSwapTest is FullTest {
         assertGt(newFee, 0);
         assertTrue(vm.revertToState(snapshot));
         vm.prank(admin);
-        signedExclusiveSwap.setOwnerFee(1 << 63);
+        signedExclusiveSwap.setOwnerFee(poolKey, 1 << 63);
         _ownerFeeSwap(poolKey, false, 100_000, uint32(1 << 26));
         (, uint128 ownerShare) =
             core.savedBalances(address(signedExclusiveSwap), poolKey.token0, poolKey.token1, bytes32(0));
@@ -375,7 +412,7 @@ contract SignedExclusiveSwapTest is FullTest {
         PoolKey memory poolKey = createSignedExclusiveSwapPool(0, 20_000);
         createPosition(poolKey, -100_000, 100_000, 1_000_000, 1_000_000);
         vm.prank(admin);
-        signedExclusiveSwap.setOwnerFee(type(uint64).max);
+        signedExclusiveSwap.setOwnerFee(poolKey, type(uint64).max);
         vm.expectCall(address(core), abi.encodeWithSelector(ICore.updateSavedBalances.selector), uint64(0));
         _ownerFeeSwap(poolKey, false, 0, type(uint32).max);
     }
@@ -663,7 +700,7 @@ contract SignedExclusiveSwapTest is FullTest {
     function test_initialize_pool_emits_pool_state_updated() public {
         PoolKey memory poolKey = signedExclusiveSwapPoolKey(20_000);
         SignedExclusiveSwapPoolState expectedState =
-            createSignedExclusiveSwapPoolState(controller, uint32(block.timestamp));
+            createSignedExclusiveSwapPoolState(controller, uint32(block.timestamp), 0);
 
         vm.expectEmit(true, false, false, true, address(signedExclusiveSwap));
         emit ISignedExclusiveSwap.PoolStateUpdated(poolKey.toPoolId(), expectedState);

--- a/test/types/signedExclusiveSwapPoolState.t.sol
+++ b/test/types/signedExclusiveSwapPoolState.t.sol
@@ -8,38 +8,61 @@ import {
     controller,
     lastUpdateTime,
     withLastUpdateTime,
-    withController
+    withController,
+    ownerFee,
+    withOwnerFee
 } from "../../src/types/signedExclusiveSwapPoolState.sol";
 import {ControllerAddress, isEoa} from "../../src/types/controllerAddress.sol";
 
 contract SignedExclusiveSwapPoolStateTest is Test {
-    function test_pack_unpack(address _controller, uint32 _lastUpdateTime) public pure {
+    function test_pack_unpack(address _controller, uint32 _lastUpdateTime, uint64 _ownerFee) public pure {
         ControllerAddress controllerAddress = ControllerAddress.wrap(_controller);
-        SignedExclusiveSwapPoolState state = createSignedExclusiveSwapPoolState(controllerAddress, _lastUpdateTime);
+        SignedExclusiveSwapPoolState state =
+            createSignedExclusiveSwapPoolState(controllerAddress, _lastUpdateTime, _ownerFee);
 
         assertEq(ControllerAddress.unwrap(controller(state)), _controller);
         assertEq(lastUpdateTime(state), _lastUpdateTime);
+        assertEq(ownerFee(state), _ownerFee);
         assertEq(isEoa(controller(state)), uint160(_controller) >> 159 == 0);
     }
 
-    function test_withLastUpdateTime(address _controller, uint32 _lastUpdateTime, uint32 nextTime) public pure {
+    function test_withLastUpdateTime(address _controller, uint32 _lastUpdateTime, uint32 nextTime, uint64 _ownerFee)
+        public
+        pure
+    {
         ControllerAddress controllerAddress = ControllerAddress.wrap(_controller);
-        SignedExclusiveSwapPoolState state = createSignedExclusiveSwapPoolState(controllerAddress, _lastUpdateTime);
+        SignedExclusiveSwapPoolState state =
+            createSignedExclusiveSwapPoolState(controllerAddress, _lastUpdateTime, _ownerFee);
         SignedExclusiveSwapPoolState updated = withLastUpdateTime(state, nextTime);
 
         assertEq(ControllerAddress.unwrap(controller(updated)), _controller);
         assertEq(isEoa(controller(updated)), uint160(_controller) >> 159 == 0);
         assertEq(lastUpdateTime(updated), nextTime);
+        assertEq(ownerFee(updated), _ownerFee);
     }
 
-    function test_withController(address _controller, uint32 _lastUpdateTime, address nextController) public pure {
+    function test_withController(address _controller, uint32 _lastUpdateTime, address nextController, uint64 _ownerFee)
+        public
+        pure
+    {
         ControllerAddress controllerAddress = ControllerAddress.wrap(_controller);
         ControllerAddress nextControllerAddress = ControllerAddress.wrap(nextController);
-        SignedExclusiveSwapPoolState state = createSignedExclusiveSwapPoolState(controllerAddress, _lastUpdateTime);
+        SignedExclusiveSwapPoolState state =
+            createSignedExclusiveSwapPoolState(controllerAddress, _lastUpdateTime, _ownerFee);
         SignedExclusiveSwapPoolState updated = withController(state, nextControllerAddress);
 
         assertEq(ControllerAddress.unwrap(controller(updated)), nextController);
         assertEq(isEoa(controller(updated)), uint160(nextController) >> 159 == 0);
         assertEq(lastUpdateTime(updated), _lastUpdateTime);
+        assertEq(ownerFee(updated), _ownerFee);
+    }
+
+    function test_withOwnerFee(address _controller, uint32 time, uint64 fee, uint64 nextFee) public pure {
+        SignedExclusiveSwapPoolState state =
+            createSignedExclusiveSwapPoolState(ControllerAddress.wrap(_controller), time, fee);
+        SignedExclusiveSwapPoolState updated = withOwnerFee(state, nextFee);
+        assertEq(ControllerAddress.unwrap(controller(updated)), _controller);
+        assertEq(lastUpdateTime(updated), time);
+        assertEq(ownerFee(updated), nextFee);
     }
 }

--- a/test/types/signedExclusiveSwapPoolState.t.sol
+++ b/test/types/signedExclusiveSwapPoolState.t.sol
@@ -17,8 +17,9 @@ import {ControllerAddress, isEoa} from "../../src/types/controllerAddress.sol";
 contract SignedExclusiveSwapPoolStateTest is Test {
     function test_pack_unpack(address _controller, uint32 _lastUpdateTime, uint64 _ownerFee) public pure {
         ControllerAddress controllerAddress = ControllerAddress.wrap(_controller);
-        SignedExclusiveSwapPoolState state =
-            createSignedExclusiveSwapPoolState(controllerAddress, _lastUpdateTime, _ownerFee);
+        SignedExclusiveSwapPoolState state = createSignedExclusiveSwapPoolState({
+            _controller: controllerAddress, _lastUpdateTime: _lastUpdateTime, _ownerFee: _ownerFee
+        });
 
         assertEq(ControllerAddress.unwrap(controller(state)), _controller);
         assertEq(lastUpdateTime(state), _lastUpdateTime);
@@ -31,8 +32,9 @@ contract SignedExclusiveSwapPoolStateTest is Test {
         pure
     {
         ControllerAddress controllerAddress = ControllerAddress.wrap(_controller);
-        SignedExclusiveSwapPoolState state =
-            createSignedExclusiveSwapPoolState(controllerAddress, _lastUpdateTime, _ownerFee);
+        SignedExclusiveSwapPoolState state = createSignedExclusiveSwapPoolState({
+            _controller: controllerAddress, _lastUpdateTime: _lastUpdateTime, _ownerFee: _ownerFee
+        });
         SignedExclusiveSwapPoolState updated = withLastUpdateTime(state, nextTime);
 
         assertEq(ControllerAddress.unwrap(controller(updated)), _controller);
@@ -47,8 +49,9 @@ contract SignedExclusiveSwapPoolStateTest is Test {
     {
         ControllerAddress controllerAddress = ControllerAddress.wrap(_controller);
         ControllerAddress nextControllerAddress = ControllerAddress.wrap(nextController);
-        SignedExclusiveSwapPoolState state =
-            createSignedExclusiveSwapPoolState(controllerAddress, _lastUpdateTime, _ownerFee);
+        SignedExclusiveSwapPoolState state = createSignedExclusiveSwapPoolState({
+            _controller: controllerAddress, _lastUpdateTime: _lastUpdateTime, _ownerFee: _ownerFee
+        });
         SignedExclusiveSwapPoolState updated = withController(state, nextControllerAddress);
 
         assertEq(ControllerAddress.unwrap(controller(updated)), nextController);
@@ -58,8 +61,9 @@ contract SignedExclusiveSwapPoolStateTest is Test {
     }
 
     function test_withOwnerFee(address _controller, uint32 time, uint64 fee, uint64 nextFee) public pure {
-        SignedExclusiveSwapPoolState state =
-            createSignedExclusiveSwapPoolState(ControllerAddress.wrap(_controller), time, fee);
+        SignedExclusiveSwapPoolState state = createSignedExclusiveSwapPoolState({
+            _controller: ControllerAddress.wrap(_controller), _lastUpdateTime: time, _ownerFee: fee
+        });
         SignedExclusiveSwapPoolState updated = withOwnerFee(state, nextFee);
         assertEq(ControllerAddress.unwrap(controller(updated)), _controller);
         assertEq(lastUpdateTime(updated), time);


### PR DESCRIPTION
SignedExclusiveSwap can reserve an owner-controlled share of each collected swap fee, configured per pool with `setOwnerFee(PoolKey,uint64)` and supplied at initialization. The Q0.64 rate occupies the unused low 64 bits of the packed pool state, so swaps use the already loaded state without an extra storage read. Changes emit `PoolStateUpdated`; state is readable through ExposedStorage.

The owner share uses `computeFee`, rounding up, while the swapper’s total charge stays unchanged. Nonzero owner shares are saved in Core under salt zero for the ordered token pair and can be withdrawn only by the owner. The remainder stays in the pool’s separate pending LP balance. Zero owner shares skip the extra saved-balance update.

## Audit disposition

[V12 diff audit](https://v12.sh/runs/7702) reported two pre-existing issues:
- [Pending LP fee attribution](https://v12.sh/runs/7702/274639): acknowledged. The proposed same-timestamp lifecycle flush was reverted. Timestamp-gated donation remains intentional: the controller authorizes swaps and fees and has an arbitrage incentive to leave the pool at the correct end-of-block price. Flushing on position changes does not provide correct attribution across subsequent swaps; perfect per-step attribution requires a Core change. The guide documents the accepted liquidity-change and zero-liquidity tradeoffs.
- Exact-output input overflow: fixed by validating that total input including the fee fits `int128`.

Tests cover deferred-fee behavior in both token directions, exact-output overflow, all four swap cases, fee conservation, rounding, initial and per-pool rates, access control, withdrawals, packed state preservation, and zero-share call counts.

## Validation

- Foundry v1.5.1 full `forge snapshot --offline`: 981 passed, zero failures.
- SignedExclusiveSwap suite: 53 passed.
- `bun run lint`: passed using the shared checkout’s complexity tooling.
- `forge fmt --check` and `git diff --check`: passed.
